### PR TITLE
gnome-online-accounts-gtk: Add missing rundeps

### DIFF
--- a/packages/g/gnome-online-accounts-gtk/abi_libs
+++ b/packages/g/gnome-online-accounts-gtk/abi_libs
@@ -1,0 +1,1 @@
+gnome-online-accounts-gtk

--- a/packages/g/gnome-online-accounts-gtk/abi_symbols
+++ b/packages/g/gnome-online-accounts-gtk/abi_symbols
@@ -1,0 +1,1 @@
+gnome-online-accounts-gtk:_IO_stdin_used

--- a/packages/g/gnome-online-accounts-gtk/package.yml
+++ b/packages/g/gnome-online-accounts-gtk/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-online-accounts-gtk
 version    : 3.50.4
-release    : 2
+release    : 3
 source     :
     - https://github.com/xapp-project/gnome-online-accounts-gtk/archive/refs/tags/3.50.4.tar.gz : 661192f5092cf722fb883d364f1f3555a4f2c00194e5c27f92e2ac0db65f1e93
 homepage   : https://github.com/xapp-project/gnome-online-accounts-gtk
@@ -13,9 +13,12 @@ description: |
 builddeps  :
     - pkgconfig(goa-1.0)
     - pkgconfig(gtk4)
+rundeps    :
+    - gvfs-goa
 setup      : |
     %meson_configure
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/g/gnome-online-accounts-gtk/pspec_x86_64.xml
+++ b/packages/g/gnome-online-accounts-gtk/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-online-accounts-gtk</Name>
         <Homepage>https://github.com/xapp-project/gnome-online-accounts-gtk</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.gtk</PartOf>
@@ -23,6 +23,7 @@
             <Path fileType="executable">/usr/bin/gnome-online-accounts-gtk</Path>
             <Path fileType="data">/usr/share/applications/gnome-online-accounts-gtk.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/gnome-online-accounts-gtk.svg</Path>
+            <Path fileType="data">/usr/share/licenses/gnome-online-accounts-gtk/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/br/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
@@ -68,12 +69,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-11-06</Date>
+        <Update release="3">
+            <Date>2026-06-01</Date>
             <Version>3.50.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add `gvfs-goa` as rundeps. This will enable cloud storage integratation with file manager (Thunar, Nemo, Nautilus) out of the box.

**Test Plan**

<!-- Short description of how the package was tested -->
Login to Google and Microsoft account. See that Google Drive and OneDrive present in Thunar.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
