### PR TITLE
xorg updates

### DIFF
--- a/packages/t/tigervnc/abi_libs
+++ b/packages/t/tigervnc/abi_libs
@@ -1,3 +1,2 @@
 Xvnc
 libvnc.so
-x0vncserver

--- a/packages/t/tigervnc/abi_symbols
+++ b/packages/t/tigervnc/abi_symbols
@@ -4934,4 +4934,3 @@ libvnc.so:vncSetParam
 libvnc.so:vncUTF8ToLatin1
 libvnc.so:vncUpdateDesktopName
 libvnc.so:zlibLevel
-x0vncserver:_IO_stdin_used

--- a/packages/t/tigervnc/package.yml
+++ b/packages/t/tigervnc/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : tigervnc
 version    : 1.16.2
-release    : 32
+release    : 33
 source     :
     - https://github.com/TigerVNC/tigervnc/archive/refs/tags/v1.16.2.tar.gz : b107c0c8b8a962594281690366c24186e95c2ea4a169acbc0076aa62ed01f467
-    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.23.tar.xz : e39832e5617dadaf072fdf9f0e19e5d2e1c2a13607ac280bac1aba9f8fe14634
+    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.24.tar.xz : 1a4eb36ca65cc3b1b936566d677a9786e13c11cd5806e951ac55f3f5ce3984af
 homepage   : https://tigervnc.org/
 license    :
     - GPL-2.0-or-later

--- a/packages/t/tigervnc/pspec_x86_64.xml
+++ b/packages/t/tigervnc/pspec_x86_64.xml
@@ -82,8 +82,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2026-06-02</Date>
+        <Update release="33">
+            <Date>2026-07-08</Date>
             <Version>1.16.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Troy Harvey</Name>

--- a/packages/x/xorg-server/abi_libs
+++ b/packages/x/xorg-server/abi_libs
@@ -1,7 +1,4 @@
-Xephyr
-Xnest
 Xorg
-Xvfb
 inputtest_drv.so
 libexa.so
 libfbdevhw.so

--- a/packages/x/xorg-server/abi_symbols
+++ b/packages/x/xorg-server/abi_symbols
@@ -1,5 +1,3 @@
-Xephyr:_IO_stdin_used
-Xnest:_IO_stdin_used
 Xorg:AccessUsingXdmcp
 Xorg:AccessXCancelRepeatKey
 Xorg:AccessXComputeCurveFactor
@@ -2000,7 +1998,6 @@ Xorg:xorgHWAccess
 Xorg:xorg_backtrace
 Xorg:xstrtokenize
 Xorg:xthread_sigmask
-Xvfb:_IO_stdin_used
 inputtest_drv.so:inputtestModuleData
 libexa.so:ExaOffscreenMarkUsed
 libexa.so:exaDrawableIsOffscreen

--- a/packages/x/xorg-server/package.yml
+++ b/packages/x/xorg-server/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 # Updating this package? Make sure to update the bundled xorg-server in tigervnc too
 name       : xorg-server
-version    : 21.1.23
-release    : 112
+version    : 21.1.24
+release    : 113
 source     :
-    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.23.tar.xz : e39832e5617dadaf072fdf9f0e19e5d2e1c2a13607ac280bac1aba9f8fe14634
+    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.24.tar.xz : 1a4eb36ca65cc3b1b936566d677a9786e13c11cd5806e951ac55f3f5ce3984af
 homepage   : https://xorg.freedesktop.org/wiki/
 license    : MIT
 component  :

--- a/packages/x/xorg-server/pspec_x86_64.xml
+++ b/packages/x/xorg-server/pspec_x86_64.xml
@@ -67,7 +67,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="112">xorg-server</Dependency>
+            <Dependency release="113">xorg-server</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xorg/XIstubs.h</Path>
@@ -244,9 +244,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="112">
-            <Date>2026-06-02</Date>
-            <Version>21.1.23</Version>
+        <Update release="113">
+            <Date>2026-07-08</Date>
+            <Version>21.1.24</Version>
             <Comment>Packaging update</Comment>
             <Name>Troy Harvey</Name>
             <Email>harvey@getsol.us</Email>

--- a/packages/x/xorg-xwayland/package.yml
+++ b/packages/x/xorg-xwayland/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xorg-xwayland
-version    : 24.1.12
-release    : 40
+version    : 24.1.13
+release    : 41
 source     :
-    - https://www.x.org/releases/individual/xserver/xwayland-24.1.12.tar.xz : 6df02c511b92c1b9848734d9d1b03a4c24f8375ba3cada44e9684a21b5f78e21
+    - https://www.x.org/releases/individual/xserver/xwayland-24.1.13.tar.xz : 173aea3d6f79609164c04528e1c8e4c9b60fcd59391c3c9dad4667297d727fb6
 license    : MIT
 component  : xorg.server
 homepage   : https://www.x.org/

--- a/packages/x/xorg-xwayland/pspec_x86_64.xml
+++ b/packages/x/xorg-xwayland/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2026-06-02</Date>
-            <Version>24.1.12</Version>
+        <Update release="41">
+            <Date>2026-07-08</Date>
+            <Version>24.1.13</Version>
             <Comment>Packaging update</Comment>
             <Name>Troy Harvey</Name>
             <Email>harvey@getsol.us</Email>


### PR DESCRIPTION
**Summary**

xorg-server: Update to [v21.1.24](https://lists.x.org/archives/xorg-announce/2026-July/003718.html)
xorg-xwayland: Update to [v24.1.13](https://lists.x.org/archives/xorg-announce/2026-July/003717.html)
tigervnc: Update bundled xorg

**Test Plan**

- Boot into Budgie x11 session, use firefox.
- Boot into Plasma x11 session, use firefox.
- Boot into Plasma Wayland session, force firefox to use xwayland.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
