### PR TITLE
docker-compose: Update to v5.3.0

### DIFF
--- a/packages/d/docker-compose/package.yml
+++ b/packages/d/docker-compose/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker-compose
-version    : 5.2.0
-release    : 63
+version    : 5.3.0
+release    : 64
 source     :
-    - https://github.com/docker/compose/archive/refs/tags/v5.2.0.tar.gz : 7bc980b6a73728372f7123ec1e2908fc30a4b0c2ff6096d8229853742117b205
+    - https://github.com/docker/compose/archive/refs/tags/v5.3.0.tar.gz : 496ee43bc6ecee6fbac28e93f6e784a7b0207baec7ae2b0ffb57cfd83bc92874
 homepage   : https://docs.docker.com/compose/
 license    : Apache-2.0
 component  : virt
@@ -18,17 +18,22 @@ builddeps  :
 rundeps    :
     - docker
 environment: |
-    export _compose_r=github.com/docker/compose/v5
+    export _compose_r=github.com/docker/compose
     export GO111MODULE=auto
 
     export CGO_CFLAGS="${CFLAGS}"
     export CGO_CPPFLAGS="${CPPFLAGS}"
     export CGO_CXXFLAGS="${CXXFLAGS}"
     export CGO_LDFLAGS="${LDFLAGS}"
-    export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw -ldflags=-linkmode=external -ldflags=-X=${_compose_r}/internal.Version=v$version"
+    export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw -ldflags=-linkmode=external"
 setup      : |
     go mod vendor
 build      : |
+    export GOFLAGS+=" -ldflags=-X=${_compose_r}/v2/internal.Version=v$version"
+
+    # Git commit corresponding to the version tag
+    export GITCOMMIT="$(git ls-remote https://github.com/docker/compose.git refs/tags/v$version | awk '{print $1}')"
+
     go build -tags "e2e,kube" -o docker-compose ./cmd
 install    : |
     install -Ddm00755 ${installdir}/%libdir%/docker/cli-plugins

--- a/packages/d/docker-compose/pspec_x86_64.xml
+++ b/packages/d/docker-compose/pspec_x86_64.xml
@@ -28,9 +28,9 @@ With Compose, you use a Compose file to configure your application&#x2019;s serv
         </Files>
     </Package>
     <History>
-        <Update release="63">
-            <Date>2026-06-25</Date>
-            <Version>5.2.0</Version>
+        <Update release="64">
+            <Date>2026-07-02</Date>
+            <Version>5.3.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/docker/compose/releases/tag/v5.3.0).
- Bug fixes

**Test Plan**

Make a container with compose. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
