### PR TITLE
runc: Build against libsecomp

### DIFF
--- a/packages/r/runc/abi_symbols
+++ b/packages/r/runc/abi_symbols
@@ -1,3 +1,8 @@
 runc:_cgo_panic
 runc:_cgo_topofstack
 runc:crosscall2
+runc:seccomp_export_bpf_mem
+runc:seccomp_precompute
+runc:seccomp_transaction_commit
+runc:seccomp_transaction_reject
+runc:seccomp_transaction_start

--- a/packages/r/runc/files/0001-seccomp-ignore-unsupported-wait-kill-flag-probe.patch
+++ b/packages/r/runc/files/0001-seccomp-ignore-unsupported-wait-kill-flag-probe.patch
@@ -1,0 +1,23 @@
+From 4d84a3403b12fba631adf31896bf2cb71e0b6a6d Mon Sep 17 00:00:00 2001
+From: Paco Xu <roollingstone@gmail.com>
+Date: Fri, 26 Jun 2026 18:16:40 +0800
+Subject: [PATCH] seccomp: ignore unsupported wait-kill flag probe
+
+Signed-off-by: Paco Xu <roollingstone@gmail.com>
+---
+ libcontainer/seccomp/patchbpf/enosys_linux.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libcontainer/seccomp/patchbpf/enosys_linux.go b/libcontainer/seccomp/patchbpf/enosys_linux.go
+index b9a0be8c8f8..34ecc1e2099 100644
+--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
++++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
+@@ -673,7 +673,7 @@ func filterFlags(config *configs.Seccomp, filter *libseccomp.ScmpFilter) (flags
+ 		}
+ 	}
+ 	if apiLevel >= 7 {
+-		if waitKill, err := filter.GetWaitKill(); err != nil {
++		if waitKill, err := filter.GetWaitKill(); err != nil && !errors.Is(err, unix.EINVAL) {
+ 			return 0, false, fmt.Errorf("unable to fetch SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV bit: %w", err)
+ 		} else if waitKill {
+ 			flags |= uint(C.C_FILTER_FLAG_WAIT_KILLABLE_RECV)

--- a/packages/r/runc/package.yml
+++ b/packages/r/runc/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : runc
 version    : 1.5.0
-release    : 41
+release    : 42
 source     :
     - https://github.com/opencontainers/runc/archive/refs/tags/v1.5.0.tar.gz : 1bcd55af6081cf080557b148d906f64e6e4ca886d8345fe4b5510a90b52815d1
 homepage   : https://runc.io/
@@ -20,6 +20,8 @@ networking : true
 setup      : |
     mkdir -p src/github.com/opencontainers/runc
     find ./* -prune ! -name src -exec mv {} src/github.com/opencontainers/runc/ \;
+    cd src/github.com/opencontainers/runc
+    %patch -p1 -i ${pkgfiles}/0001-seccomp-ignore-unsupported-wait-kill-flag-probe.patch
 environment: |
     export GOPATH="`pwd`"
     export RUNC_BUILDTAGS='seccomp apparmor'

--- a/packages/r/runc/pspec_x86_64.xml
+++ b/packages/r/runc/pspec_x86_64.xml
@@ -43,8 +43,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2026-06-23</Date>
+        <Update release="42">
+            <Date>2026-07-05</Date>
             <Version>1.5.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>


### PR DESCRIPTION
**Summary**
- The v1.5.0 package was built against libseccomp 2.5.5 headers, so runc
queries the wrong seccomp attribute after libseccomp 2.6.1 landed and
Docker fails to start containers.
- Resolves: #9492 

**Test Plan**

Hello world in docker. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
