### PR TITLE
packagekit-qt: Add packagekit as rundep

### DIFF
--- a/packages/p/packagekit-qt/package.yml
+++ b/packages/p/packagekit-qt/package.yml
@@ -1,19 +1,20 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : packagekit-qt
 version    : 1.1.4
-release    : 5
+release    : 6
 source     :
     - https://github.com/PackageKit/PackageKit-Qt/archive/refs/tags/v1.1.4.tar.gz : bbb8398d0f98c46e2ed7fd3ce526d4f7fc8476f5a449e89269f01b1bc751c4ad
 homepage   : https://github.com/PackageKit/PackageKit-Qt
 license    : LGPL-2.1-or-later
 component  : desktop.qt
-summary    :
-    Qt bindings for PackageKit
+summary    : Qt bindings for PackageKit
 description: |
     Qt bindings for PackageKit
 builddeps  :
     - pkgconfig(Qt6Core)
     - pkgconfig(packagekit-glib2)
+rundeps    :
+    - packagekit
 clang      : true
 optimize   : lto
 setup      : |
@@ -26,7 +27,7 @@ build      : |
 install    : |
     %ninja_install
     %install_license COPYING
-replaces:
+replaces   :
     - packagekit-qt-qt5
     - packagekit-qt-qt6
     - devel :

--- a/packages/p/packagekit-qt/pspec_x86_64.xml
+++ b/packages/p/packagekit-qt/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>packagekit-qt</Name>
         <Homepage>https://github.com/PackageKit/PackageKit-Qt</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop.qt</PartOf>
@@ -36,7 +36,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">packagekit-qt</Dependency>
+            <Dependency release="6">packagekit-qt</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/PackageKitQt/PackageKit/Daemon</Path>
@@ -65,12 +65,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-05-07</Date>
+        <Update release="6">
+            <Date>2026-07-08</Date>
             <Version>1.1.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

It was dropped as a rundep a few months ago.

A user reported in the development channel that plasma-discover was not working on the latest "Beta-plasma-iso". It appears only packagekit-qt was installed by default and installing packagekit fixed plasma-discover.


**Test Plan**

- See that packagekit is listed as a dependency of packagekit-qt

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
