### PR TITLE
python-xapp: Update to v3.0.3

### DIFF
--- a/packages/py/python-xapp/package.yml
+++ b/packages/py/python-xapp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-xapp
-version    : 3.0.1
-release    : 20
+version    : 3.0.3
+release    : 21
 source     :
-    - https://github.com/linuxmint/python3-xapp/archive/refs/tags/3.0.1.tar.gz : 9083f64b80040aca6c20ede688f5f1e86ce90dbd808846400c5612fffde8a6ce
+    - https://github.com/linuxmint/python3-xapp/archive/refs/tags/3.0.3.tar.gz : 30cf81249a7c5cabc25e465e369928724e091e95c5095704518f14ca6fd11f41
 homepage   : https://github.com/linuxmint/python3-xapp
 license    : LGPL-2.0-or-later
 component  : programming.python

--- a/packages/py/python-xapp/pspec_x86_64.xml
+++ b/packages/py/python-xapp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-xapp</Name>
         <Homepage>https://github.com/linuxmint/python3-xapp</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.0-or-later</License>
         <PartOf>programming.python</PartOf>
@@ -32,8 +32,10 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/xapp/threading/__pycache__/__init__.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/xapp/util/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/xapp/util/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/xapp/widgets/Dialog.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/xapp/widgets/ListEditor.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/xapp/widgets/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/xapp/widgets/__pycache__/Dialog.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/xapp/widgets/__pycache__/ListEditor.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/xapp/widgets/__pycache__/__init__.cpython-314.pyc</Path>
             <Path fileType="data">/usr/share/licenses/python-xapp/COPYING</Path>
@@ -72,21 +74,23 @@
             <Path fileType="localedata">/usr/share/locale/pt/LC_MESSAGES/python-xapp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/python-xapp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/python-xapp.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sk/LC_MESSAGES/python-xapp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sl/LC_MESSAGES/python-xapp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/python-xapp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/python-xapp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/python-xapp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/python-xapp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/python-xapp.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/python-xapp.mo</Path>
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-06-07</Date>
-            <Version>3.0.1</Version>
+        <Update release="21">
+            <Date>2026-07-03</Date>
+            <Version>3.0.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/linuxmint/python3-xapp/blob/3.0.3/debian/changelog).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that xapp applications still work.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
