### PR TITLE
c-ares: Update to v1.34.7

### DIFF
--- a/packages/c/c-ares/abi_symbols
+++ b/packages/c/c-ares/abi_symbols
@@ -352,6 +352,7 @@ libcares.so.2:ares_lookup_hostaliases
 libcares.so.2:ares_malloc
 libcares.so.2:ares_malloc_data
 libcares.so.2:ares_malloc_zero
+libcares.so.2:ares_malloc_zero_array
 libcares.so.2:ares_memeq
 libcares.so.2:ares_memeq_ci
 libcares.so.2:ares_memmem
@@ -369,6 +370,7 @@ libcares.so.2:ares_parse_into_addrinfo
 libcares.so.2:ares_parse_mx_reply
 libcares.so.2:ares_parse_naptr_reply
 libcares.so.2:ares_parse_ns_reply
+libcares.so.2:ares_parse_port
 libcares.so.2:ares_parse_ptr_reply
 libcares.so.2:ares_parse_ptr_reply_dnsrec
 libcares.so.2:ares_parse_soa_reply
@@ -397,6 +399,7 @@ libcares.so.2:ares_queue_wait_empty
 libcares.so.2:ares_rand_bytes
 libcares.so.2:ares_realloc
 libcares.so.2:ares_realloc_zero
+libcares.so.2:ares_realloc_zero_array
 libcares.so.2:ares_reinit
 libcares.so.2:ares_requeue_query
 libcares.so.2:ares_round_up_pow2
@@ -427,6 +430,7 @@ libcares.so.2:ares_set_socket_functions
 libcares.so.2:ares_set_socket_functions_def
 libcares.so.2:ares_set_socket_functions_ex
 libcares.so.2:ares_set_sortlist
+libcares.so.2:ares_size_t_mul_overflow
 libcares.so.2:ares_slist_create
 libcares.so.2:ares_slist_destroy
 libcares.so.2:ares_slist_first_val
@@ -460,6 +464,7 @@ libcares.so.2:ares_str_isnum
 libcares.so.2:ares_str_isprint
 libcares.so.2:ares_str_lower
 libcares.so.2:ares_str_ltrim
+libcares.so.2:ares_str_parse_uint
 libcares.so.2:ares_str_rtrim
 libcares.so.2:ares_str_trim
 libcares.so.2:ares_strcasecmp
@@ -497,6 +502,7 @@ libcares.so.2:ares_thread_mutex_unlock
 libcares.so.2:ares_threadsafety
 libcares.so.2:ares_timedout
 libcares.so.2:ares_timeout
+libcares.so.2:ares_timeval_add
 libcares.so.2:ares_timeval_diff
 libcares.so.2:ares_timeval_remaining
 libcares.so.2:ares_tolower

--- a/packages/c/c-ares/package.yml
+++ b/packages/c/c-ares/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : c-ares
-version    : 1.34.6
-release    : 17
+version    : 1.34.7
+release    : 18
 source     :
-    - https://github.com/c-ares/c-ares/releases/download/v1.34.6/c-ares-1.34.6.tar.gz : 912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5
+    - https://github.com/c-ares/c-ares/releases/download/v1.34.7/c-ares-1.34.7.tar.gz : 556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327
 homepage   : https://c-ares.org/
 license    : MIT
 component  : programming.library
@@ -13,13 +13,16 @@ description: |
 builddeps  :
     - pkgconfig(gtest)
 clang      : true
-optimize   : thin-lto
+optimize   :
+    - thin-lto
 setup      : |
-    %patch -p1 -i $pkgfiles/Remove-live-tests.patch
+    %patch -p1 -i ${pkgfiles}/Remove-live-tests.patch
+
     %cmake_ninja -DCARES_BUILD_TESTS=ON
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE.md
 check      : |
     %ninja_check

--- a/packages/c/c-ares/pspec_x86_64.xml
+++ b/packages/c/c-ares/pspec_x86_64.xml
@@ -23,7 +23,8 @@
             <Path fileType="executable">/usr/bin/adig</Path>
             <Path fileType="executable">/usr/bin/ahost</Path>
             <Path fileType="library">/usr/lib64/libcares.so.2</Path>
-            <Path fileType="library">/usr/lib64/libcares.so.2.19.5</Path>
+            <Path fileType="library">/usr/lib64/libcares.so.2.19.6</Path>
+            <Path fileType="data">/usr/share/licenses/c-ares/LICENSE.md</Path>
             <Path fileType="man">/usr/share/man/man1/adig.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/ahost.1.zst</Path>
         </Files>
@@ -35,7 +36,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="17">c-ares</Dependency>
+            <Dependency release="18">c-ares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ares.h</Path>
@@ -204,9 +205,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2025-12-08</Date>
-            <Version>1.34.6</Version>
+        <Update release="18">
+            <Date>2026-07-06</Date>
+            <Version>1.34.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/c-ares/c-ares/releases/tag/v1.34.7).

**Security**
- CVE-2026-33630
- GHSA-pjmc-gx33-gc76
- GHSA-jv8r-gqr9-68wj

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild a reverse dependency.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
