### PR TITLE
xapp-symbolic-icons: Update to v1.1.0

### DIFF
--- a/packages/x/xapp-symbolic-icons/package.yml
+++ b/packages/x/xapp-symbolic-icons/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xapp-symbolic-icons
-version    : 1.0.9
-release    : 3
+version    : 1.1.0
+release    : 4
 source     :
-    - https://github.com/xapp-project/xapp-symbolic-icons/archive/refs/tags/1.0.9.tar.gz : 0ebb603eaa34f34d44bc419119595c91785caf0e29a2ad2adaa7fea9cc2e6ebb
+    - https://github.com/xapp-project/xapp-symbolic-icons/archive/refs/tags/1.1.0.tar.gz : fa96ac6a1a85c0cb16dccab5c03ae1e651a3482cde4a93f792956977bc19108d
 homepage   : https://github.com/xapp-project/xapp-symbolic-icons
 license    :
     - BSD-3-Clause

--- a/packages/x/xapp-symbolic-icons/pspec_x86_64.xml
+++ b/packages/x/xapp-symbolic-icons/pspec_x86_64.xml
@@ -183,6 +183,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-drive-multidisk-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-drive-optical-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-drive-removable-media-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-drive-removable-media-usb-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-edit-clear-all-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-edit-clear-symbolic-rtl.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-edit-clear-symbolic.svg</Path>
@@ -222,6 +223,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-emoji-symbols-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-emoji-travel-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-emote-love-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-empty-icon-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-engineering-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-error-correct-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-executable-symbolic.svg</Path>
@@ -237,6 +239,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-face-surprise-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-face-uncertain-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-face-wink-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-fan-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-favorite-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-file-manager-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-find-location-symbolic.svg</Path>
@@ -283,6 +286,8 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-format-text-strikethrough-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-format-text-underline-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-games-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-gauge-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-gauge2-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-geolocation-disabled-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-geolocation-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-git-pr-symbolic.svg</Path>
@@ -314,6 +319,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-help-contents-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-help-faq-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-help-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-image-crop-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-image-loading-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-image-missing-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-image-x-generic-symbolic.svg</Path>
@@ -332,6 +338,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-keyboard-character-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-keyboard-shortcuts-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-keyboard-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-launch-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-list-add-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-list-drag-handle-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-list-edit-symbolic.svg</Path>
@@ -499,6 +506,11 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-phone-apple-iphone-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-phone-old-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-phone-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-physics-amps-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-physics-volts-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-physics-watts-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-physics-wave-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-physics-wavelength-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-pin-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-power-profile-balanced-symbolic-rtl.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-power-profile-balanced-symbolic.svg</Path>
@@ -506,6 +518,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-power-profile-performance-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-power-profile-power-saver-symbolic-rtl.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-power-profile-power-saver-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-power-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-preferences-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-preview-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-printer-error-symbolic.svg</Path>
@@ -569,6 +582,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-switch-user-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-tab-new-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-tablet-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-tag-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-task-due-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-task-past-due-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-temperature-symbolic.svg</Path>
@@ -679,8 +693,11 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-zoom-in-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-zoom-original-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xsi-zoom-out-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/licenses/xapp-symbolic-icons/BSD-3-Clause.txt</Path>
+            <Path fileType="data">/usr/share/licenses/xapp-symbolic-icons/CC-BY-4.0.txt</Path>
             <Path fileType="data">/usr/share/licenses/xapp-symbolic-icons/CC-BY-SA-4.0.txt</Path>
             <Path fileType="data">/usr/share/licenses/xapp-symbolic-icons/CC0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/xapp-symbolic-icons/GPL-3.0.txt</Path>
             <Path fileType="data">/usr/share/licenses/xapp-symbolic-icons/LGPL-3.0.txt</Path>
             <Path fileType="data">/usr/share/licenses/xapp-symbolic-icons/LICENSE</Path>
             <Path fileType="data">/usr/share/licenses/xapp-symbolic-icons/MIT.txt</Path>
@@ -688,9 +705,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-03-31</Date>
-            <Version>1.0.9</Version>
+        <Update release="4">
+            <Date>2026-07-03</Date>
+            <Version>1.1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/xapp-project/xapp-symbolic-icons/blob/1.1.0/debian/changelog).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install, see icons.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
