### PR TITLE
libseccomp: Update to v2.6.1

### DIFF
--- a/packages/l/libseccomp/abi_symbols
+++ b/packages/l/libseccomp/abi_symbols
@@ -8,6 +8,7 @@ libseccomp.so.2:seccomp_arch_resolve_name
 libseccomp.so.2:seccomp_attr_get
 libseccomp.so.2:seccomp_attr_set
 libseccomp.so.2:seccomp_export_bpf
+libseccomp.so.2:seccomp_export_bpf_mem
 libseccomp.so.2:seccomp_export_pfc
 libseccomp.so.2:seccomp_init
 libseccomp.so.2:seccomp_load
@@ -18,6 +19,7 @@ libseccomp.so.2:seccomp_notify_free
 libseccomp.so.2:seccomp_notify_id_valid
 libseccomp.so.2:seccomp_notify_receive
 libseccomp.so.2:seccomp_notify_respond
+libseccomp.so.2:seccomp_precompute
 libseccomp.so.2:seccomp_release
 libseccomp.so.2:seccomp_reset
 libseccomp.so.2:seccomp_rule_add
@@ -29,4 +31,7 @@ libseccomp.so.2:seccomp_syscall_resolve_name
 libseccomp.so.2:seccomp_syscall_resolve_name_arch
 libseccomp.so.2:seccomp_syscall_resolve_name_rewrite
 libseccomp.so.2:seccomp_syscall_resolve_num_arch
+libseccomp.so.2:seccomp_transaction_commit
+libseccomp.so.2:seccomp_transaction_reject
+libseccomp.so.2:seccomp_transaction_start
 libseccomp.so.2:seccomp_version

--- a/packages/l/libseccomp/abi_used_symbols
+++ b/packages/l/libseccomp/abi_used_symbols
@@ -2,6 +2,7 @@ libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__stack_chk_fail
@@ -18,6 +19,7 @@ libc.so.6:getopt
 libc.so.6:ioctl
 libc.so.6:malloc
 libc.so.6:memcmp
+libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:optarg
@@ -29,6 +31,5 @@ libc.so.6:stderr
 libc.so.6:strcmp
 libc.so.6:strdup
 libc.so.6:strlen
-libc.so.6:strtol
 libc.so.6:syscall
 libc.so.6:write

--- a/packages/l/libseccomp/package.yml
+++ b/packages/l/libseccomp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libseccomp
-version    : 2.5.5
-release    : 12
+version    : 2.6.1
+release    : 13
 source     :
-    - https://github.com/seccomp/libseccomp/releases/download/v2.5.5/libseccomp-2.5.5.tar.gz : 248a2c8a4d9b9858aa6baf52712c34afefcf9c9e94b76dce02c1c9aa25fb3375
+    - https://github.com/seccomp/libseccomp/releases/download/v2.6.1/libseccomp-2.6.1.tar.gz : 501f66c667225d53791b97e1d7cf85ab764c297d04881f60f38f451c4b0ee1be
 license    : LGPL-2.1-only
 homepage   : https://github.com/seccomp/libseccomp
 summary    : High level interface to the Linux Kernel's seccomp filter
@@ -14,10 +14,12 @@ builddeps  :
     - pkgconfig(valgrind)
     - gperf
 setup      : |
-    %configure
+    %configure \
+        --disable-static
 build      : |
     %make
 install    : |
     %make_install
+    %install_license LICENSE
 check      : |
     %make check

--- a/packages/l/libseccomp/pspec_x86_64.xml
+++ b/packages/l/libseccomp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libseccomp</Name>
         <Homepage>https://github.com/seccomp/libseccomp</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-only</License>
         <PartOf>system.base</PartOf>
@@ -22,8 +22,9 @@
         <Files>
             <Path fileType="executable">/usr/bin/scmp_sys_resolver</Path>
             <Path fileType="library">/usr/lib64/libseccomp.so.2</Path>
-            <Path fileType="library">/usr/lib64/libseccomp.so.2.5.5</Path>
-            <Path fileType="man">/usr/share/man/man1/scmp_sys_resolver.1</Path>
+            <Path fileType="library">/usr/lib64/libseccomp.so.2.6.1</Path>
+            <Path fileType="data">/usr/share/licenses/libseccomp/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/scmp_sys_resolver.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -33,55 +34,57 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">libseccomp</Dependency>
+            <Dependency release="13">libseccomp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/seccomp-syscalls.h</Path>
             <Path fileType="header">/usr/include/seccomp.h</Path>
-            <Path fileType="library">/usr/lib64/libseccomp.a</Path>
             <Path fileType="library">/usr/lib64/libseccomp.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libseccomp.pc</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_api_get.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_api_set.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_arch_add.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_arch_exist.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_arch_native.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_arch_remove.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_arch_resolve_name.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_attr_get.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_attr_set.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_export_bpf.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_export_pfc.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_init.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_load.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_merge.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_notify_alloc.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_notify_fd.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_notify_free.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_notify_id_valid.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_notify_receive.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_notify_respond.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_release.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_reset.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_rule_add.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_rule_add_array.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_rule_add_exact.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_rule_add_exact_array.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_syscall_priority.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_syscall_resolve_name.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_syscall_resolve_name_arch.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_syscall_resolve_name_rewrite.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_syscall_resolve_num_arch.3</Path>
-            <Path fileType="man">/usr/share/man/man3/seccomp_version.3</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_api_get.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_api_set.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_arch_add.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_arch_exist.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_arch_native.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_arch_remove.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_arch_resolve_name.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_attr_get.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_attr_set.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_export_bpf.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_export_bpf_mem.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_export_pfc.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_init.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_load.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_merge.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_notify_alloc.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_notify_fd.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_notify_free.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_notify_id_valid.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_notify_receive.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_notify_respond.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_precompute.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_release.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_reset.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_rule_add.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_rule_add_array.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_rule_add_exact.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_rule_add_exact_array.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_syscall_priority.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_syscall_resolve_name.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_syscall_resolve_name_arch.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_syscall_resolve_name_rewrite.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_syscall_resolve_num_arch.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_transaction_start.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/seccomp_version.3.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2024-01-19</Date>
-            <Version>2.5.5</Version>
+        <Update release="13">
+            <Date>2026-07-02</Date>
+            <Version>2.6.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/seccomp/libseccomp/blob/v2.6.1/CHANGELOG).

**Security**
- GHSA-4q85-33p6-j5g6
- GHSA-46fr-jh49-xvhx
- GHSA-2hqh-5c36-grrm

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuilt a reverse dependency.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
