### PR TITLE
xrt: skip building specification due to server weirdness

### DIFF
--- a/packages/x/xrt/package.yml
+++ b/packages/x/xrt/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xrt
 version    : 2.21.75
-release    : 1
+release    : 2
 source     :
     - https://github.com/Xilinx/XRT/releases/download/2.21.75/2.21.75.tar.gz : 30343a3c74103ac5d5016525d6f051601b197855c54e980f8d6623bfc6f3d229
 homepage   : https://xilinx.github.io/XRT/
@@ -25,6 +25,9 @@ setup      : |
     # Install licenses and documentation adhereing to FHS
     sed -i 's|DESTINATION ${XRT_INSTALL_DIR}/license|DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/xrt|' xrt/XRT/src/CMake/nativeLnx.cmake
     sed -i 's|DESTINATION ${XRT_INSTALL_DIR}/share/doc|DESTINATION ${CMAKE_INSTALL_DATADIR}/docs/xrt|' xrt/XRT/src/CMake/changelog.cmake
+
+    # Skip spec/doc generation targets that require wget and network access
+    sed -i 's|add_subdirectory(specification)||' xrt/XRT/src/runtime_src/core/common/aiebu/CMakeLists.txt
 
     %cmake_ninja -L \
       -DXRT_NPU=ON

--- a/packages/x/xrt/pspec_x86_64.xml
+++ b/packages/x/xrt/pspec_x86_64.xml
@@ -64,7 +64,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">xrt</Dependency>
+            <Dependency release="2">xrt</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/CL/cl_ext_xilinx.h</Path>
@@ -135,7 +135,7 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
+        <Update release="2">
             <Date>2026-07-03</Date>
             <Version>2.21.75</Version>
             <Comment>Packaging update</Comment>


### PR DESCRIPTION
**Summary**

`xrt` tries to build the specification document (as part of the documentation), which fetches some stuff online with `wget`, failing because `wget` is not available and we don't have networking enabled. This behavior only happens on the server and I cannot reproduce this locally. My suspicion is that it's some weird timestamp thingy during the tarball extraction, triggering a `ninja` rebuild detection. To be safe, this PR removes building the specification document entirely.

**Test Plan**

Builds locally. That doesn't mean anything though :(

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [ ] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
