### PR TITLE
sane-airscan: Update to 0.99.37

### DIFF
--- a/packages/s/sane-airscan/abi_used_symbols
+++ b/packages/s/sane-airscan/abi_used_symbols
@@ -37,6 +37,7 @@ libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
+libc.so.6:__stpcpy_chk
 libc.so.6:__strcat_chk
 libc.so.6:__strcpy_chk
 libc.so.6:__vfprintf_chk
@@ -125,7 +126,6 @@ libc.so.6:strncpy
 libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtok_r
-libc.so.6:strtoul
 libc.so.6:time
 libc.so.6:ungetc
 libc.so.6:usleep
@@ -153,6 +153,7 @@ libjpeg.so.8:jpeg_read_header
 libjpeg.so.8:jpeg_read_scanlines
 libjpeg.so.8:jpeg_start_decompress
 libjpeg.so.8:jpeg_std_error
+libm.so.6:floor
 libm.so.6:pow
 libm.so.6:round
 libpng16.so.16:png_create_info_struct
@@ -173,6 +174,7 @@ libtiff.so.6:TIFFClientOpen
 libtiff.so.6:TIFFClose
 libtiff.so.6:TIFFGetField
 libtiff.so.6:TIFFReadScanline
+libxml2.so.2:xmlCtxtGetLastError
 libxml2.so.2:xmlCtxtResetPush
 libxml2.so.2:xmlDocGetRootElement
 libxml2.so.2:xmlFree

--- a/packages/s/sane-airscan/package.yml
+++ b/packages/s/sane-airscan/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : sane-airscan
-version    : 0.99.29
-release    : 3
+version    : 0.99.37
+release    : 4
 source     :
-    - https://github.com/alexpevzner/sane-airscan/archive/refs/tags/0.99.29.tar.gz : e8aa43005ed495fc0db65e2ff51b29cef11a45fc6d8c385294b3394b848db65f
+    - https://github.com/alexpevzner/sane-airscan/archive/refs/tags/0.99.37.tar.gz : b012d4ca8b526e28b0baf1e0dcc1504a1f67118914ee9362201d04a37dbf7e5f
 homepage   : https://github.com/alexpevzner/sane-airscan
 license    : GPL-2.0-or-later
 component  : office
@@ -22,3 +22,4 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING

--- a/packages/s/sane-airscan/pspec_x86_64.xml
+++ b/packages/s/sane-airscan/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>sane-airscan</Name>
         <Homepage>https://github.com/alexpevzner/sane-airscan</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office</PartOf>
@@ -24,17 +24,18 @@
             <Path fileType="config">/etc/sane.d/dll.d/airscan</Path>
             <Path fileType="executable">/usr/bin/airscan-discover</Path>
             <Path fileType="library">/usr/lib64/sane/libsane-airscan.so.1</Path>
+            <Path fileType="data">/usr/share/licenses/sane-airscan/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/airscan-discover.1.gz</Path>
             <Path fileType="man">/usr/share/man/man5/sane-airscan.5.gz</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-06-05</Date>
-            <Version>0.99.29</Version>
+        <Update release="4">
+            <Date>2026-07-07</Date>
+            <Version>0.99.37</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Bump to Latest
- Several new supported models
- Add License

No traditional change log

[Changes 0.99.29...0.99.37](https://github.com/alexpevzner/sane-airscan/compare/0.99.29...0.99.37)

**Test Plan**
- Install
- Use airscan-discover to see if it finds my compatible device
- Use scanimage -L to see if it picks up proper device
- Test scan from cli


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
