### PR TITLE
wireless-regdb: Update to v2026.05.30

### DIFF
--- a/packages/w/wireless-regdb/package.yml
+++ b/packages/w/wireless-regdb/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : wireless-regdb
-version    : 2026.03.18
-release    : 11
+version    : 2026.05.30
+release    : 12
 source     :
-    - https://mirrors.edge.kernel.org/pub/software/network/wireless-regdb/wireless-regdb-2026.03.18.tar.gz : 2ab05d06eae83f60e00ec2bec998317e887d403ca21565271b68babbd1008efd
+    - https://mirrors.edge.kernel.org/pub/software/network/wireless-regdb/wireless-regdb-2026.05.30.tar.gz : be2a4a27c417890e17bb9e4ac6514157a2662dcdba2f7786a9ab9daef436ff76
 homepage   : https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb
 license    : ISC
 component  : system.base
@@ -26,3 +26,6 @@ install    : |
         ln -srv "$installdir/usr/$file" "$installdir/$file"
     done
     popd
+
+    # License
+    %install_license LICENSE

--- a/packages/w/wireless-regdb/pspec_x86_64.xml
+++ b/packages/w/wireless-regdb/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wireless-regdb</Name>
         <Homepage>https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>ISC</License>
         <PartOf>system.base</PartOf>
@@ -26,17 +26,18 @@
             <Path fileType="library">/usr/lib/crda/regulatory.bin</Path>
             <Path fileType="library">/usr/lib64/firmware/regulatory.db</Path>
             <Path fileType="library">/usr/lib64/firmware/regulatory.db.p7s</Path>
+            <Path fileType="data">/usr/share/licenses/wireless-regdb/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man5/regulatory.bin.5.gz</Path>
             <Path fileType="man">/usr/share/man/man5/regulatory.db.5.gz</Path>
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2026-05-12</Date>
-            <Version>2026.03.18</Version>
+        <Update release="12">
+            <Date>2026-07-07</Date>
+            <Version>2026.05.30</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://lore.kernel.org/linux-wireless/ahsHUWTgbt1OeDRw@wens.tw/).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Not known how to test this.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
