### PR TITLE
nlohmann-json: Update to v3.12.0

### DIFF
--- a/packages/n/nlohmann-json/package.yml
+++ b/packages/n/nlohmann-json/package.yml
@@ -1,22 +1,38 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nlohmann-json
-version    : 3.11.3
-release    : 9
+version    : 3.12.0
+release    : 10
 source     :
-    - https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz : d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
+    - https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz : 4b92eb0c06d10683f7447ce9406cb97cd4b453be18d7279320f7b2f025c10187
+    - https://github.com/nlohmann/json_test_data/archive/refs/tags/v3.1.0.tar.gz#json_test_data.tar.gz : 884b1e21f38cfd6a62c159f1b7e0a8f5168ae5daaa384ed4dc0c0fa6660f21bd
+    - https://raw.githubusercontent.com/doctest/doctest/refs/tags/v2.4.12/doctest/doctest.h : 94029a7d32da24a56249658147dbd2b33ff0b9ed665295cbbaf19aafff5b0ced
+homepage   : https://nlohmann.github.io/json/
 license    :
     - CC0-1.0
     - MIT
 component  : programming.library
-homepage   : https://nlohmann.github.io/json/
 summary    : JSON for Modern C++
 description: |
     JSON for Modern C++
-patterns   :
-    - /*
 setup      : |
-    %cmake_ninja -DJSON_BuildTests=OFF -DJSON_MultipleHeaders=ON
+    mkdir test-data
+    tar -xf "${sources}"/json_test_data.tar.gz --strip-components=1 -C test-data
+
+    # The included doctest.h is old and has compilation issues with newer clang
+    # It's only used for building the tests so we can just replace it
+    cp "${sources}"/doctest.h tests/thirdparty/doctest/doctest.h
+
+    %cmake_ninja \
+        -DJSON_BuildTests=ON \
+        -DJSON_Install:BOOL=ON \
+        -DJSON_MultipleHeaders=ON \
+        -DJSON_TestDataDirectory:STRING=test-data
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE.MIT
+check      : |
+    ctest --test-dir solusBuildDir --label-exclude 'git_required' --timeout 3600
+patterns   :
+    - /*

--- a/packages/n/nlohmann-json/pspec_x86_64.xml
+++ b/packages/n/nlohmann-json/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nlohmann-json</Name>
         <Homepage>https://nlohmann.github.io/json/</Homepage>
         <Packager>
-            <Name>Alexander Vorobyev</Name>
-            <Email>avorobyev@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>CC0-1.0</License>
         <License>MIT</License>
@@ -60,6 +60,7 @@
             <Path fileType="header">/usr/include/nlohmann/detail/output/serializer.hpp</Path>
             <Path fileType="header">/usr/include/nlohmann/detail/string_concat.hpp</Path>
             <Path fileType="header">/usr/include/nlohmann/detail/string_escape.hpp</Path>
+            <Path fileType="header">/usr/include/nlohmann/detail/string_utils.hpp</Path>
             <Path fileType="header">/usr/include/nlohmann/detail/value_t.hpp</Path>
             <Path fileType="header">/usr/include/nlohmann/json.hpp</Path>
             <Path fileType="header">/usr/include/nlohmann/json_fwd.hpp</Path>
@@ -69,16 +70,17 @@
             <Path fileType="data">/usr/share/cmake/nlohmann_json/nlohmann_jsonConfig.cmake</Path>
             <Path fileType="data">/usr/share/cmake/nlohmann_json/nlohmann_jsonConfigVersion.cmake</Path>
             <Path fileType="data">/usr/share/cmake/nlohmann_json/nlohmann_jsonTargets.cmake</Path>
+            <Path fileType="data">/usr/share/licenses/nlohmann-json/LICENSE.MIT</Path>
             <Path fileType="data">/usr/share/pkgconfig/nlohmann_json.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-12-02</Date>
-            <Version>3.11.3</Version>
+        <Update release="10">
+            <Date>2026-07-06</Date>
+            <Version>3.12.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Alexander Vorobyev</Name>
-            <Email>avorobyev@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/nlohmann/json/releases/tag/v3.12.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild a reverse dependency.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
