### PR TITLE
noto-sans-ttf: Update to v2026.07.01

### DIFF
--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : noto-sans-ttf
-version    : 2025.12.01
-release    : 45
+version    : 2026.07.01
+release    : 46
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.12.01.tar.gz : a06f15babc162a10768964965e95a062022622a078af4bc9d988c9ba65b4c8f7
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2026.07.01.tar.gz : b614152147d67bfceaaf3409600353e582a477fa64bef4da6a8ca2e370aaf531
 homepage   : https://fonts.google.com/noto
 license    : OFL-1.1
 component  :

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>noto-sans-ttf</Name>
         <Homepage>https://fonts.google.com/noto</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
@@ -1562,12 +1562,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2025-12-09</Date>
-            <Version>2025.12.01</Version>
+        <Update release="46">
+            <Date>2026-07-06</Date>
+            <Version>2026.07.01</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Commit log [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-2025.12.01...noto-monthly-release-2026.07.01)

**Test Plan**

- Use fonts in LibreOffice Writer

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
