### PR TITLE
md4c: Update to v0.5.3

### DIFF
--- a/packages/m/md4c/abi_used_symbols
+++ b/packages/m/md4c/abi_used_symbols
@@ -1,9 +1,9 @@
-libc.so.6:__fprintf_chk
 libc.so.6:__libc_start_main
-libc.so.6:__printf_chk
-libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strncpy_chk
+libc.so.6:__vfprintf_chk
+libc.so.6:__vprintf_chk
+libc.so.6:__vsnprintf_chk
 libc.so.6:clock
 libc.so.6:exit
 libc.so.6:fclose
@@ -22,7 +22,5 @@ libc.so.6:stderr
 libc.so.6:stdin
 libc.so.6:stdout
 libc.so.6:strchr
-libc.so.6:strcmp
-libc.so.6:strcspn
 libc.so.6:strlen
 libc.so.6:strncmp

--- a/packages/m/md4c/package.yml
+++ b/packages/m/md4c/package.yml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : md4c
-version    : 0.5.2
-release    : 2
+version    : 0.5.3
+release    : 3
 source     :
-    - https://github.com/mity/md4c/archive/refs/tags/release-0.5.2.tar.gz : 55d0111d48fb11883aaee91465e642b8b640775a4d6993c2d0e7a8092758ef21
+    - https://github.com/mity/md4c/archive/refs/tags/release-0.5.3.tar.gz : 353c346f376b87c954a13f3415ede2d51264cc61dc5abcd38ff1d2aa0d059b9e
+homepage   : https://github.com/mity/md4c
 license    : MIT
 component  : programming.library
-homepage   : https://github.com/mity/md4c
 summary    : C Markdown parser and library
 description: |
     C Markdown parser. Fast. SAX-like interface. Compliant to CommonMark specification.
@@ -19,3 +19,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE.md
+check      : |
+    cd solusBuildDir
+    python "${workdir}"/scripts/run-tests.py

--- a/packages/m/md4c/pspec_x86_64.xml
+++ b/packages/m/md4c/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>md4c</Name>
         <Homepage>https://github.com/mity/md4c</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.library</PartOf>
@@ -22,10 +22,11 @@
         <Files>
             <Path fileType="executable">/usr/bin/md2html</Path>
             <Path fileType="library">/usr/lib64/libmd4c-html.so.0</Path>
-            <Path fileType="library">/usr/lib64/libmd4c-html.so.0.5.2</Path>
+            <Path fileType="library">/usr/lib64/libmd4c-html.so.0.5.3</Path>
             <Path fileType="library">/usr/lib64/libmd4c.so.0</Path>
-            <Path fileType="library">/usr/lib64/libmd4c.so.0.5.2</Path>
-            <Path fileType="man">/usr/share/man/man1/md2html.1</Path>
+            <Path fileType="library">/usr/lib64/libmd4c.so.0.5.3</Path>
+            <Path fileType="data">/usr/share/licenses/md4c/LICENSE.md</Path>
+            <Path fileType="man">/usr/share/man/man1/md2html.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -35,7 +36,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">md4c</Dependency>
+            <Dependency release="3">md4c</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/md4c-html.h</Path>
@@ -49,12 +50,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-06-28</Date>
-            <Version>0.5.2</Version>
+        <Update release="3">
+            <Date>2026-07-06</Date>
+            <Version>0.5.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/mity/md4c/blob/release-0.5.3/CHANGELOG.md).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild MarkNote against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
