### PR TITLE
libvips: Update to v8.18.3

### DIFF
--- a/packages/l/libvips/abi_used_symbols
+++ b/packages/l/libvips/abi_used_symbols
@@ -832,6 +832,7 @@ libpoppler-glib.so.8:poppler_document_get_title
 libpoppler-glib.so.8:poppler_document_new_from_stream
 libpoppler-glib.so.8:poppler_page_get_size
 libpoppler-glib.so.8:poppler_page_render
+libraw_r.so.25:libraw_adjust_sizes_info_only
 libraw_r.so.25:libraw_close
 libraw_r.so.25:libraw_dcraw_clear_mem
 libraw_r.so.25:libraw_dcraw_make_mem_image

--- a/packages/l/libvips/package.yml
+++ b/packages/l/libvips/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libvips
-version    : 8.18.2
-release    : 61
+version    : 8.18.3
+release    : 62
 source     :
-    - https://github.com/libvips/libvips/archive/refs/tags/v8.18.2.tar.gz : c6e9f3c384436c6ffc75848d1ad76347368b9639897f6d9f909178dc986d5200
+    - https://github.com/libvips/libvips/archive/refs/tags/v8.18.3.tar.gz : 21aa79be2a83f1f46582c58e0fc7fc2b355e6fbb661091fb963a3b20f494dbaf
 homepage   : https://www.libvips.org/
 license    : LGPL-2.1-or-later
 component  :

--- a/packages/l/libvips/pspec_x86_64.xml
+++ b/packages/l/libvips/pspec_x86_64.xml
@@ -26,9 +26,9 @@
             <Path fileType="executable">/usr/bin/vipsthumbnail</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/Vips-8.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libvips-cpp.so.42</Path>
-            <Path fileType="library">/usr/lib64/libvips-cpp.so.42.20.2</Path>
+            <Path fileType="library">/usr/lib64/libvips-cpp.so.42.20.3</Path>
             <Path fileType="library">/usr/lib64/libvips.so.42</Path>
-            <Path fileType="library">/usr/lib64/libvips.so.42.20.2</Path>
+            <Path fileType="library">/usr/lib64/libvips.so.42.20.3</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.18/vips-heif.so</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.18/vips-jxl.so</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.18/vips-magick.so</Path>
@@ -49,7 +49,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="61">libvips</Dependency>
+            <Dependency release="62">libvips</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/vips/VConnection8.h</Path>
@@ -1549,9 +1549,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="61">
+        <Update release="62">
             <Date>2026-07-03</Date>
-            <Version>8.18.2</Version>
+            <Version>8.18.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/libvips/libvips/releases/tag/v8.18.3).

**Test Plan**

Passes ninja checks

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
