### PR TITLE
unrar: Update to 7.2.7

### DIFF
--- a/packages/u/unrar/package.yml
+++ b/packages/u/unrar/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : unrar
-version    : 7.2.6
-release    : 53
+version    : 7.2.7
+release    : 54
 source     :
-    - https://www.rarlab.com/rar/unrarsrc-7.2.6.tar.gz : d1afa67ef4121ebc5986815699e05db0ce8648499e5dca854f282a4c3f72c003
+    - https://www.rarlab.com/rar/unrarsrc-7.2.7.tar.gz : 01d903a7dcf413cb2925696d7796e48e38d471f79bfe7ef3ad2aebf6c12dbefd
 homepage   : https://www.rarlab.com
 license    : Distributable
 component  : system.utils

--- a/packages/u/unrar/pspec_x86_64.xml
+++ b/packages/u/unrar/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>unrar</Name>
         <Homepage>https://www.rarlab.com</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>Distributable</License>
         <PartOf>system.utils</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="53">
-            <Date>2026-05-04</Date>
-            <Version>7.2.6</Version>
+        <Update release="54">
+            <Date>2026-07-05</Date>
+            <Version>7.2.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Update to latest
- Security Update

**Security**
- CVE-2026-14191 - Heap Overflow Vulnerability
- Symbolic Link / Path Traversal Vulnerability - no CVE yet-

[Change Log](https://www.rarlab.com/rarnew.htm)

**Test Plan**
- list archive contents
- extract archive

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
