### PR TITLE
slick-greeter: Update to v2.2.7

### DIFF
--- a/packages/s/slick-greeter/abi_used_symbols
+++ b/packages/s/slick-greeter/abi_used_symbols
@@ -242,6 +242,7 @@ libglib-2.0.so.0:g_file_get_contents
 libglib-2.0.so.0:g_file_set_contents
 libglib-2.0.so.0:g_file_test
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_free_sized
 libglib-2.0.so.0:g_get_monotonic_time
 libglib-2.0.so.0:g_get_user_cache_dir
 libglib-2.0.so.0:g_getenv

--- a/packages/s/slick-greeter/package.yml
+++ b/packages/s/slick-greeter/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : slick-greeter
-version    : 2.2.5
-release    : 37
+version    : 2.2.7
+release    : 38
 source     :
-    - https://github.com/linuxmint/slick-greeter/archive/refs/tags/2.2.5.tar.gz : 693f5e2f09cc2e0835d461deebeefb666e9862e3664f9d71318e58634ce1b9d2
+    - https://github.com/linuxmint/slick-greeter/archive/refs/tags/2.2.7.tar.gz : f685da6ca9d97329b4b200077d12db0ad4f9964d4515479e6c00bba721ab0626
 homepage   : https://github.com/linuxmint/slick-greeter
 license    : GPL-3.0-or-later
 component  : desktop.lightdm

--- a/packages/s/slick-greeter/pspec_x86_64.xml
+++ b/packages/s/slick-greeter/pspec_x86_64.xml
@@ -283,9 +283,9 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2025-12-13</Date>
-            <Version>2.2.5</Version>
+        <Update release="38">
+            <Date>2026-07-03</Date>
+            <Version>2.2.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/linuxmint/slick-greeter/blob/2.2.7/debian/changelog).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install package, reboot, and log in.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
