### PR TITLE
fontconfig: Add patches to fix some font detection

### DIFF
--- a/packages/f/fontconfig/files/528.patch
+++ b/packages/f/fontconfig/files/528.patch
@@ -1,0 +1,422 @@
+From 9eda91211a82ba212b86c0d8a88ea95623cf0b59 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Mon, 8 Jun 2026 22:23:24 +0900
+Subject: [PATCH 1/5] test: fix unexpected error when something went wrong in
+ pytest
+
+---
+ test/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/meson.build b/test/meson.build
+index 8bc31646..7a5b8849 100644
+--- a/test/meson.build
++++ b/test/meson.build
+@@ -96,7 +96,7 @@ else
+ endif
+ 
+ if pytest.found()
+-  test('pytest', pytest, args: ['--tap'],
++  test('pytest', pytest, args: ['--tap', '--assert=plain'],
+        workdir: meson.current_source_dir(),
+        env: [
+          'builddir=@0@'.format(meson.project_build_root()),
+-- 
+GitLab
+
+
+From 19b9c7c73b42b857e9ecafb3eef56914c0e2ed10 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Tue, 9 Jun 2026 10:38:11 +0900
+Subject: [PATCH 2/5] test: Fix a regression for sysroot in test framework
+
+Which is only happened when SOURCE_DATE_EPOCH is set.
+
+Fixes https://gitlab.freedesktop.org/fontconfig/fontconfig/-/work_items/535
+
+Changelog: fixed
+---
+ test/fctest/__init__.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/test/fctest/__init__.py b/test/fctest/__init__.py
+index 2104e8b7..fc5e0843 100644
+--- a/test/fctest/__init__.py
++++ b/test/fctest/__init__.py
+@@ -149,6 +149,8 @@ class FcTest:
+             files = [files]
+         if not time:
+             time = self._env.get('SOURCE_DATE_EPOCH', None)
++            if time:
++                time = int(time)
+ 
+         for f in files:
+             fn = Path(f).name
+@@ -162,6 +164,8 @@ class FcTest:
+             shutil.copy2(f, dname)
+             if time:
+                 os.utime(str(dname), (time, time))
++            if time:
++                os.utime(str(dpath), (time, time))
+ 
+         if time:
+             os.utime(self.fontdir.name, (time, time))
+-- 
+GitLab
+
+
+From a3a299597791f7a412a18d66bac7bb791e160dcb Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Tue, 9 Jun 2026 10:58:26 +0900
+Subject: [PATCH 3/5] test: Fix a test case failure when BUILDDIR is under /tmp
+
+Fixes https://gitlab.freedesktop.org/fontconfig/fontconfig/-/work_items/535
+
+Changelog: fixed
+---
+ test/fctest/__init__.py | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/test/fctest/__init__.py b/test/fctest/__init__.py
+index fc5e0843..d1a7d8f5 100644
+--- a/test/fctest/__init__.py
++++ b/test/fctest/__init__.py
+@@ -246,6 +246,9 @@ class FcTest:
+                      '--proc', '/proc',
+                      # Use fresh tmpfs to avoid unexpected references
+                      '--tmpfs', '/tmp',
++                     # Bind a builddir here to avoid a situation where
++                     # it is cleaned up by the above option when it is under /tmp
++                     '--ro-bind', self._builddir, self._builddir,
+                      '--setenv', 'FONTCONFIG_FILE', self._env['FONTCONFIG_FILE']]
+             boxed += self.__bind
+             if debug:
+-- 
+GitLab
+
+
+From 1968763976990af1b8b197e126ef7eb9f75143e3 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Tue, 9 Jun 2026 11:02:11 +0900
+Subject: [PATCH 4/5] test: cleanup
+
+---
+ test/run-test-map.sh             | 107 -------------------------------
+ test/run-test.d/functions        |  55 ----------------
+ test/run-test.d/remap-flatpak.sh | 104 ------------------------------
+ 3 files changed, 266 deletions(-)
+ delete mode 100755 test/run-test-map.sh
+ delete mode 100644 test/run-test.d/functions
+ delete mode 100644 test/run-test.d/remap-flatpak.sh
+
+diff --git a/test/run-test-map.sh b/test/run-test-map.sh
+deleted file mode 100755
+index 869d7b25..00000000
+--- a/test/run-test-map.sh
++++ /dev/null
+@@ -1,107 +0,0 @@
+-#!/bin/bash
+-# fontconfig/test/run-test-cache-map.sh
+-#
+-# Copyright © 2018 Keith Packard
+-#
+-# Permission to use, copy, modify, distribute, and sell this software and its
+-# documentation for any purpose is hereby granted without fee, provided that
+-# the above copyright notice appear in all copies and that both that copyright
+-# notice and this permission notice appear in supporting documentation, and
+-# that the name of the copyright holders not be used in advertising or
+-# publicity pertaining to distribution of the software without specific,
+-# written prior permission.  The copyright holders make no representations
+-# about the suitability of this software for any purpose.  It is provided "as
+-# is" without express or implied warranty.
+-#
+-# THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+-# INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+-# EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+-# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+-# DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-# TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+-# OF THIS SOFTWARE.
+-#
+-
+-case "$OSTYPE" in
+-    msys ) MyPWD=`pwd -W` ;;  # On Msys/MinGW, returns a MS Windows style path.
+-    *    ) MyPWD=`pwd`    ;;  # On any other platforms, returns a Unix style path.
+-esac
+-
+-TESTDIR=${srcdir-"$MyPWD"}
+-BUILDTESTDIR=${builddir-"$MyPWD"}
+-
+-FONTDIRA="$MyPWD"/fontsa
+-FONTDIRB="$MyPWD"/fontsb
+-CACHEDIR="$MyPWD"/cache.dir
+-EXPECTEDIN=${EXPECTEDIN-"out-map.expected.in"}
+-EXPECTEDA="out-map-a.expected"
+-EXPECTEDB="out-map-b.expected"
+-EXPECTED="out-map.expected"
+-
+-FCLIST=../fc-list/fc-list$EXEEXT
+-FCCACHE=../fc-cache/fc-cache$EXEEXT
+-
+-which bwrap > /dev/null 2>&1
+-if [ $? -eq 0 ]; then
+-    BWRAP=`which bwrap`
+-fi
+-
+-FONT1=$TESTDIR/4x6.pcf
+-FONT2=$TESTDIR/8x16.pcf
+-
+-check () {
+-  $FCLIST - file family pixelsize | sort > out
+-  echo "=" >> out
+-  $FCLIST - file family pixelsize | sort >> out
+-  echo "=" >> out
+-  $FCLIST - file family pixelsize | sort >> out
+-  tr -d '\015' <out >out.tmp; mv out.tmp out
+-  if cmp out $BUILDTESTDIR/$EXPECTED > /dev/null ; then : ; else
+-    echo "*** Test failed: $TEST"
+-    echo "*** output is in 'out', expected output in '$EXPECTED'"
+-    exit 1
+-  fi
+-  rm -f out
+-}
+-
+-prep() {
+-  rm -rf $CACHEDIR
+-  rm -rf $FONTDIRA $FONTDIRB
+-  mkdir $FONTDIRA
+-  mkdir $CACHEDIR
+-}
+-
+-dotest () {
+-  TEST=$1
+-  test x$VERBOSE = x || echo Running: $TEST
+-}
+-
+-sed "s!@FONTDIR@!$FONTDIRA!
+-s!@MAP@!!
+-s!@CACHEDIR@!$CACHEDIR!" < $TESTDIR/fonts.conf.in > fonts-a.conf
+-
+-sed "s!@FONTDIR@!$FONTDIRB!
+-s!@MAP@!map="'"'"$FONTDIRA"'"'"!
+-s!@CACHEDIR@!$CACHEDIR!" < $TESTDIR/fonts.conf.in > fonts-b.conf
+-
+-sed "s!@FONTDIR@!$FONTDIRA!" < $EXPECTEDIN > $EXPECTEDA
+-sed "s!@FONTDIR@!$FONTDIRB!" < $EXPECTEDIN > $EXPECTEDB
+-
+-FONTCONFIG_FILE="$MyPWD"/fonts-a.conf
+-export FONTCONFIG_FILE
+-
+-dotest "Basic check"
+-prep
+-cp $FONT1 $FONT2 $FONTDIRA
+-cp $EXPECTEDA $EXPECTED
+-$FCCACHE $FONTDIRA
+-check
+-
+-dotest "mapped check"
+-prep
+-cp $FONT1 $FONT2 $FONTDIRA
+-cp $EXPECTEDB $EXPECTED
+-$FCCACHE $FONTDIRA
+-mv $FONTDIRA $FONTDIRB
+-export FONTCONFIG_FILE="$MyPWD"/fonts-b.conf
+-check
+diff --git a/test/run-test.d/functions b/test/run-test.d/functions
+deleted file mode 100644
+index 38e3db90..00000000
+--- a/test/run-test.d/functions
++++ /dev/null
+@@ -1,55 +0,0 @@
+-#! /bin/sh
+-# -*- sh -*-
+-# Copyright (C) 2023 fontconfig Authors
+-# SPDX-License-Identifier: MIT
+-
+-set -e
+-
+-: "${TMPDIR=/tmp}"
+-
+-case "$OSTYPE" in
+-    msys ) MyPWD=$(pwd -W) ;;  # On Msys/MinGW, returns a MS Windows style path.
+-    *    ) MyPWD=$(pwd)    ;;  # On any other platforms, returns a Unix style path.
+-esac
+-
+-TESTDIR=${srcdir-"$MyPWD"}
+-BUILDTESTDIR=${builddir-"$MyPWD"}
+-
+-BASEDIR=$(mktemp -d "$TMPDIR"/fontconfig.XXXXXXXX)
+-FONTDIR="$BASEDIR"/fonts
+-CACHEDIR="$BASEDIR"/cache.dir
+-EXPECTED=${EXPECTED-"out.expected"}
+-
+-FCLIST="$LOG_COMPILER ../../fc-list/fc-list$EXEEXT"
+-FCCACHE="$LOG_COMPILER ../../fc-cache/fc-cache$EXEEXT"
+-FCMATCH="$LOG_COMPILER ../../fc-match/fc-match$EXEEXT"
+-
+-if [ -x "$(command -v bwrap)" ]; then
+-    BWRAP="$(command -v bwrap)"
+-fi
+-
+-FONT1=$TESTDIR/../4x6.pcf
+-FONT2=$TESTDIR/../8x16.pcf
+-TEST=""
+-
+-clean_exit() {
+-    rc=$?
+-    trap - INT TERM ABRT EXIT
+-    if [ "x$TEST" != "x" ]; then
+-        echo "Aborting from '$TEST' with the exit code $rc"
+-    fi
+-    rm -rf $BASEDIR
+-    exit $rc
+-}
+-trap clean_exit INT TERM ABRT EXIT
+-
+-prep() {
+-    rm -rf "$CACHEDIR"
+-    rm -rf "$FONTDIR"
+-    mkdir "$FONTDIR"
+-}
+-
+-dotest () {
+-    TEST=$1
+-    test x"$VERBOSE" = x || echo "Running: $TEST"
+-}
+diff --git a/test/run-test.d/remap-flatpak.sh b/test/run-test.d/remap-flatpak.sh
+deleted file mode 100644
+index 36d31bdb..00000000
+--- a/test/run-test.d/remap-flatpak.sh
++++ /dev/null
+@@ -1,104 +0,0 @@
+-#! /bin/sh
+-# -*- sh -*-
+-# Copyright (C) 2023 fontconfig Authors
+-# SPDX-License-Identifier: MIT
+-
+-. $(dirname $0)/functions
+-
+-dotest "Remap - same family name but different filename"
+-prep
+-
+-TESTRESULT1=$(mktemp "$TMPDIR"/fontconfig.XXXXXXXX)
+-TESTRESULT2=$(mktemp "$TMPDIR"/fontconfig.XXXXXXXX)
+-TESTRESULT3=$(mktemp "$TMPDIR"/fontconfig.XXXXXXXX)
+-TESTFONT1DIR=$(mktemp -d "$TMPDIR"/fontconfig.XXXXXXXX)
+-TESTFONT2DIR=$(mktemp -d "$TMPDIR"/fontconfig.XXXXXXXX)
+-TESTCACHE1DIR=$(mktemp -d "$TMPDIR"/fontconfig.XXXXXXXX)
+-TESTCACHE2DIR=$(mktemp -d "$TMPDIR"/fontconfig.XXXXXXXX)
+-TESTBUILD1DIR=$(mktemp -d "$TMPDIR"/fontconfig.XXXXXXXX)
+-TESTBUILD2DIR=$(mktemp -d "$TMPDIR"/fontconfig.XXXXXXXX)
+-TESTRUNDIR=$(mktemp -d "$TMPDIR"/fontconfig.XXXXXXXX)
+-mkdir -p "$TESTBUILD1DIR"/build
+-mkdir -p "$TESTBUILD2DIR"/build
+-mkdir -p "$TESTRUNDIR"/fonts
+-mkdir -p "$TESTRUNDIR"/fonts-cache
+-cp "$FONT1" "$TESTFONT1DIR"/foo.pcf
+-cp "$FONT1" "$TESTFONT2DIR"/bar.pcf
+-touch -m -t $(date -d @0 +%y%m%d%H%M.%S) "$TESTFONT1DIR"
+-touch -m -t $(date -d @0 +%y%m%d%H%M.%S) "$TESTFONT1DIR"/*
+-touch -m -t $(date -d @0 +%y%m%d%H%M.%S) "$TESTFONT2DIR"
+-touch -m -t $(date -d @0 +%y%m%d%H%M.%S) "$TESTFONT2DIR"/*
+-
+-cat<<_EOF_>>"$TESTBUILD1DIR"/fonts.conf
+-<fontconfig>
+-  <dir>/usr/share/fonts</dir>
+-  <cachedir>/usr/lib/fontconfig/cache</cachedir>
+-</fontconfig>
+-_EOF_
+-cat<<_EOF_>>"$TESTBUILD2DIR"/fonts.conf
+-<fontconfig>
+-  <dir salt="flatpak">/usr/share/fonts</dir>
+-  <cachedir>/usr/lib/fontconfig/cache</cachedir>
+-</fontconfig>
+-_EOF_
+-cat<<_EOF_>>"$TESTBUILD2DIR"/bind-fonts.conf
+-<fontconfig>
+-<dir salt="flatpak">/usr/share/fonts</dir>
+-<dir>$TESTRUNDIR/fonts</dir>
+-<cachedir>/usr/lib/fontconfig/cache</cachedir>
+-<cachedir>$TESTRUNDIR/fonts-cache</cachedir>
+-
+-<remap-dir as-path="/usr/share/fonts">$TESTRUNDIR/fonts</remap-dir>
+-</fontconfig>
+-_EOF_
+-
+-# Generate host caches
+-$BWRAP --bind / / --bind "$TESTCACHE1DIR" /usr/lib/fontconfig/cache --bind "$TESTFONT1DIR" /usr/share/fonts --bind "$TESTBUILD1DIR" /usr/share/fontconfig --dev-bind /dev /dev --setenv FONTCONFIG_FILE "$TESTBUILD1DIR"/fonts.conf $FCCACHE
+-touch -m -t $(date -d @0 +%y%m%d%H%M.%S) "$TESTCACHE1DIR"
+-touch -m -t $(date -d @0 +%y%m%d%H%M.%S) "$TESTCACHE1DIR"/*
+-$BWRAP --bind / / --bind "$TESTCACHE1DIR" /usr/lib/fontconfig/cache --bind "$TESTFONT1DIR" /usr/share/fonts --bind "$TESTBUILD1DIR" /usr/share/fontconfig --dev-bind /dev /dev --setenv FONTCONFIG_FILE "$TESTBUILD1DIR"/fonts.conf $FCMATCH Fixed file > "$TESTRESULT1"
+-
+-if grep foo.pcf "$TESTRESULT1" > /dev/null; then : ; else
+-    echo "*** Test failed: $TEST"
+-    echo "file property doesn't point to the expected file."
+-    cat "$TESTRESULT1"
+-    exit 1
+-fi
+-
+-# Generate runtime caches
+-$BWRAP --bind / / --bind "$TESTCACHE2DIR" /usr/lib/fontconfig/cache --bind "$TESTFONT2DIR" /usr/share/fonts --bind "$TESTBUILD2DIR" /usr/share/fontconfig --dev-bind /dev /dev --setenv FONTCONFIG_FILE "$TESTBUILD2DIR"/fonts.conf $FCCACHE
+-touch -m -t $(date -d @0 +%y%m%d%H%M.%S) "$TESTCACHE2DIR"
+-touch -m -t $(date -d @0 +%y%m%d%H%M.%S) "$TESTCACHE2DIR"/*
+-$BWRAP --bind / / --bind "$TESTCACHE2DIR" /usr/lib/fontconfig/cache --bind "$TESTFONT2DIR" /usr/share/fonts --bind "$TESTBUILD2DIR" /usr/share/fontconfig --dev-bind /dev /dev --setenv FONTCONFIG_FILE "$TESTBUILD2DIR"/fonts.conf $FCMATCH Fixed file > "$TESTRESULT2"
+-
+-if grep bar.pcf "$TESTRESULT2" > /dev/null; then : ; else
+-    echo "*** Test failed: $TEST"
+-    echo "file property doesn't point to the expected file."
+-    cat "$TESTRESULT2"
+-    exit 1
+-fi
+-
+-# Ask for fonts on similar environemnt to flatpak
+-$BWRAP --bind / / --ro-bind "$TESTCACHE2DIR" /usr/lib/fontconfig/cache --ro-bind "$TESTFONT2DIR" /usr/share/fonts --bind "$TESTBUILD2DIR" /usr/share/fontconfig --ro-bind "$TESTRUNDIR" "$TESTRUNDIR" --ro-bind "$TESTCACHE1DIR" "$TESTRUNDIR"/fonts-cache --ro-bind "$TESTFONT1DIR" "$TESTRUNDIR"/fonts --dev-bind /dev /dev --setenv FONTCONFIG_FILE "$TESTBUILD2DIR"/bind-fonts.conf $FCMATCH Fixed file > "$TESTRESULT3"
+-$BWRAP --bind / / --ro-bind "$TESTCACHE2DIR" /usr/lib/fontconfig/cache --ro-bind "$TESTFONT2DIR" /usr/share/fonts --bind "$TESTBUILD2DIR" /usr/share/fontconfig --ro-bind "$TESTRUNDIR" "$TESTRUNDIR" --ro-bind "$TESTCACHE1DIR" "$TESTRUNDIR"/fonts-cache --ro-bind "$TESTFONT1DIR" "$TESTRUNDIR"/fonts --dev-bind /dev /dev --setenv FONTCONFIG_FILE "$TESTBUILD2DIR"/bind-fonts.conf ls $(sed 's/:file=//' "$TESTRESULT3") > /dev/null
+-
+-# Check the amount of cache files
+-if [ $(ls "$TESTCACHE1DIR"|wc -l) == 2 ]; then : ; else
+-    echo "*** Test failed: $TEST"
+-    echo "Too much cache files created at host cache dir."
+-    ls "$TESTCACHE1DIR"
+-    exit 1
+-fi
+-if [ $(ls "$TESTCACHE2DIR"|wc -l) == 2 ]; then : ; else
+-    echo "*** Test failed: $TEST"
+-    echo "Too much cache files created at runtime cache dir."
+-    ls "$TESTCACHE2DIR"
+-    exit 1
+-fi
+-
+-rm -rf "$TESTFONT1DIR" "$TESTFONT2DIR" "$TESTCACHE1DIR" "$TESTCACHE2DIR" "$TESTBUILD1DIR" "$TESTBUILD2DIR"
+-rm -f "$TESTRESULT1" "$TESTRESULT2"
+-
+-TEST=""
+-
+-echo "Success."
+-- 
+GitLab
+
+
+From cef37f9f3cd38618a3d0df0f89b8f777d86e38ba Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Tue, 9 Jun 2026 11:03:13 +0900
+Subject: [PATCH 5/5] Add .gitignore
+
+---
+ .gitignore | 4 ++++
+ 1 file changed, 4 insertions(+)
+ create mode 100644 .gitignore
+
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 00000000..82102bd0
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1,4 @@
++*~
++__pycache__
++/prefix*
++/build*
+-- 
+GitLab
+

--- a/packages/f/fontconfig/files/529.patch
+++ b/packages/f/fontconfig/files/529.patch
@@ -1,0 +1,890 @@
+From e8afd82cd76d8c53a8bb1446457ac7ae21640a0a Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Tue, 9 Jun 2026 14:53:06 +0900
+Subject: [PATCH 1/4] meson: Add tests-external-fonts option to disable
+ network-dependent tests
+
+Add a new meson build option 'tests-external-fonts' (enabled by default)
+to control whether tests requiring external font files should run.
+
+This allows building and testing without network access by explicitly
+disabling the option, while ensuring tests fail properly (not skip)
+when the option is enabled but fonts are missing.
+
+Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+
+Changelog: added
+---
+ fc-fontations/instance_enumerate.rs |  4 ++--
+ fc-fontations/meson.build           | 11 +++++----
+ fc-fontations/name_records.rs       |  1 +
+ meson.build                         |  1 +
+ meson.options                       |  2 ++
+ test/fctest/__init__.py             |  2 ++
+ test/meson.build                    | 36 ++++++++++++++++++-----------
+ test/pytest.ini                     |  3 +++
+ test/test_crbug1004254.py           |  1 +
+ test/test_fontations_ft_query.py    |  1 +
+ test/test_genconf.py                |  1 +
+ test/test_issue431.py               |  4 +---
+ 12 files changed, 44 insertions(+), 23 deletions(-)
+ create mode 100644 test/pytest.ini
+
+diff --git a/fc-fontations/instance_enumerate.rs b/fc-fontations/instance_enumerate.rs
+index 5ed6ea12..3488a29a 100644
+--- a/fc-fontations/instance_enumerate.rs
++++ b/fc-fontations/instance_enumerate.rs
+@@ -146,10 +146,10 @@ mod test {
+     ];
+ 
+     #[test]
++    #[cfg_attr(skip_external_fonts, ignore)]
+     fn test_instance_iterator() {
+         let bytes = std::fs::read(variable_collection_testfont())
+-            .ok()
+-            .unwrap_or_default();
++            .expect("Could not read test font file");
+         let fileref = FileRef::new(&bytes).ok();
+         let fonts = fonts_and_indices(fileref);
+         for (font, _ttc_index) in fonts {
+diff --git a/fc-fontations/meson.build b/fc-fontations/meson.build
+index 9533b1ee..b420ed08 100644
+--- a/fc-fontations/meson.build
++++ b/fc-fontations/meson.build
+@@ -53,11 +53,14 @@ if (fontations.enabled())
+     sources: ['../src/fcfontations.c', fcstdint_h, fclang_h, alias_headers],
+   )
+ 
++  rust_args_list = ['--check-cfg', 'cfg(skip_external_fonts)']
++  if not get_option('tests-external-fonts').allowed()
++    rust_args_list += ['--cfg', 'skip_external_fonts']
++  endif
++
+   fc_fontations = cargo.package().library(
+-    link_with: [
+-      pattern_lib,
+-      fontations_query_lib,
+-    ],
++    link_with: [pattern_lib, fontations_query_lib],
+     install: true,
++    rust_args: rust_args_list,
+   )
+ endif
+diff --git a/fc-fontations/name_records.rs b/fc-fontations/name_records.rs
+index 631ccdc0..afb921b8 100644
+--- a/fc-fontations/name_records.rs
++++ b/fc-fontations/name_records.rs
+@@ -150,6 +150,7 @@ mod test {
+     }
+ 
+     #[test]
++    #[cfg_attr(skip_external_fonts, ignore)]
+     fn test_sort_name_records() {
+         let font_bytes = get_test_font_bytes().expect("Could not read test font file.");
+         let font = read_fonts::FontRef::new(font_bytes.as_slice()).unwrap();
+diff --git a/meson.build b/meson.build
+index dd3f4441..26767b5a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -643,6 +643,7 @@ summary({
+   'Documentation': (doc_targets.length() > 0 ? doc_targets : false),
+   'NLS': not opt_nls.disabled(),
+   'Tests': not get_option('tests').disabled(),
++  'Tests (external fonts)': get_option('tests-external-fonts').allowed(),
+   'Pytest': pytest.found(),
+   'Tools': not get_option('tools').disabled(),
+   'iconv': found_iconv == 1,
+diff --git a/meson.options b/meson.options
+index e2936426..2f4066d2 100644
+--- a/meson.options
++++ b/meson.options
+@@ -10,6 +10,8 @@ option('nls', type : 'feature', value : 'auto', yield: true,
+ option('tests', type : 'feature', value : 'auto', yield : true,
+   description: 'Enable unit tests')
+ option('tests-bwrap', type: 'feature', value: 'auto')
++option('tests-external-fonts', type: 'feature', value: 'enabled', yield: true,
++  description: 'Download external test fonts (requires network access)')
+ option('tools', type : 'feature', value : 'auto', yield : true,
+   description: 'Build command-line tools (fc-list, fc-query, etc.)')
+ option('cache-build', type : 'feature', value : 'enabled',
+diff --git a/test/fctest/__init__.py b/test/fctest/__init__.py
+index d1a7d8f5..e93a3ca4 100644
+--- a/test/fctest/__init__.py
++++ b/test/fctest/__init__.py
+@@ -362,6 +362,8 @@ class FcExternalTestFont:
+     def __init__(self):
+         fctest = FcTest()
+         self._fonts = [str(fn) for fn in (Path(fctest.builddir) / "testfonts").glob('**/*.ttf')]
++        if not self._fonts:
++            raise RuntimeError("No external test fonts available. Run with -Dtests-external-fonts=enabled to fetch them.")
+ 
+     @property
+     def fonts(self):
+diff --git a/test/meson.build b/test/meson.build
+index 7a5b8849..83840504 100644
+--- a/test/meson.build
++++ b/test/meson.build
+@@ -1,16 +1,20 @@
+-fetch_test_fonts = custom_target(
+-  'fetch_test_fonts',
+-  output: 'testfonts',
+-  command: [
+-    python3,
+-    join_paths(meson.project_source_root(), 'build-aux', 'fetch-testfonts.py'),
+-    '--target-dir',
+-    '@BUILD_ROOT@/testfonts',
+-    '--try-symlink',
+-  ],
+-  build_by_default: false,
+-  build_always_stale: true,
+-)
++if get_option('tests-external-fonts').allowed()
++  fetch_test_fonts = custom_target(
++    'fetch_test_fonts',
++    output: 'testfonts',
++    command: [
++      python3,
++      join_paths(meson.project_source_root(), 'build-aux', 'fetch-testfonts.py'),
++      '--target-dir',
++      '@BUILD_ROOT@/testfonts',
++      '--try-symlink',
++    ],
++    build_by_default: false,
++    build_always_stale: true,
++  )
++else
++  fetch_test_fonts = []
++endif
+ 
+ tests = [
+   ['test-bz89617.c', {'c_args': ['-DSRCDIR="@0@"'.format(meson.current_source_dir())]}],
+@@ -96,7 +100,11 @@ else
+ endif
+ 
+ if pytest.found()
+-  test('pytest', pytest, args: ['--tap', '--assert=plain'],
++  pytest_args = ['--tap', '--assert=plain']
++  if not get_option('tests-external-fonts').allowed()
++    pytest_args += ['-m', 'not network']
++  endif
++  test('pytest', pytest, args: pytest_args,
+        workdir: meson.current_source_dir(),
+        env: [
+          'builddir=@0@'.format(meson.project_build_root()),
+diff --git a/test/pytest.ini b/test/pytest.ini
+new file mode 100644
+index 00000000..c0860942
+--- /dev/null
++++ b/test/pytest.ini
+@@ -0,0 +1,3 @@
++[pytest]
++markers =
++    network: marks tests as requiring external fonts downloaded from the network (deselect with '-m "not network"')
+diff --git a/test/test_crbug1004254.py b/test/test_crbug1004254.py
+index b843c198..fe88d6d6 100644
+--- a/test/test_crbug1004254.py
++++ b/test/test_crbug1004254.py
+@@ -20,6 +20,7 @@ def fcfont():
+     return FcTestFont()
+ 
+ 
++@pytest.mark.network
+ @pytest.mark.skipif(not not os.getenv('EXEEXT'), reason='not working on Win32')
+ def test_crbug1004254(fctest, fcfont):
+     builddir = Path(fctest.builddir)
+diff --git a/test/test_fontations_ft_query.py b/test/test_fontations_ft_query.py
+index 5bd03ca2..45739a72 100644
+--- a/test/test_fontations_ft_query.py
++++ b/test/test_fontations_ft_query.py
+@@ -47,6 +47,7 @@ def compare_fontations_freetype(fctest, font_file, ret_code_behavior: RetCodeBeh
+     ), f"FreeType and Fontations fc-query result must match. Fontations: {result_fontations}, FreeType: {result_freetype}"
+ 
+ 
++@pytest.mark.network
+ @pytest.mark.parametrize("font_file", FcExternalTestFont().fonts)
+ def test_fontations_freetype_fcquery_equal(fctest, font_file):
+     fctest.logger.info(f'Testing with: {font_file}')
+diff --git a/test/test_genconf.py b/test/test_genconf.py
+index eae61094..8268c8c8 100644
+--- a/test/test_genconf.py
++++ b/test/test_genconf.py
+@@ -17,6 +17,7 @@ def fcfont():
+     return FcTestFont()
+ 
+ 
++@pytest.mark.network
+ @pytest.mark.parametrize("font_file", FcExternalTestFont().fonts)
+ def test_genconf(fctest, fcfont, font_file):
+     font_path = Path(font_file)
+diff --git a/test/test_issue431.py b/test/test_issue431.py
+index 6b15a5fc..a8559118 100644
+--- a/test/test_issue431.py
++++ b/test/test_issue431.py
+@@ -13,6 +13,7 @@ def fctest():
+     return FcTest()
+ 
+ 
++@pytest.mark.network
+ def test_issue431(fctest):
+     roboto_flex_font = (
+         Path(fctest.builddir)
+@@ -20,9 +21,6 @@ def test_issue431(fctest):
+         / "roboto-flex-fonts/fonts/variable/RobotoFlex[GRAD,XOPQ,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght].ttf"
+     )
+ 
+-    if not roboto_flex_font.exists():
+-        pytest.skip(f"Font file not found: {roboto_flex_font}")
+-
+     for ret, stdout, stderr in fctest.run_query(['-f',
+                                                  '%{family[0]}:%{index}:%{style[0]}:%{postscriptname}\n',
+                                                  roboto_flex_font]):
+-- 
+GitLab
+
+
+From 0290d37073f4d93d8f1b7a1f0d9f7b79e3238025 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Tue, 9 Jun 2026 14:56:42 +0900
+Subject: [PATCH 2/4] Add .editorconfig
+
+---
+ .editorconfig | 5 +++++
+ .gitignore    | 2 ++
+ 2 files changed, 7 insertions(+)
+ create mode 100644 .editorconfig
+
+diff --git a/.editorconfig b/.editorconfig
+new file mode 100644
+index 00000000..fa3306a2
+--- /dev/null
++++ b/.editorconfig
+@@ -0,0 +1,5 @@
++root = true
++
++[meson.build]
++indent_style = space
++indent_size = 2
+diff --git a/.gitignore b/.gitignore
+index 82102bd0..9d59c21d 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -2,3 +2,5 @@
+ __pycache__
+ /prefix*
+ /build*
++/target*
++/subprojects/*/
+-- 
+GitLab
+
+
+From d7666d394b4ca690d2e4b1334f262ecf548755e7 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Wed, 10 Jun 2026 12:37:01 +0900
+Subject: [PATCH 3/4] test: improve marker handling
+
+Simply skip when disabling the tests-external-fonts meson option.
+Otherwise raise an error if no fonts available.
+---
+ test/fctest/__init__.py          | 288 +++++++++++++++++++------------
+ test/meson.build                 |   2 +-
+ test/test_fontations_ft_query.py |  10 +-
+ test/test_genconf.py             |  19 +-
+ 4 files changed, 186 insertions(+), 133 deletions(-)
+
+diff --git a/test/fctest/__init__.py b/test/fctest/__init__.py
+index e93a3ca4..6e6a3fbe 100644
+--- a/test/fctest/__init__.py
++++ b/test/fctest/__init__.py
+@@ -12,67 +12,102 @@ import re
+ import shutil
+ import subprocess
+ import sys
++import pytest
++from _pytest.mark.expression import Expression
+ 
+ 
+ logging.basicConfig(level=logging.DEBUG)
+ 
++
++def pytest_generate_tests(metafunc):
++    markexpr = metafunc.config.getoption("-m")
++    if not markexpr:
++        network_enabled = True
++    else:
++        try:
++            expr = Expression.compile(markexpr)
++            network_enabled = expr.evaluate(lambda name: name in ["network"])
++        except Exception:
++            network_enabled = False
++
++    if "parametrized_external_font" in metafunc.fixturenames:
++        if network_enabled:
++            metafunc.parametrize(
++                "parametrized_external_font", FcExternalTestFont().fonts
++            )
++        else:
++            metafunc.parametrize(
++                "parametrized_external_font",
++                [
++                    pytest.param(
++                        None,
++                        marks=pytest.mark.skip(
++                            reason="Skipped: Network access diabled"
++                        ),
++                    )
++                ],
++            )
++
++
+ class FcTest:
+ 
+     def __init__(self):
+         self._with_fontations = False
+         self.logger = logging.getLogger()
+         self._env = os.environ.copy()
+-        self._fontdir = TemporaryDirectory(prefix='fontconfig.',
+-                                           suffix='.host_fontdir')
+-        self._cachedir = TemporaryDirectory(prefix='fontconfig.',
+-                                            suffix='.host_cachedir')
+-        self._conffile = NamedTemporaryFile(prefix='fontconfig.',
+-                                            suffix='.host.conf',
+-                                            mode='w',
+-                                            delete_on_close=False)
+-        self._builddir = self._env.get('builddir', str(Path(__file__).parents[2] / 'build'))
+-        self._srcdir = self._env.get('srcdir', '.')
+-        self._exeext = self._env.get('EXEEXT',
+-                                     '.exe' if sys.platform == 'win32' else '')
+-        self._drive = PureWindowsPath(self._env.get('SystemDrive', '')).drive
+-        self._exewrapper = ''
+-        if self._exeext and sys.platform != 'win32':
+-            self._exewrapper = shutil.which('wine')
++        self._fontdir = TemporaryDirectory(prefix="fontconfig.", suffix=".host_fontdir")
++        self._cachedir = TemporaryDirectory(
++            prefix="fontconfig.", suffix=".host_cachedir"
++        )
++        self._conffile = NamedTemporaryFile(
++            prefix="fontconfig.", suffix=".host.conf", mode="w", delete_on_close=False
++        )
++        self._builddir = self._env.get(
++            "builddir", str(Path(__file__).parents[2] / "build")
++        )
++        self._srcdir = self._env.get("srcdir", str(Path(__file__).parents[2]))
++        self._exeext = self._env.get(
++            "EXEEXT", ".exe" if sys.platform == "win32" else ""
++        )
++        self._drive = PureWindowsPath(self._env.get("SystemDrive", "")).drive
++        self._exewrapper = ""
++        if self._exeext and sys.platform != "win32":
++            self._exewrapper = shutil.which("wine")
+             if not self._exewrapper:
+-                raise RuntimeError('No runner available')
+-            self._drive = 'z:'
+-            cc = self._env.get('CC', 'cc')
+-            res = subprocess.run([cc, '-print-sysroot'], capture_output=True)
+-            sysroot = res.stdout.decode('utf-8').rstrip()
++                raise RuntimeError("No runner available")
++            self._drive = "z:"
++            cc = self._env.get("CC", "cc")
++            res = subprocess.run([cc, "-print-sysroot"], capture_output=True)
++            sysroot = res.stdout.decode("utf-8").rstrip()
+             if res.returncode != 0 or not sysroot:
+-                raise RuntimeError('Unable to get sysroot')
+-            sysroot = Path(sysroot) / 'mingw' / 'bin'
+-            self._env['WINEPATH'] = ';'.join(
+-                [
+-                    self.convert_path(self._builddir),
+-                    self.convert_path(sysroot)
+-                ])
+-        self._bwrap = shutil.which('bwrap')
++                raise RuntimeError("Unable to get sysroot")
++            sysroot = Path(sysroot) / "mingw" / "bin"
++            self._env["WINEPATH"] = ";".join(
++                [self.convert_path(self._builddir), self.convert_path(sysroot)]
++            )
++        self._bwrap = shutil.which("bwrap")
++
+         def bin_path(bin):
+             fn = bin + self._exeext
+             return self.convert_path(Path(self.builddir) / bin / fn)
+-        self._fccache = bin_path('fc-cache')
+-        self._fccat = bin_path('fc-cat')
+-        self._fcgenconf = bin_path('fc-genconf')
+-        self._fclist = bin_path('fc-list')
+-        self._fcmatch = bin_path('fc-match')
+-        self._fcpattern = bin_path('fc-pattern')
+-        self._fcquery = bin_path('fc-query')
+-        self._fcscan = bin_path('fc-scan')
+-        self._fcvalidate = bin_path('fc-validate')
++
++        self._fccache = bin_path("fc-cache")
++        self._fccat = bin_path("fc-cat")
++        self._fcgenconf = bin_path("fc-genconf")
++        self._fclist = bin_path("fc-list")
++        self._fcmatch = bin_path("fc-match")
++        self._fcpattern = bin_path("fc-pattern")
++        self._fcquery = bin_path("fc-query")
++        self._fcscan = bin_path("fc-scan")
++        self._fcvalidate = bin_path("fc-validate")
+         self._extra = []
+-        self.__conf_templ = '''
++        self.__conf_templ = """
+         <fontconfig>
+           {extra}
+           <dir>{fontdir}</dir>
+           <cachedir>{cachedir}</cachedir>
+         </fontconfig>
+-        '''
++        """
+         self._sandboxed = False
+ 
+     def __del__(self):
+@@ -98,11 +133,11 @@ class FcTest:
+ 
+     @property
+     def extra(self):
+-        return '\n'.join(self._extra)
++        return "\n".join(self._extra)
+ 
+     @property
+     def remapdir(self):
+-        return [x for x in self._extra if re.search(r'\b<remap-dir\b', x)]
++        return [x for x in self._extra if re.search(r"\b<remap-dir\b", x)]
+ 
+     @property
+     def with_fontations(self):
+@@ -114,7 +149,7 @@ class FcTest:
+ 
+     @remapdir.setter
+     def remapdir(self, v: str) -> None:
+-        self._extra = [x for x in self._extra if not re.search(r'\b<remap-dir\b', x)]
++        self._extra = [x for x in self._extra if not re.search(r"\b<remap-dir\b", x)]
+         self._extra += [f'<remap-dir as-path="{self.fontdir.name}">{v}</remap-dir>']
+ 
+     @property
+@@ -122,9 +157,11 @@ class FcTest:
+         return self._env
+ 
+     def config(self) -> str:
+-        return self.__conf_templ.format(fontdir=self.convert_path(self.fontdir.name),
+-                                        cachedir=self.convert_path(self.cachedir.name),
+-                                        extra=self.extra)
++        return self.__conf_templ.format(
++            fontdir=self.convert_path(self.fontdir.name),
++            cachedir=self.convert_path(self.cachedir.name),
++            extra=self.extra,
++        )
+ 
+     def setup(self):
+         if self._sandboxed:
+@@ -133,7 +170,9 @@ class FcTest:
+             self._remapped_conffile.close()
+             conf = self._remapped_conffile.name
+             try:
+-                fn = Path(self._remapped_conffile.name).relative_to(Path(self._builddir).resolve())
++                fn = Path(self._remapped_conffile.name).relative_to(
++                    Path(self._builddir).resolve()
++                )
+                 conf = str(Path(self._remapped_builddir.name) / fn)
+             except ValueError:
+                 pass
+@@ -142,13 +181,13 @@ class FcTest:
+             self._conffile.close()
+             conf = self._conffile.name
+ 
+-        self._env['FONTCONFIG_FILE'] = self.convert_path(conf)
++        self._env["FONTCONFIG_FILE"] = self.convert_path(conf)
+ 
+     def install_font(self, files, dest, time=None):
+         if not isinstance(files, list):
+             files = [files]
+         if not time:
+-            time = self._env.get('SOURCE_DATE_EPOCH', None)
++            time = self._env.get("SOURCE_DATE_EPOCH", None)
+             if time:
+                 time = int(time)
+ 
+@@ -173,30 +212,29 @@ class FcTest:
+     @contextmanager
+     def sandboxed(self, remapped_basedir, bind=None) -> Self:
+         if not self._bwrap:
+-            raise RuntimeError('No bwrap installed')
+-        self._remapped_fontdir = TemporaryDirectory(prefix='fontconfig.',
+-                                                    suffix='.fontdir',
+-                                                    dir=remapped_basedir,
+-                                                    delete=False)
+-        self._remapped_cachedir = TemporaryDirectory(prefix='fontconfig.',
+-                                                     suffix='.cachedir',
+-                                                     dir=remapped_basedir,
+-                                                     delete=False)
+-        self._remapped_builddir = TemporaryDirectory(prefix='fontconfig.',
+-                                                     suffix='.build',
+-                                                     dir=remapped_basedir,
+-                                                     delete=False)
+-        self._remapped_conffile = NamedTemporaryFile(prefix='fontconfig.',
+-                                                     suffix='.conf',
+-                                                     dir=Path(self._builddir) / 'test',
+-                                                     mode='w',
+-                                                     delete_on_close=False)
++            raise RuntimeError("No bwrap installed")
++        self._remapped_fontdir = TemporaryDirectory(
++            prefix="fontconfig.", suffix=".fontdir", dir=remapped_basedir, delete=False
++        )
++        self._remapped_cachedir = TemporaryDirectory(
++            prefix="fontconfig.", suffix=".cachedir", dir=remapped_basedir, delete=False
++        )
++        self._remapped_builddir = TemporaryDirectory(
++            prefix="fontconfig.", suffix=".build", dir=remapped_basedir, delete=False
++        )
++        self._remapped_conffile = NamedTemporaryFile(
++            prefix="fontconfig.",
++            suffix=".conf",
++            dir=Path(self._builddir) / "test",
++            mode="w",
++            delete_on_close=False,
++        )
+         self._basedir = remapped_basedir
+         self.remapdir = self._remapped_fontdir.name
+         self._orig_cachedir = self.cachedir
+         self._cachedir = self._remapped_cachedir
+         self._sandboxed = True
+-        dummy = TemporaryDirectory(prefix='fontconfig.')
++        dummy = TemporaryDirectory(prefix="fontconfig.")
+         # Set same mtime to dummy directory to avoid updating cache
+         # because of mtime
+         st = Path(self.fontdir.name).stat()
+@@ -207,8 +245,8 @@ class FcTest:
+         self.setup()
+         self._fontdir = orig_fontdir
+         base_bind = {
+-                self._orig_cachedir.name: self._remapped_cachedir.name,
+-                self._builddir: self._remapped_builddir.name,
++            self._orig_cachedir.name: self._remapped_cachedir.name,
++            self._builddir: self._remapped_builddir.name,
+         }
+         if not bind:
+             bind = base_bind | {
+@@ -216,7 +254,7 @@ class FcTest:
+             }
+         else:
+             bind = base_bind | bind
+-        b = [('--bind', x, y) for x, y in bind.items()]
++        b = [("--bind", x, y) for x, y in bind.items()]
+         self.__bind = list(chain.from_iterable(i for i in b))
+         try:
+             yield self
+@@ -232,7 +270,7 @@ class FcTest:
+             self.remapdir = None
+             self._basedir = None
+             self.__bind = None
+-            self._env['FONTCONFIG_FILE'] = self._conffile.name
++            self._env["FONTCONFIG_FILE"] = self._conffile.name
+ 
+     def run(self, binary, args=[], debug=False) -> Iterator[[int, str, str]]:
+         cmd = []
+@@ -241,45 +279,56 @@ class FcTest:
+         cmd += [str(binary)]
+         cmd += args
+         if self._sandboxed:
+-            boxed = [self._bwrap, '--ro-bind', '/', '/',
+-                     '--dev-bind', '/dev', '/dev',
+-                     '--proc', '/proc',
+-                     # Use fresh tmpfs to avoid unexpected references
+-                     '--tmpfs', '/tmp',
+-                     # Bind a builddir here to avoid a situation where
+-                     # it is cleaned up by the above option when it is under /tmp
+-                     '--ro-bind', self._builddir, self._builddir,
+-                     '--setenv', 'FONTCONFIG_FILE', self._env['FONTCONFIG_FILE']]
++            boxed = [
++                self._bwrap,
++                "--ro-bind",
++                "/",
++                "/",
++                "--dev-bind",
++                "/dev",
++                "/dev",
++                "--proc",
++                "/proc",
++                # Use fresh tmpfs to avoid unexpected references
++                "--tmpfs",
++                "/tmp",
++                # Bind a builddir here to avoid a situation where
++                # it is cleaned up by the above option when it is under /tmp
++                "--ro-bind",
++                self._builddir,
++                self._builddir,
++                "--setenv",
++                "FONTCONFIG_FILE",
++                self._env["FONTCONFIG_FILE"],
++            ]
+             boxed += self.__bind
+             if debug:
+-                boxed += ['--setenv', 'FC_DEBUG', str(debug)]
++                boxed += ["--setenv", "FC_DEBUG", str(debug)]
+             if self.with_fontations:
+-                boxed += ['--setenv', 'FC_FONTATIONS', '1']
++                boxed += ["--setenv", "FC_FONTATIONS", "1"]
+             boxed += cmd
+             self.logger.info(boxed)
+-            res = subprocess.run(boxed, capture_output=True,
+-                                 env=self._env)
++            res = subprocess.run(boxed, capture_output=True, env=self._env)
+         else:
+-            origdebug = self._env.get('FC_DEBUG')
++            origdebug = self._env.get("FC_DEBUG")
+             if debug:
+-                self._env['FC_DEBUG'] = str(debug)
+-            origfontations = self._env.get('FC_FONTATIONS')
++                self._env["FC_DEBUG"] = str(debug)
++            origfontations = self._env.get("FC_FONTATIONS")
+             if self.with_fontations:
+-                self._env['FC_FONTATIONS'] = '1'
++                self._env["FC_FONTATIONS"] = "1"
+             self.logger.info(cmd)
+-            res = subprocess.run(cmd, capture_output=True,
+-                                 env=self._env)
++            res = subprocess.run(cmd, capture_output=True, env=self._env)
+             if debug:
+                 if origdebug:
+-                    self._env['FC_DEBUG'] = origdebug
++                    self._env["FC_DEBUG"] = origdebug
+                 else:
+-                    del self._env['FC_DEBUG']
++                    del self._env["FC_DEBUG"]
+             if self.with_fontations:
+                 if origfontations:
+-                    self._env['FC_FONTATIONS'] = origfontations
++                    self._env["FC_FONTATIONS"] = origfontations
+                 else:
+-                    del self._env['FC_FONTATIONS']
+-        yield res.returncode, res.stdout.decode('utf-8'), res.stderr.decode('utf-8')
++                    del self._env["FC_FONTATIONS"]
++        yield res.returncode, res.stdout.decode("utf-8"), res.stderr.decode("utf-8")
+ 
+     def run_cache(self, args, debug=False) -> Iterator[[int, str, str]]:
+         return self.run(self._fccache, args, debug)
+@@ -309,43 +358,48 @@ class FcTest:
+         return self.run(self._fcvalidate, args, debug)
+ 
+     def cache_files(self) -> Iterator[Path]:
+-        for c in Path(self.cachedir.name).glob('*cache*'):
++        for c in Path(self.cachedir.name).glob("*cache*"):
+             yield c
+ 
+     def convert_path(self, path) -> str:
+         winpath = PureWindowsPath(path)
+         if not winpath.drive and self._drive:
+-            return str(PureWindowsPath(self._drive) / '/' / winpath).replace('\\', '/')
++            return str(PureWindowsPath(self._drive) / "/" / winpath).replace("\\", "/")
+         return path
+ 
+ 
+ class FcTestFont:
+ 
+-    def __init__(self, srcdir='.'):
++    def __init__(self, srcdir="."):
+         self._fonts = []
+         p = Path(srcdir)
+-        if (p / 'test').exists():
+-            p = p / 'test'
+-        if not (p / '4x6.pcf').exists():
+-            raise RuntimeError('No 4x6.pcf available.')
++        if (p / "test").exists():
++            p = p / "test"
++        if not (p / "4x6.pcf").exists():
++            raise RuntimeError("No 4x6.pcf available.")
+         else:
+-            self._fonts.append(p / '4x6.pcf')
+-        if not (p / '8x16.pcf').exists():
+-            raise RuntimeError('No 8x16.pcf available.')
++            self._fonts.append(p / "4x6.pcf")
++        if not (p / "8x16.pcf").exists():
++            raise RuntimeError("No 8x16.pcf available.")
+         else:
+-            self._fonts.append(p / '8x16.pcf')
++            self._fonts.append(p / "8x16.pcf")
+ 
+     @property
+     def fonts(self):
+         return self._fonts
+ 
++
+ class FcBrokenFont:
+-    def __init__(self, srcdir='.'):
++    def __init__(self, srcdir="."):
+         fctest = FcTest()
+         p = Path(srcdir)
+-        if (p / 'test').exists():
+-            p = p / 'test'
+-        candidates = [ "broken_cff_major.otf", "no_family_name.ttf", "no_family_name_serif.ttf" ]
++        if (p / "test").exists():
++            p = p / "test"
++        candidates = [
++            "broken_cff_major.otf",
++            "no_family_name.ttf",
++            "no_family_name_serif.ttf",
++        ]
+         self._fonts = []
+         for f in candidates:
+             font_path = p / f
+@@ -357,20 +411,26 @@ class FcBrokenFont:
+     def fonts(self):
+         return self._fonts
+ 
++
+ class FcExternalTestFont:
+ 
+     def __init__(self):
+         fctest = FcTest()
+-        self._fonts = [str(fn) for fn in (Path(fctest.builddir) / "testfonts").glob('**/*.ttf')]
++        self._fonts = [
++            str(fn) for fn in (Path(fctest.builddir) / "testfonts").glob("**/*.ttf")
++        ]
+         if not self._fonts:
+-            raise RuntimeError("No external test fonts available. Run with -Dtests-external-fonts=enabled to fetch them.")
++            raise RuntimeError(
++                "No external test fonts available. "
++                "External fonts are enabled but fetch-testfonts.py did not download any fonts."
++            )
+ 
+     @property
+     def fonts(self):
+         return self._fonts
+ 
+ 
+-if __name__ == '__main__':
++if __name__ == "__main__":
+     f = FcTest()
+     print(f.fontdir.name)
+     print(f.cachedir.name)
+diff --git a/test/meson.build b/test/meson.build
+index 83840504..f89eaa68 100644
+--- a/test/meson.build
++++ b/test/meson.build
+@@ -100,7 +100,7 @@ else
+ endif
+ 
+ if pytest.found()
+-  pytest_args = ['--tap', '--assert=plain']
++  pytest_args = ['--tap', '-vv', '--assert=plain']
+   if not get_option('tests-external-fonts').allowed()
+     pytest_args += ['-m', 'not network']
+   endif
+diff --git a/test/test_fontations_ft_query.py b/test/test_fontations_ft_query.py
+index 45739a72..11d1a834 100644
+--- a/test/test_fontations_ft_query.py
++++ b/test/test_fontations_ft_query.py
+@@ -2,7 +2,7 @@
+ # Copyright (C) 2025 Google LLC.
+ # SPDX-License-Identifier: HPND
+ 
+-from fctest import FcTest, FcExternalTestFont, FcBrokenFont
++from fctest import FcTest, FcExternalTestFont, FcBrokenFont, pytest_generate_tests
+ from pathlib import Path
+ from enum import Enum
+ import pytest
+@@ -47,12 +47,10 @@ def compare_fontations_freetype(fctest, font_file, ret_code_behavior: RetCodeBeh
+     ), f"FreeType and Fontations fc-query result must match. Fontations: {result_fontations}, FreeType: {result_freetype}"
+ 
+ 
+-@pytest.mark.network
+-@pytest.mark.parametrize("font_file", FcExternalTestFont().fonts)
+-def test_fontations_freetype_fcquery_equal(fctest, font_file):
+-    fctest.logger.info(f'Testing with: {font_file}')
++def test_fontations_freetype_fcquery_equal(fctest, parametrized_external_font):
++    fctest.logger.info(f'Testing with: {parametrized_external_font}')
+     compare_fontations_freetype(
+-        fctest, font_file, RetCodeBehavior.MUST_BE_ZERO)
++        fctest, parametrized_external_font, RetCodeBehavior.MUST_BE_ZERO)
+ 
+ 
+ @pytest.mark.parametrize("font_file", FcBrokenFont().fonts)
+diff --git a/test/test_genconf.py b/test/test_genconf.py
+index 8268c8c8..e610ec05 100644
+--- a/test/test_genconf.py
++++ b/test/test_genconf.py
+@@ -1,7 +1,7 @@
+ # Copyright (C) 2025 fontconfig Authors
+ # SPDX-License-Identifier: HPND
+ 
+-from fctest import FcTest, FcExternalTestFont, FcTestFont
++from fctest import FcTest, FcExternalTestFont, FcTestFont, pytest_generate_tests
+ from pathlib import Path
+ from tempfile import NamedTemporaryFile
+ import pytest
+@@ -17,13 +17,8 @@ def fcfont():
+     return FcTestFont()
+ 
+ 
+-@pytest.mark.network
+-@pytest.mark.parametrize("font_file", FcExternalTestFont().fonts)
+-def test_genconf(fctest, fcfont, font_file):
+-    font_path = Path(font_file)
+-
+-    if not font_path.exists():
+-        pytest.skip(f"Font file not found: {font_file}")
++def test_genconf(fctest, fcfont, parametrized_external_font):
++    font_path = Path(parametrized_external_font)
+ 
+     extraconffile = NamedTemporaryFile(prefix='fontconfig.',
+                                        suffix='.extra.conf',
+@@ -32,10 +27,10 @@ def test_genconf(fctest, fcfont, font_file):
+     fctest._extra.append(f'<include ignore_missing="yes">{fctest.convert_path(extraconffile.name)}</include>')
+     fctest.setup()
+     fctest.install_font(fcfont.fonts, '.')
+-    fctest.install_font(font_file, '.')
++    fctest.install_font(parametrized_external_font, '.')
+ 
+     f = g = fmt = None
+-    for ret, stdout, stderr in fctest.run_query(['-f', '%{family}:%{genericfamily}\n', font_file]):
++    for ret, stdout, stderr in fctest.run_query(['-f', '%{family}:%{genericfamily}\n', parametrized_external_font]):
+         assert ret == 0, stderr
+         for l in stdout.strip().splitlines():
+             f, g = l.split(':')
+@@ -47,7 +42,7 @@ def test_genconf(fctest, fcfont, font_file):
+             else:
+                 fmt = f':genericfamily={g}'
+ 
+-    for ret, stdout, stderr in fctest.run_genconf(['-g', g, '-f', f, '-o', extraconffile.name, font_file]):
++    for ret, stdout, stderr in fctest.run_genconf(['-g', g, '-f', f, '-o', extraconffile.name, parametrized_external_font]):
+         assert ret == 0, stderr
+ 
+     for ret, stdout, stderr in fctest.run_match(['-f', '%{file}\n', fmt]):
+@@ -55,7 +50,7 @@ def test_genconf(fctest, fcfont, font_file):
+         if Path(stdout.strip().splitlines()[0]).name != font_path.name:
+             assert ret == 0, stderr
+ 
+-    for ret, stdout, stderr in fctest.run_scan(['-f', '%{genericfamily}\n', font_file]):
++    for ret, stdout, stderr in fctest.run_scan(['-f', '%{genericfamily}\n', parametrized_external_font]):
+         assert ret == 0, stderr
+         for l in stdout.strip().splitlines():
+             assert g == l, stdout
+-- 
+GitLab
+
+
+From 4026ca429d7b086f9f68fcacaf0020e6b805fbfb Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Wed, 10 Jun 2026 13:54:40 +0900
+Subject: [PATCH 4/4] test: Fix a fail on subproject build
+
+---
+ test/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/meson.build b/test/meson.build
+index f89eaa68..72e35d24 100644
+--- a/test/meson.build
++++ b/test/meson.build
+@@ -6,7 +6,7 @@ if get_option('tests-external-fonts').allowed()
+       python3,
+       join_paths(meson.project_source_root(), 'build-aux', 'fetch-testfonts.py'),
+       '--target-dir',
+-      '@BUILD_ROOT@/testfonts',
++      '@0@/testfonts'.format(meson.project_build_root()),
+       '--try-symlink',
+     ],
+     build_by_default: false,
+-- 
+GitLab
+

--- a/packages/f/fontconfig/files/531.patch
+++ b/packages/f/fontconfig/files/531.patch
@@ -1,0 +1,63 @@
+From 97ad8cd89b47213fe211d7a08082a313f6393ff6 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Wed, 10 Jun 2026 22:06:16 +0900
+Subject: [PATCH 1/2] ci: set SOURCE_DATE_EPOCH to the build script
+
+---
+ .gitlab-ci/build.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/.gitlab-ci/build.py b/.gitlab-ci/build.py
+index 17692c39..3652bf1c 100755
+--- a/.gitlab-ci/build.py
++++ b/.gitlab-ci/build.py
+@@ -110,6 +110,7 @@ class Build:
+         os.environ.setdefault("CI_MERGE_REQUEST_PROJECT_URL", "https://gitlab.freedesktop.org/fontconfig/fontconfig")
+         os.environ.setdefault("CI_COMMIT_REF_NAME", "main")
+         os.environ.setdefault("BUILDLOG", str(pathlib.Path(os.environ["BUILDDIR"]) / "fc-build.log"))
++        os.environ.setdefault("SOURCE_DATE_EPOCH", str(int(time.time())))
+ 
+         self.builddir = pathlib.Path(os.environ["BUILDDIR"])
+         self.prefix = pathlib.Path(os.environ["PREFIX"])
+-- 
+GitLab
+
+
+From c6c94e13b4a0b0aaa15823ea1093ee0eb17a5944 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Wed, 10 Jun 2026 22:39:31 +0900
+Subject: [PATCH 2/2] test: unset SOURCE_DATE_EPOCH for some test cases
+
+They depend on the timestamp change.
+We can't fix the timestamp with SOURCE_DATE_EPOCH for them.
+---
+ test/test_basic.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/test/test_basic.py b/test/test_basic.py
+index ebb2c3d8..30ab3080 100644
+--- a/test/test_basic.py
++++ b/test/test_basic.py
+@@ -163,6 +163,8 @@ def test_with_complicated_dir_structure(fctest, fcfont):
+ 
+ 
+ def test_subdir_with_out_of_date_cache(fctest, fcfont):
++    # This test case depends on the timestamp. Do not fix with SOURCE_DATE_EPOCH
++    fctest.env.pop('SOURCE_DATE_EPOCH')
+     fctest.setup()
+     fctest.install_font([], 'a')
+     for ret, stdout, stderr in fctest.run_cache([str(Path(fctest.fontdir.name) / 'a')]):
+@@ -188,7 +190,9 @@ def test_subdir_with_out_of_date_cache(fctest, fcfont):
+         assert out == out_expected
+ 
+ 
+-def test_new_file_with_out_of_date_cache(fctest, fcfont):
++def test_new_file_with_out_of_date_cache(monkeypatch, fctest, fcfont):
++    # This test case depends on the timestamp. Do not fix with SOURCE_DATE_EPOCH
++    fctest.env.pop('SOURCE_DATE_EPOCH')
+     fctest.setup()
+     fctest.install_font(fcfont.fonts[0], '.')
+     for ret, stdout, stderr in fctest.run_cache([fctest.fontdir.name]):
+-- 
+GitLab
+

--- a/packages/f/fontconfig/files/535.patch
+++ b/packages/f/fontconfig/files/535.patch
@@ -1,0 +1,2313 @@
+From 6c7531850ec1d1ebb5e51642e860028b346ba7e0 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Fri, 26 Jun 2026 17:23:40 +0900
+Subject: [PATCH 1/3] test: Fix a KeyError
+
+---
+ test/test_basic.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/test/test_basic.py b/test/test_basic.py
+index 30ab3080..1eff37de 100644
+--- a/test/test_basic.py
++++ b/test/test_basic.py
+@@ -164,7 +164,7 @@ def test_with_complicated_dir_structure(fctest, fcfont):
+ 
+ def test_subdir_with_out_of_date_cache(fctest, fcfont):
+     # This test case depends on the timestamp. Do not fix with SOURCE_DATE_EPOCH
+-    fctest.env.pop('SOURCE_DATE_EPOCH')
++    fctest.env.pop('SOURCE_DATE_EPOCH', None)
+     fctest.setup()
+     fctest.install_font([], 'a')
+     for ret, stdout, stderr in fctest.run_cache([str(Path(fctest.fontdir.name) / 'a')]):
+@@ -192,7 +192,7 @@ def test_subdir_with_out_of_date_cache(fctest, fcfont):
+ 
+ def test_new_file_with_out_of_date_cache(monkeypatch, fctest, fcfont):
+     # This test case depends on the timestamp. Do not fix with SOURCE_DATE_EPOCH
+-    fctest.env.pop('SOURCE_DATE_EPOCH')
++    fctest.env.pop('SOURCE_DATE_EPOCH', None)
+     fctest.setup()
+     fctest.install_font(fcfont.fonts[0], '.')
+     for ret, stdout, stderr in fctest.run_cache([fctest.fontdir.name]):
+-- 
+GitLab
+
+
+From 4471940fabe675d7500246b8f584754c63257840 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Mon, 29 Jun 2026 15:15:29 +0900
+Subject: [PATCH 2/3] Add a hash table for fonts to generate expected
+ genericfamily
+
+This aims to improve a situation where genericfamily object in cache
+is set as unknown without any config files.
+
+Fixes https://gitlab.freedesktop.org/fontconfig/fontconfig/-/work_items/532
+
+Changelog: fixed
+---
+ .gitignore                           |  30 ++-
+ Makefile.am                          |  10 +-
+ configure.ac                         |   1 +
+ fc-fontations/meson.build            |   4 +-
+ fc-fontations/names.rs               | 108 ++++++---
+ fc-genericfamily/Makefile.am         |  37 ++++
+ fc-genericfamily/cursive.txt         |  17 ++
+ fc-genericfamily/emoji.txt           |  13 ++
+ fc-genericfamily/fangsong.txt        |   3 +
+ fc-genericfamily/fantasy.txt         |  76 +++++++
+ fc-genericfamily/fc-genericfamily.py | 189 ++++++++++++++++
+ fc-genericfamily/math.txt            |   9 +
+ fc-genericfamily/meson.build         |  32 +++
+ fc-genericfamily/monospace.txt       | 138 ++++++++++++
+ fc-genericfamily/sans-serif.txt      | 314 +++++++++++++++++++++++++++
+ fc-genericfamily/serif.txt           | 240 ++++++++++++++++++++
+ fc-genericfamily/system-ui.txt       |  39 ++++
+ fc-genericfamily/ui-monospace.txt    |   0
+ fc-genericfamily/ui-rounded.txt      |   0
+ fc-genericfamily/ui-sans-serif.txt   |   0
+ fc-genericfamily/ui-serif.txt        |   0
+ meson.build                          |   1 +
+ src/Makefile.am                      |   4 +-
+ src/fcconffile.c                     | 181 +++++++++------
+ src/fcfreetype.c                     |  61 ++++--
+ src/fcgenericalias.c                 |  40 ++++
+ src/fcint.h                          |   4 +
+ src/meson.build                      |  25 ++-
+ test/test_genconf.py                 |  48 ++--
+ 29 files changed, 1466 insertions(+), 158 deletions(-)
+ create mode 100644 fc-genericfamily/Makefile.am
+ create mode 100644 fc-genericfamily/cursive.txt
+ create mode 100644 fc-genericfamily/emoji.txt
+ create mode 100644 fc-genericfamily/fangsong.txt
+ create mode 100644 fc-genericfamily/fantasy.txt
+ create mode 100755 fc-genericfamily/fc-genericfamily.py
+ create mode 100644 fc-genericfamily/math.txt
+ create mode 100644 fc-genericfamily/meson.build
+ create mode 100644 fc-genericfamily/monospace.txt
+ create mode 100644 fc-genericfamily/sans-serif.txt
+ create mode 100644 fc-genericfamily/serif.txt
+ create mode 100644 fc-genericfamily/system-ui.txt
+ create mode 100644 fc-genericfamily/ui-monospace.txt
+ create mode 100644 fc-genericfamily/ui-rounded.txt
+ create mode 100644 fc-genericfamily/ui-sans-serif.txt
+ create mode 100644 fc-genericfamily/ui-serif.txt
+ create mode 100644 src/fcgenericalias.c
+
+diff --git a/.gitignore b/.gitignore
+index 9d59c21d..38dd3c1b 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -1,6 +1,32 @@
+ *~
+ __pycache__
+-/prefix*
++ABOUT-NLS
++Makefile
++Makefile*in
++aclocal.m4
++compile
++config.guess
++config.h.in
++config.rpath
++config.sub
++configure
++depcomp
++install-sh
++ltmain.sh
++missing
++test-driver
++/autom4te.cache
+ /build*
+-/target*
++/m4/*.m4
++/po*/*.gmo
++/po*/*.pot
++/po*/Makevars.template
++/po*/Rules-quot
++/po*/boldquot.sed
++/po*/en@*.header
++/po*/insert-header.sin
++/po*/quot.sed
++/po*/remove-potcdate.sin
++/prefix*
+ /subprojects/*/
++/target*
+diff --git a/Makefile.am b/Makefile.am
+index fef2d7c0..78faeb0a 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,8 +1,8 @@
+-# 
++#
+ #  fontconfig/Makefile.am
+-# 
++#
+ #  Copyright © 2003 Keith Packard
+-# 
++#
+ #  Permission to use, copy, modify, distribute, and sell this software and its
+ #  documentation for any purpose is hereby granted without fee, provided that
+ #  the above copyright notice appear in all copies and that both that
+@@ -12,7 +12,7 @@
+ #  specific, written prior permission.  The authors make no
+ #  representations about the suitability of this software for any purpose.  It
+ #  is provided "as is" without express or implied warranty.
+-# 
++#
+ #  THE AUTHOR(S) DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+ #  INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+ #  EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+@@ -21,7 +21,7 @@
+ #  TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ #  PERFORMANCE OF THIS SOFTWARE.
+ 
+-SUBDIRS=fontconfig fc-case fc-lang fc-const src \
++SUBDIRS=fontconfig fc-case fc-lang fc-const fc-genericfamily src \
+ 	fc-cache fc-cat fc-conflist fc-list fc-match \
+ 	fc-pattern fc-query fc-scan fc-validate conf.d \
+ 	its po po-conf test
+diff --git a/configure.ac b/configure.ac
+index 851f23f0..9eb68960 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -905,6 +905,7 @@ fc-cat/Makefile
+ fc-conflist/Makefile
+ fc-const/Makefile
+ fc-genconf/Makefile
++fc-genericfamily/Makefile
+ fc-list/Makefile
+ fc-match/Makefile
+ fc-pattern/Makefile
+diff --git a/fc-fontations/meson.build b/fc-fontations/meson.build
+index b420ed08..80e5f904 100644
+--- a/fc-fontations/meson.build
++++ b/fc-fontations/meson.build
+@@ -10,7 +10,7 @@ if (fontations.enabled())
+     include_directories: incbase,
+     args: [
+       '--merge-extern-blocks',
+-      '--allowlist-item=(FcCharSet.*|FC_(SLANT|WEIGHT|WIDTH)_.*|FcFontSet(Add|Create|Destroy).*|FcLangSet(Create|Destroy|Copy|Add|HasLang)|FcWeightFromOpenType.*|FC_SPACING_.*|FC_FAMILY_(UNKNOWN|SANS|SERIF|MONO|EMOJI|MATH))',
++      '--allowlist-item=(FcCharSet.*|FC_(SLANT|WEIGHT|WIDTH)_.*|FcFontSet(Add|Create|Destroy).*|FcLangSet(Create|Destroy|Copy|Add|HasLang)|FcWeightFromOpenType.*|FC_SPACING_.*|FC_FAMILY_.*)',
+       '--raw-line=#![allow(nonstandard_style,unused)]',
+     ],
+     # FC_NO_MT=1 is added here to reduce required headers in bindings generation.
+@@ -24,7 +24,7 @@ if (fontations.enabled())
+     include_directories: incbase,
+     args: [
+       '--merge-extern-blocks',
+-      '--allowlist-item=(FcPattern.*|FcRange.*|FC_.*_OBJECT|FcCharSet.*|FcLangSetFromCharSet)',
++      '--allowlist-item=(FcPattern.*|FcRange.*|FC_.*_OBJECT|FcCharSet.*|FcLangSetFromCharSet|FcGenericAliasGetClassification)',
+       '--blocklist-type=(FcCharSet|FcLangSet)',
+       '--raw-line=#![allow(nonstandard_style,unused)]',
+       '--raw-line=extern crate fontconfig_bindings;',
+diff --git a/fc-fontations/names.rs b/fc-fontations/names.rs
+index 3e9a685d..bec1520e 100644
+--- a/fc-fontations/names.rs
++++ b/fc-fontations/names.rs
+@@ -28,11 +28,12 @@ use skrifa::{string::StringId, MetadataProvider};
+ use fcint_bindings::{
+     FC_FAMILYLANG_OBJECT, FC_FAMILY_OBJECT, FC_FULLNAMELANG_OBJECT, FC_FULLNAME_OBJECT,
+     FC_GENERIC_FAMILY_OBJECT, FC_INVALID_OBJECT, FC_POSTSCRIPT_NAME_OBJECT, FC_STYLELANG_OBJECT,
+-    FC_STYLE_OBJECT,
++    FC_STYLE_OBJECT, FcGenericAliasGetClassification,
+ };
+ use fontconfig_bindings::{
+-    FC_FAMILY_EMOJI, FC_FAMILY_MATH, FC_FAMILY_MONO, FC_FAMILY_SANS, FC_FAMILY_SERIF,
+-    FC_FAMILY_UNKNOWN,
++    FC_FAMILY_CURSIVE, FC_FAMILY_EMOJI, FC_FAMILY_FANGSONG, FC_FAMILY_FANTASY, FC_FAMILY_MATH,
++    FC_FAMILY_MONO, FC_FAMILY_SANS, FC_FAMILY_SERIF, FC_FAMILY_SYSTEM_UI, FC_FAMILY_UI_MONO,
++    FC_FAMILY_UI_ROUNDED, FC_FAMILY_UI_SANS, FC_FAMILY_UI_SERIF, FC_FAMILY_UNKNOWN,
+ };
+ 
+ use crate::{name_records::FcSortedNameRecords, FcPatternBuilder, InstanceMode, PatternElement};
+@@ -166,24 +167,32 @@ fn mangle_full_name_for_named_instance(font: &FontRef, named_instance_id: i32) -
+     CString::new(full_name + &subfam).ok()
+ }
+ 
+-fn get_generic_family(family_name: &CStr) -> i32 {
+-    [
+-        ("mono", FC_FAMILY_MONO),
+-        ("sans", FC_FAMILY_SANS),
+-        ("serif", FC_FAMILY_SERIF),
+-        ("emoji", FC_FAMILY_EMOJI),
+-        ("math", FC_FAMILY_MATH),
+-    ]
+-    .into_iter()
+-    .find_map(|(font_sub_name, generic_family_id)| {
+-        family_name
+-            .to_string_lossy()
+-            .into_owned()
+-            .to_lowercase()
+-            .contains(font_sub_name)
+-            .then_some(generic_family_id)
+-    })
+-    .unwrap_or(FC_FAMILY_UNKNOWN) as i32
++fn get_generic_family(family_name: &CStr) -> u32 {
++    // Try FcGenericAliasGetClassification first
++    let classification = unsafe { FcGenericAliasGetClassification(family_name.as_ptr()) };
++
++    // If it returns UNKNOWN, fall back to substring matching
++    if classification == FC_FAMILY_UNKNOWN {
++        [
++            ("mono", FC_FAMILY_MONO),
++            ("sans", FC_FAMILY_SANS),
++            ("serif", FC_FAMILY_SERIF),
++            ("emoji", FC_FAMILY_EMOJI),
++            ("math", FC_FAMILY_MATH),
++        ]
++        .into_iter()
++        .find_map(|(font_sub_name, generic_family_id)| {
++            family_name
++                .to_string_lossy()
++                .into_owned()
++                .to_lowercase()
++                .contains(font_sub_name)
++                .then_some(1 << (generic_family_id - 1))
++        })
++        .unwrap_or(FC_FAMILY_UNKNOWN)
++    } else {
++        classification
++    }
+ }
+ 
+ pub fn add_names(
+@@ -280,21 +289,50 @@ pub fn add_names(
+     }
+ 
+     // Determine generic family and append.
+-    let generic_family = pattern
+-        .family_names()
+-        .find_map(|family_name| {
+-            let id = get_generic_family(family_name);
+-            if id != FC_FAMILY_UNKNOWN as i32 {
+-                Some(id)
+-            } else {
+-                None
++    // Try each family name until we find one with a classification
++    let mut generic_families: Vec<u32> = Vec::new();
++    for family_name in pattern.family_names() {
++        let classification = get_generic_family(family_name);
++        if classification != FC_FAMILY_UNKNOWN {
++            // Extract each bit from the bitfield
++            for family_type in [
++                FC_FAMILY_SERIF,
++                FC_FAMILY_SANS,
++                FC_FAMILY_MONO,
++                FC_FAMILY_CURSIVE,
++                FC_FAMILY_FANTASY,
++                FC_FAMILY_SYSTEM_UI,
++                FC_FAMILY_UI_SERIF,
++                FC_FAMILY_UI_SANS,
++                FC_FAMILY_UI_MONO,
++                FC_FAMILY_UI_ROUNDED,
++                FC_FAMILY_EMOJI,
++                FC_FAMILY_MATH,
++                FC_FAMILY_FANGSONG,
++            ] {
++                if classification & (1 << (family_type - 1)) != 0 {
++                    generic_families.push(family_type);
++                }
+             }
+-        })
+-        .unwrap_or(FC_FAMILY_UNKNOWN as i32);
+-    pattern.append_element(PatternElement::new(
+-        FC_GENERIC_FAMILY_OBJECT as i32,
+-        generic_family.into(),
+-    ));
++            break;
++        }
++    }
++
++    // If no classification found, add UNKNOWN
++    if generic_families.is_empty() {
++        pattern.append_element(PatternElement::new(
++            FC_GENERIC_FAMILY_OBJECT as i32,
++            (FC_FAMILY_UNKNOWN as i32).into(),
++        ));
++    } else {
++        // Append each generic family classification
++        for family_type in generic_families {
++            pattern.append_element(PatternElement::new(
++                FC_GENERIC_FAMILY_OBJECT as i32,
++                (family_type as i32).into(),
++            ));
++        }
++    }
+ 
+     Ok(())
+ }
+diff --git a/fc-genericfamily/Makefile.am b/fc-genericfamily/Makefile.am
+new file mode 100644
+index 00000000..3b5e1930
+--- /dev/null
++++ b/fc-genericfamily/Makefile.am
+@@ -0,0 +1,37 @@
++noinst_HEADERS=fcgenericfamily.h
++
++NULL =
++LIST_FILES = 			\
++	serif.txt			\
++	sans-serif.txt		\
++	monospace.txt		\
++	cursive.txt			\
++	fantasy.txt			\
++	system-ui.txt		\
++	ui-serif.txt		\
++	ui-sans-serif.txt	\
++	ui-monospace.txt	\
++	ui-rounded.txt		\
++	emoji.txt			\
++	math.txt			\
++	fangsong.txt		\
++	$(NULL)
++
++BUILT_SOURCES =						\
++	fcgenericfamily.gperf			\
++	$(builddir)/fcgenericfamily.h	\
++	$(NULL)
++
++fcgenericfamily.gperf: fc-genericfamily.py $(LIST_FILES) Makefile.am
++	-@$(RM) stamp-fcgenericfamily.gperf
++	@$(MAKE) stamp-fcgenericfamily.gperf
++	@touch -r stamp-fcgenericfamily.gperf $@
++stamp-fcgenericfamily.gperf: Makefile.am fc-genericfamily.py
++	$(AM_V_GEN) $(PYTHON) $(srcdir)/fc-genericfamily.py -d $(srcdir) -o fcgenericfamily.gperf && touch $@
++
++$(builddir)/fcgenericfamily.h: Makefile.am fcgenericfamily.gperf
++	$(AM_V_GEN) $(GPERF) --pic -m 100 fcgenericfamily.gperf > $@.tmp && \
++	mv -f $@.tmp $@ || ( $(RM) $@.tmp && false )
++
++CLEANFILES = stamp-fcgenericfamily.gperf
++MAINTAINERCLEANFILES = fcgenericfamily.h
+diff --git a/fc-genericfamily/cursive.txt b/fc-genericfamily/cursive.txt
+new file mode 100644
+index 00000000..3d696a6a
+--- /dev/null
++++ b/fc-genericfamily/cursive.txt
+@@ -0,0 +1,17 @@
++# Font families for cursive generic family
++Comic Sans MS
++IranNastaliq
++ITC Zapf Chancery Std
++Nafees Nastaleeq
++Zapfino
++UnGungseo
++UnPen
++UnPenheulim
++UnPilgia
++Dancing Script
++Great Vibes
++Écolier Court
++Noto Kufi Arabic
++Noto Nastaliq Urdu
++Petaluma Script
++TeX Gyre Chorus
+diff --git a/fc-genericfamily/emoji.txt b/fc-genericfamily/emoji.txt
+new file mode 100644
+index 00000000..9949faf2
+--- /dev/null
++++ b/fc-genericfamily/emoji.txt
+@@ -0,0 +1,13 @@
++# Font families for emoji generic family
++Android Emoji
++Apple Color Emoji
++Emoji One
++Emoji Two
++EmojiOne Mozilla
++JoyPixels
++Noto Color Emoji
++Noto Emoji
++OpenMoji Black
++OpenMoji Color
++Segoe UI Emoji
++Twitter Color Emoji
+diff --git a/fc-genericfamily/fangsong.txt b/fc-genericfamily/fangsong.txt
+new file mode 100644
+index 00000000..f8e2ced7
+--- /dev/null
++++ b/fc-genericfamily/fangsong.txt
+@@ -0,0 +1,3 @@
++# Font families for fangsong generic family
++Noto Fangsong KSS Rotated
++Noto Fangsong KSS Vertical
+diff --git a/fc-genericfamily/fantasy.txt b/fc-genericfamily/fantasy.txt
+new file mode 100644
+index 00000000..eb7c5c9b
+--- /dev/null
++++ b/fc-genericfamily/fantasy.txt
+@@ -0,0 +1,76 @@
++# Font families for fantasy generic family
++Bauhaus Std
++Cooper Std
++Copperplate Gothic Std
++Fantezi
++Homa
++Impact
++Kamran
++Tabassom
++Akkadian
++Analecta
++Beteckna
++Beteckna Lower Case
++Beteckna Small Caps
++Bola
++Bravura
++CaladingsCLM
++Campania
++Delphine
++Digna's Handwriting
++Domestic Manners
++FontAwesome
++FontAwesome 7 Brands
++FontAwesome 7 Free
++Foundation Icons
++Khmer OS Fasthand
++Khmer OS Freehand
++Khmer OS Metal Chrieng
++Laconic-Shadow
++Leland
++Material Icons
++Perizia
++Petaluma
++PetalumaScript
++SMonohand
++Sniglet
++SteveHand
++Tiza
++ToBeContinued
++UnBom
++UnDinaru
++UnJamoBatang
++UnJamoDotum
++UnJamoNovel
++UnJamoSora
++UnVada
++UnYetgul
++UnifrakturMaguntia
++Widelands
++entypo
++letters laughing
++mnmlicons
++Aegean
++Aegyptus
++Bellota
++GFS Ambrosia
++GFS Baskerville
++GFS Bodoni Classic
++GFS Complutum
++GFS Eustace
++GFS Fleischman
++GFS Garaldus
++GFS Gazis
++GFS Ignacio
++GFS Jackson
++GFS Nicefore
++GFS Olga
++GFS Porson
++GFS Pyrsos
++GFS Solomos
++GFS Theokritos
++Patrick Hand
++Yanone Kaffeesatz
++Agbalumo
++Finale Broadway
++Finale Broadway Text
+diff --git a/fc-genericfamily/fc-genericfamily.py b/fc-genericfamily/fc-genericfamily.py
+new file mode 100755
+index 00000000..fe9887b0
+--- /dev/null
++++ b/fc-genericfamily/fc-genericfamily.py
+@@ -0,0 +1,189 @@
++#!/usr/bin/env python3
++# Copyright (C) 2025 fontconfig Authors
++# SPDX-License-Identifier: HPND
++
++import sys
++import os
++import argparse
++from pathlib import Path
++
++
++# Map from input files to FC_FAMILY_* bit positions
++# Each family can have multiple classifications, represented as bit fields
++FAMILY_FILE_MAP = {
++    "serif.txt": "FC_FAMILY_SERIF",
++    "sans-serif.txt": "FC_FAMILY_SANS",
++    "monospace.txt": "FC_FAMILY_MONO",
++    "cursive.txt": "FC_FAMILY_CURSIVE",
++    "fantasy.txt": "FC_FAMILY_FANTASY",
++    "system-ui.txt": "FC_FAMILY_SYSTEM_UI",
++    "ui-serif.txt": "FC_FAMILY_UI_SERIF",
++    "ui-sans-serif.txt": "FC_FAMILY_UI_SANS",
++    "ui-monospace.txt": "FC_FAMILY_UI_MONO",
++    "ui-rounded.txt": "FC_FAMILY_UI_ROUNDED",
++    "emoji.txt": "FC_FAMILY_EMOJI",
++    "math.txt": "FC_FAMILY_MATH",
++    "fangsong.txt": "FC_FAMILY_FANGSONG",
++}
++
++# FC_FAMILY_* enumeration values (as bit positions)
++FAMILY_ENUM_BITS = {
++    "FC_FAMILY_SERIF": 0,
++    "FC_FAMILY_SANS": 1,
++    "FC_FAMILY_MONO": 2,
++    "FC_FAMILY_CURSIVE": 3,
++    "FC_FAMILY_FANTASY": 4,
++    "FC_FAMILY_SYSTEM_UI": 5,
++    "FC_FAMILY_UI_SERIF": 6,
++    "FC_FAMILY_UI_SANS": 7,
++    "FC_FAMILY_UI_MONO": 8,
++    "FC_FAMILY_UI_ROUNDED": 9,
++    "FC_FAMILY_EMOJI": 10,
++    "FC_FAMILY_MATH": 11,
++    "FC_FAMILY_FANGSONG": 12,
++}
++
++
++def gen_header():
++    return """/* Copyright (C) 2026 fontconfig Authors */
++/* SPDX-License-Identifier: HPND */
++/* This file is auto-generated. Do not edit. */
++
++"""
++
++
++def read_family_file(filepath: Path):
++    """Read family names from a file, one per line, ignoring comments and empty lines."""
++    families = []
++    if filepath.exists():
++        for line in filepath.read_text(encoding="utf-8").splitlines():
++            # Remove inline comments
++            if "#" in line:
++                line = line.split("#", 1)[0]
++
++            line = line.strip().rstrip()
++
++            # Skip empty lines
++            if line:
++                families.append(line.lower())
++
++    return families
++
++
++def collect_family_data(base_dir: Path = Path(".")):
++    """
++    Collect family names from all configured files and build a mapping
++    from family name to classification bit field.
++    """
++    family_map = {}
++
++    for filename, family_enum in FAMILY_FILE_MAP.items():
++        filepath = base_dir / filename
++        families = read_family_file(filepath)
++
++        if not families:
++            continue
++
++        bit_pos = FAMILY_ENUM_BITS.get(family_enum, 0)
++        bit_value = 1 << bit_pos
++
++        for family in families:
++            if family in family_map:
++                # Family can belong to multiple categories (OR the bit fields)
++                family_map[family] |= bit_value
++            else:
++                family_map[family] = bit_value
++
++    return family_map
++
++
++def gen_gperf_code(family_map):
++    """Generate gperf input code for family name classification lookup."""
++    lines = []
++
++    # gperf header
++    lines.append("%{")
++    lines.append("#include <string.h>")
++    lines.append("#include <stdint.h>")
++    lines.append("")
++    lines.append("struct FcGenericFamilyEntry {")
++    lines.append("    int      name;")
++    lines.append("    uint32_t classification;  /* Bit field of FC_FAMILY_* values */")
++    lines.append("};")
++    lines.append("%}")
++    lines.append("")
++
++    # gperf directives
++    lines.append("%struct-type")
++    lines.append("%ignore-case")
++    lines.append("%language=ANSI-C")
++    lines.append("%define slot-name name")
++    lines.append("%define lookup-function-name fc_generic_family_lookup")
++    lines.append("%define hash-function-name fc_generic_family_hash")
++    lines.append("%define string-pool-name FcConstFamilyNamePool")
++    lines.append("%readonly-tables")
++    lines.append("%pic")
++    lines.append("%includes")
++    lines.append("")
++    lines.append("struct FcGenericFamilyEntry;")
++    lines.append("%%")
++
++    # Sort family names for consistent output
++    for family in sorted(family_map.keys()):
++        classification = family_map[family]
++        # Escape special characters in family name if needed
++        escaped_family = family.replace('"', '\\"')
++        lines.append(f'"{escaped_family}", 0x{classification:08x}')
++
++    lines.append("%%")
++    lines.append("")
++
++    return "\n".join(lines)
++
++
++def main():
++    # Ensure stdout uses UTF-8 encoding
++    if sys.stdout.encoding != 'utf-8':
++        sys.stdout.reconfigure(encoding='utf-8')
++
++    parser = argparse.ArgumentParser(
++        description="Generate gperf code for generic font family classification",
++        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
++    )
++    parser.add_argument(
++        "-o",
++        "--output",
++        type=argparse.FileType("w", encoding="utf-8"),
++        default=sys.stdout,
++        help="Output file (default: stdout)",
++    )
++    parser.add_argument(
++        "-d",
++        "--directory",
++        type=Path,
++        default=".",
++        help="Base directory containing family name files",
++    )
++
++    args = parser.parse_args()
++
++    # Collect family data from files
++    family_map = collect_family_data(args.directory)
++
++    if not family_map:
++        print(
++            "Error: No family data found. Make sure family list files exist.",
++            file=sys.stderr,
++        )
++        sys.exit(1)
++
++    # Generate output
++    with args.output:
++        args.output.write(gen_header())
++        args.output.write(gen_gperf_code(family_map))
++
++    return 0
++
++
++if __name__ == "__main__":
++    sys.exit(main())
+diff --git a/fc-genericfamily/math.txt b/fc-genericfamily/math.txt
+new file mode 100644
+index 00000000..257161a2
+--- /dev/null
++++ b/fc-genericfamily/math.txt
+@@ -0,0 +1,9 @@
++# Font families for math generic family
++Asana Math
++Cambria Math
++Latin Modern Math
++Lucida Math
++Minion Math
++STIX Two Math
++XITS Math
++Noto Sans Math
+diff --git a/fc-genericfamily/meson.build b/fc-genericfamily/meson.build
+new file mode 100644
+index 00000000..4435879b
+--- /dev/null
++++ b/fc-genericfamily/meson.build
+@@ -0,0 +1,32 @@
++fcgenericfamily_gperf = custom_target(
++  'fcgenericfamily.gperf',
++  output: 'fcgenericfamily.gperf',
++  input: [
++    'serif.txt',
++    'sans-serif.txt',
++    'monospace.txt',
++    'cursive.txt',
++    'fantasy.txt',
++    'system-ui.txt',
++    'ui-serif.txt',
++    'ui-sans-serif.txt',
++    'ui-monospace.txt',
++    'ui-rounded.txt',
++    'emoji.txt',
++    'math.txt',
++    'fangsong.txt',
++  ],
++  command: [
++    find_program('fc-genericfamily.py'),
++    '-d',
++    '@0@'.format(meson.current_source_dir()),
++    '-o',
++    '@OUTPUT@',
++  ],
++)
++fcgenericfamily_h = custom_target(
++  'fcgenericfamily.h',
++  input: fcgenericfamily_gperf,
++  output: 'fcgenericfamily.h',
++  command: [gperf, '--pic', '-m', '100', '@INPUT@', '--output-file', '@OUTPUT@'],
++)
+diff --git a/fc-genericfamily/monospace.txt b/fc-genericfamily/monospace.txt
+new file mode 100644
+index 00000000..a7ba2d40
+--- /dev/null
++++ b/fc-genericfamily/monospace.txt
+@@ -0,0 +1,138 @@
++# Font families for monospace generic family
++Andale Mono
++AR PL New Sung Mono
++Bitstream Vera Sans Mono
++Consolas
++Courier
++Courier New
++Courier Std
++Cumberland
++Cumberland AMT
++DejaVu Sans Mono
++Fixedsys
++FreeMono
++GF Zemen Unicode
++HanyiSong  # FIXME: serif
++Hapax Berbère  # FIXME: sans-serif
++Hasida
++Inconsolata
++IPAGothic  # FIXME: sans-serif
++IPAMonaGothic  # FIXME: sans-serif
++Liberation Mono
++LKLUG  # FIXME: sans-serif
++Lohit Bengali  # FIXME: sans-serif
++Lohit Devanagari  # FIXME: sans-serif
++Lohit Gujarati  # FIXME: sans-serif
++Lohit Hindi  # FIXME: sans-serif
++Lohit Kannada  # FIXME: sans-serif
++Lohit Kashmiri  # FIXME: sans-serif
++Lohit Konkani  # FIXME: sans-serif
++Lohit Maithili  # FIXME: sans-serif
++Lohit Malayalam  # FIXME: sans-serif
++Lohit Marathi  # FIXME: sans-serif
++Lohit Nepali  # FIXME: sans-serif
++Lohit Odia  # FIXME: sans-serif
++Lohit Punjabi  # FIXME: sans-serif
++Lohit Sindhi  # FIXME: sans-serif
++Lohit Tamil  # FIXME: sans-serif
++Lohit Telugu  # FIXME: sans-serif
++Luxi Mono
++Meera  # FIXME: sans-serif
++MingLiu  # FIXME: serif
++Miriam Mono
++MS Gothic  # FIXME: sans-serif
++NanumGothic  # FIXME: sans-serif
++NanumGothicCoding
++Nimbus Mono
++Nimbus Mono L
++Nimbus Mono PS
++Noto Sans Mono
++Noto Sans Mono CJK KR
++NSimSun  # FIXME: serif
++Terminal
++TlwgMono
++TlwgTypewriter
++TlwgTypist
++TlwgTypo
++UmePlus Gothic  # FIXME: sans-serif
++VL Gothic  # FIXME: sans-serif
++ZYSong18030  # FIXME: serif
++AR PL UKai HK  # FIXME: cursive
++AR PL UKai TW  # FIXME: cursive
++Adwaita Mono
++Anka/Coder
++Anka/Coder Condensed
++Anka/Coder Narrow
++Anonymous Pro
++Arundina Sans Mono
++B612 Mono
++Baekmuk Gulim
++Cascadia Code
++Cascadia Code NF
++Cascadia Code PL
++Cascadia Mono
++Cascadia Mono NF
++Cascadia Mono PL
++Clean
++Console
++Cousine
++Droid Sans Mono
++Fangsong ti  # FIXME: fangsong
++Fira Code
++Fixed
++Geist Mono
++Hack
++IBM 3270
++Inconsolata Bold
++Inconsolata Regular
++Intel One Mono
++Khmer OS Battambang
++Khmer OS Bokor
++Khmer OS Content
++Khmer OS Muol
++Khmer OS Muol Light
++Khmer OS Muol Pali
++Khmer OS Siemreap
++Khmer OS System
++Linux Libertine Mono
++LucidaTypewriter
++Mint Mono
++Mint Mono 35
++MotoyaLCedar
++MotoyaLMaru
++NanumGothic_Coding
++NotCourierSans
++Overpass Mono
++Oxygen Mono
++PT Mono
++Padauk  # FIXME: sans-serif
++ProggySquareTTSZ
++ProggyTinyTTSZ
++Red Hat Mono
++Roboto Mono
++Source Code Pro
++Source Code VF
++Source Han Code JP
++Source Han Mono
++Source Han Mono HC
++Source Han Mono K
++Source Han Mono SC
++Source Han Mono TC
++Source Han Sans CN  # FIXME: sans-serif
++Source Han Sans TW  # FIXME: sans-serif
++Terminus
++Terminus (TTF)
++UnShinmun
++UnTaza
++Vazirmatn
++WenQuanYi Micro Hei Mono
++WenQuanYi Zen Hei Sharp  # FIXME: sans-serif
++Hermit
++JetBrains Mono
++Noto Sans Mono CJK HK
++Noto Sans Mono CJK JP
++Noto Sans Mono CJK SC
++Noto Sans Mono CJK TC
++RIT Meera New  # FIXME: sans-serif
++TeX Gyre Cursor
++Miriam Mono CLM
+diff --git a/fc-genericfamily/sans-serif.txt b/fc-genericfamily/sans-serif.txt
+new file mode 100644
+index 00000000..948fb251
+--- /dev/null
++++ b/fc-genericfamily/sans-serif.txt
+@@ -0,0 +1,314 @@
++# Font families for sans-serif generic family
++Albany
++Albany AMT
++Apple SD Gothic Neo
++Arial
++Arial Unicode
++Arial Unicode MS
++ArmNet Helvetica
++Arshia
++Artsounk
++B Compset
++B Davat
++Bitstream Vera Sans
++BPG Glaho International
++BPG UTF8 M
++Britannic
++Calibri
++Candara
++Century Gothic
++Corbel
++DejaVu Sans
++Elham
++Farnaz
++FreeSans
++Garuda
++GF Zemen Unicode
++Haettenschweiler
++Hapax Berbère
++Helvetica
++Helvetica LT Std
++Hiragino Sans
++Hiragino Sans CNS
++Hiragino Sans GB
++IPAGothic
++IPAMonaGothic
++JG Lao Old Arial
++Kacst-Qr
++KacstQura
++Kerkis
++Khmer OS
++Kochi Gothic
++Koodak
++Liberation Sans
++LKLUG
++Lohit Bengali
++Lohit Devanagari
++Lohit Gujarati
++Lohit Hindi
++Lohit Kannada
++Lohit Kashmiri
++Lohit Konkani
++Lohit Maithili
++Lohit Malayalam
++Lohit Marathi
++Lohit Nepali
++Lohit Odia
++Lohit Punjabi
++Lohit Sindhi
++Lohit Tamil
++Lohit Telugu
++Loma
++Lucida Sans Unicode
++Luxi Sans
++malayalam
++Meera
++MgOpen Modata
++Microsoft JhengHei
++Microsoft YaHei
++MS Gothic
++MS Sans Serif
++Mukti Narrow
++Nachlieli
++NanumGothic
++Nasim
++Nimbus Sans
++Nimbus Sans L
++Noto Sans
++Noto Sans CJK KR
++padmaa
++Pigiarniq
++PingFang HK
++PingFang SC
++PingFang TC
++Raghindi
++Roya
++Sampige
++Saysettha Unicode
++Sazanami Gothic
++Sina
++Tahoma
++Terafik
++Trebuchet MS
++TSCu_Paranar
++Twentieth Century
++UmePlus P Gothic
++Umpush
++Urdu Nastaliq Unicode
++Verdana
++VL Gothic
++Waree
++WenQuanYi Zen Hei
++Yudit Unicode
++ＭＳ ゴシック
++Adwaita Sans
++AharoniCLM
++Anorexia
++Aqui
++Arimo
++Aroania
++Arundina Sans
++B612
++BIZ UDGothic
++BIZ UDPGothic
++Baekmuk Dotum
++BonvenoCF
++BravuraText
++Carlito
++Comfortaa
++Comic Neue
++Comic Neue Angular
++Cure
++D-DIN
++D-DIN Condensed
++D-DIN Exp
++Drift
++Droid Arabic Kufi
++Droid Sans
++Droid Sans Armenian
++Droid Sans Devanagari
++Droid Sans Ethiopic
++Droid Sans Fallback
++Droid Sans Georgian
++Droid Sans Hebrew
++Droid Sans Japanese
++Droid Sans Tamil
++Droid Sans Thai
++Dustismo
++Edges
++Ektype Baloo 2
++Ektype Baloo Bhai 2
++Ektype Baloo Bhaina 2
++Ektype Baloo Chettan 2
++Ektype Baloo Da 2
++Ektype Baloo Paaji 2
++Ektype Baloo Tamma 2
++Ektype Baloo Tammudu 2
++Ektype Baloo Thambi 2
++ElliniaCLM
++Fkp
++Geist
++Gelly
++Glisp
++IPAPGothic
++IPAexGothic
++IPAexゴシック
++Infofont
++Infofont Z
++Inter
++Inter Display
++Inter Variable
++KacstBook
++KacstDigital
++KacstFarsi
++KacstLetter
++KacstOffice
++KacstOne
++KacstPoster
++KacstQurn
++KacstScreen
++KacstTitle
++KacstTitleL
++Kates
++Keter YG
++Keyfont V2
++Laconic
++Lato
++League Gothic
++Leland Text
++Liberation Sans Narrow
++Lime
++Linux Biolinum
++Lohit Assamese
++Madan
++Manchu2005
++Mingzat
++Mints Mild
++Mints Strong
++Miriam CLM
++Molot
++Montserrat
++Montserrat Alternates
++Montserrat Underline
++Mukti
++Nachlieli CLM
++Navilu
++News Cycle
++Nu
++Nuosu SIL
++Open Sans
++OpenDyslexic
++Overpass
++Oxygen-Sans
++PCfont
++PCfont Z
++Padauk
++Padauk Book
++PakType Naqsh
++PakType Tehreer
++PetalumaText
++Red Hat Display
++Red Hat Text
++Roboto
++Roboto Condensed
++Signfont
++Signfont Z
++Silkscreen
++Silkscreen Expanded
++Simple CLM
++Smoothansi
++Snap
++Source Han Sans CN
++Source Han Sans JP
++Source Han Sans KR
++Source Han Sans TW
++Source Sans 3
++Spark Dot-line Extrathick
++Spark Dot-line Extrathin
++Spark Dot-line Medium
++Spark Dot-line Thick
++Spark Dot-line Thin
++Sparks Bar Extranarrow
++Sparks Bar Extrawide
++Sparks Bar Medium
++Sparks Bar Narrow
++Sparks Bar Wide
++Sparks Dot Extralarge
++Sparks Dot Extrasmall
++Sparks Dot Large
++Sparks Dot Medium
++Sparks Dot Small
++Titillium
++UKIJ Tuz
++Ume Gothic
++Ume Gothic C4
++Ume Gothic C5
++Ume Gothic O5
++Ume Gothic S4
++Ume Gothic S5
++Ume Hy Gothic
++Ume Hy Gothic O5
++Ume P Gothic
++Ume P Gothic C4
++Ume P Gothic C5
++Ume P Gothic O5
++Ume P Gothic S4
++Ume P Gothic S5
++UnDotum
++UnGraphic
++Unikurd Web
++VDRSymbols Sans
++VL PGothic
++Vazirmatn
++Vazirmatn NL
++Vazirmatn RD
++Vazirmatn RD NL
++WenQuanYi Micro Hei
++WenQuanYi Zen Hei Sharp
++YehudaCLM
++alef
++gargi
++kacstPen
++tuffy
++Alegreya Sans
++Andika
++Andika Compact
++Andika New Basic
++Clear Sans
++DarkGarden
++Exo 2
++GFS Decker
++GFS NeoHellenic
++GFS Orpheus Sans
++Gillius ADF
++Harmattan
++Jura
++Lohit Gurmukhi
++M Yuppy GB
++Merriweather Sans
++Muli
++Noto Sans CJK HK
++Noto Sans CJK JP
++Noto Sans CJK SC
++Noto Sans CJK TC
++Nunito
++Oswald
++PT Sans
++Pothana2000
++Public Sans
++RIT Keraleeyam
++RIT Meera New
++RIT TN Joy
++Raleway
++Rubik
++Shimenkan
++Sophia Nubian
++Vemana2000
++Work Sans
++Yudit
++Edwin  # FIXME: serif
++TeX Gyre Adventor
++TeX Gyre Heros
++TeX Gyre Heros Cn
++URW Gothic
++Madan2
+diff --git a/fc-genericfamily/serif.txt b/fc-genericfamily/serif.txt
+new file mode 100644
+index 00000000..f3e866e1
+--- /dev/null
++++ b/fc-genericfamily/serif.txt
+@@ -0,0 +1,240 @@
++# Font families for serif generic family
++AppleMyungjo
++AR PL Mingti2L Big5
++AR PL New Sung
++AR PL ShanHeiSun Uni
++AR PL SungtiL GB
++AR PL Zenkai Uni  # FIXME: cursive
++AR PL ZenKai Uni  # FIXME: cursive
++Artsounk
++B Compset
++B Davat
++Badr
++Bitstream Vera Serif
++BPG UTF8 M
++Cambria
++Code2000
++Code2001
++Constantia
++DejaVu Serif
++Dror
++Elephant
++Ferdosi
++Frank Ruehl
++Frank Ruehl CLM
++FreeSerif
++Garamond
++Georgia
++HanyiSong
++Hapax Berbère
++Hiragino Mincho ProN
++IPAMincho
++IPAMonaMincho
++Jadid
++JG LaoTimes
++Kacst-Qr
++KacstQura
++Khmer OS
++Kinnari
++Kochi Mincho
++Liberation Serif
++LKLUG
++Lohit Bengali  # FIXME: sans-serif
++Lohit Gujarati  # FIXME: sans-serif
++Lohit Hindi  # FIXME: sans-serif
++Lohit Kannada  # FIXME: sans-serif
++Lohit Kashmiri  # FIXME: sans-serif
++Lohit Konkani  # FIXME: sans-serif
++Lohit Maithili  # FIXME: sans-serif
++Lohit Malayalam  # FIXME: sans-serif
++Lohit Marathi  # FIXME: sans-serif
++Lohit Nepali  # FIXME: sans-serif
++Lohit Odia  # FIXME: sans-serif
++Lohit Punjabi  # FIXME: sans-serif
++Lohit Sindhi  # FIXME: sans-serif
++Lohit Tamil  # FIXME: sans-serif
++Lohit Telugu  # FIXME: sans-serif
++Lotoos
++Luxi Serif
++malayalam  # FIXME: sans-serif
++MgOpen Canonica
++Mitra
++MS Mincho
++MS Serif
++Mukti Narrow
++NanumMyeongjo
++Nazli
++Nimbus Roman
++Nimbus Roman No9 L
++Norasi
++Noto Serif
++Noto Serif CJK KR
++padmaa  # FIXME: sans-serif
++Palatino Linotype
++Pigiarniq
++PMingLiu
++Rachana
++Raghindi
++Sampige  # FIXME: sans-serif
++Saysettha Unicode
++Sazanami Mincho
++SimSong
++SimSun
++Songti SC
++Songti TC
++Thorndale
++Thorndale AMT
++Times
++Times New Roman
++Titr
++Urdu Nastaliq Unicode
++WenQuanYi Bitmap Song
++Zar
++ZYSong18030
++ＭＳ 明朝
++AR PL UKai HK  # FIXME: cursive
++AR PL UKai TW  # FIXME: cursive
++AR PL UMing HK
++AR PL UMing TW
++Abyssinica SIL
++Alegreya
++Alexander
++Amiri
++Amiri Quran
++Amiri Quran Colored
++Anaktoria
++AntykwaTorunska
++AntykwaTorunska Light
++AntykwaTorunska Medium
++AntykwaTorunskaCond
++AntykwaTorunskaCond Light
++AntykwaTorunskaCond Medium
++Arundina Serif
++Asana Math
++Asea
++Avdira
++BIZ UDMincho
++BIZ UDPMincho
++Baekmuk Batang
++Caladea
++Crete Round
++David CLM
++Droid Arabic Naskh
++Droid Serif
++DrugulinCLM
++Dustismo  # FIXME: sans-serif
++Edwin
++Gentium Basic
++Gentium Book Basic
++Goudy Bookletter 1911
++Grand Hotel
++Gubbi
++Hadasim CLM
++HanaMin
++Heuristica
++IPAPMincho
++IPAexMincho
++IPAex明朝
++Jomolhari
++KacstArt
++KacstDecorative
++LPfont
++Lateef
++Libertinus
++Linux Libertine
++Mukta Devanagari
++Mukta Mahee
++Mukta Malar
++Mukta Vaani
++Musica
++New Athena Unicode
++Old Standard SFD
++PT Serif
++PT Serif Caption
++Prociono
++Roboto Slab
++Saab
++Scheherazade New
++Shofar
++Source Han Serif CN
++Source Han Serif JP
++Source Han Serif KR
++Source Han Serif TW
++Source Serif 4
++Stam Ashkenaz CLM
++Stam Sefarad CLM
++Symbola
++Tinos
++Ume Mincho
++Ume Mincho S3
++Ume P Mincho
++Ume P Mincho S3
++UnBatang
++WenQuanYi Zen Hei Sharp  # FIXME: sans-serif
++Zilla Slab
++Zilla Slab Highlight
++conakry
++Accanthis ADF Std
++Alkalami
++Annapurna SIL
++Apparatus SIL
++Awami Nastaliq
++Charis SIL
++Charis SIL Compact
++Cormorant
++Dai Banna SIL
++Ethiopic WashRa
++Ezra SIL
++GFS Artemisia
++GFS Bodoni
++GFS Didot
++GFS Didot Classic
++GFS Galatea
++GFS Göschen
++GFS Orpheus
++GFS Orpheus Classic
++GFS Philostratos
++Gentium Plus
++Gentium Plus Compact
++Khmer Mondulkiri
++Literata
++Merriweather
++Namdhinggo SIL
++Noto Serif CJK HK
++Noto Serif CJK JP
++Noto Serif CJK SC
++Noto Serif CJK TC
++RIT Rachana
++STIX
++Spectral
++Tagmukay
++Tai Heritage Pro
++Tribun ADF Std
++Uniol
++C059
++David CLM
++Jomolhari
++Latin Modern Roman
++Latin Modern Roman Caps
++Latin Modern Roman Demi
++Latin Modern Roman Dunhill
++Latin Modern Roman Slanted
++Latin Modern Roman Unslanted
++Nimbus Roman
++P052
++RIT Rachana
++STIX Two Text
++TeX Gyre Bonum
++TeX Gyre Pagella
++TeX Gyre Schola
++TeX Gyre Termes
++URW Bookman
++Z003
++Noto Naskh Arabic
++KacstNaskh
++PakType Naskh Basic
++PakType Naskh Basic Semi Wide
++PakType Naskh Basic Wide
++GB_SS_GB18030
++GB_SS_GB18030_Extended
++GB_SS_GB18030_ExtendedK
+diff --git a/fc-genericfamily/system-ui.txt b/fc-genericfamily/system-ui.txt
+new file mode 100644
+index 00000000..eba2c1ab
+--- /dev/null
++++ b/fc-genericfamily/system-ui.txt
+@@ -0,0 +1,39 @@
++# Font families for system-ui generic family
++Adwaita Sans
++Cantarell
++Khmer UI
++Lao UI
++Leelawadee UI
++Meiryo UI
++Microsoft JhengHei UI
++Microsoft YaHei UI
++MS UI Gothic
++Nirmala UI
++Noto Sans Arabic UI
++Noto Sans Bengali UI
++Noto Sans Devanagari UI
++Noto Sans Gujarati UI
++Noto Sans Gurmukhi UI
++Noto Sans Kannada UI
++Noto Sans Khmer UI
++Noto Sans Lao UI
++Noto Sans Malayalam UI
++Noto Sans Myanmar UI
++Noto Sans Oriya UI
++Noto Sans Sinhala UI
++Noto Sans Tamil UI
++Noto Sans Telugu UI
++Noto Sans Thai UI
++Noto Sans UI
++Segoe UI
++Segoe UI Historic
++Segoe UI Symbol
++Yu Gothic UI
++Khmer OS System
++Ume UI Gothic
++Ume UI Gothic O5
++Vazirmatn RD UI
++Vazirmatn RD UI NL
++Vazirmatn UI
++Vazirmatn UI NL
++Noto Naskh Arabic UI
+diff --git a/fc-genericfamily/ui-monospace.txt b/fc-genericfamily/ui-monospace.txt
+new file mode 100644
+index 00000000..e69de29b
+diff --git a/fc-genericfamily/ui-rounded.txt b/fc-genericfamily/ui-rounded.txt
+new file mode 100644
+index 00000000..e69de29b
+diff --git a/fc-genericfamily/ui-sans-serif.txt b/fc-genericfamily/ui-sans-serif.txt
+new file mode 100644
+index 00000000..e69de29b
+diff --git a/fc-genericfamily/ui-serif.txt b/fc-genericfamily/ui-serif.txt
+new file mode 100644
+index 00000000..e69de29b
+diff --git a/meson.build b/meson.build
+index 26767b5a..3b4ae559 100644
+--- a/meson.build
++++ b/meson.build
+@@ -529,6 +529,7 @@ tools_man_pages = []
+ subdir('fc-case')
+ subdir('fc-lang')
+ subdir('fc-const')
++subdir('fc-genericfamily')
+ subdir('src')
+ 
+ if get_option('fontations').enabled()
+diff --git a/src/Makefile.am b/src/Makefile.am
+index ed685793..57c683f1 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -44,7 +44,7 @@ else
+ install-libtool-import-lib:
+ uninstall-libtool-import-lib:
+ 
+-fontconfig_def_dependency = 
++fontconfig_def_dependency =
+ 
+ endif
+ 
+@@ -76,6 +76,7 @@ AM_CPPFLAGS = 						\
+ 	-I$(top_srcdir)/src				\
+ 	-I$(top_builddir)/fc-lang			\
+ 	-I$(top_builddir)/fc-const			\
++	-I$(top_builddir)/fc-genericfamily	\
+ 	$(FREETYPE_CFLAGS)				\
+ 	$(ICONV_CFLAGS)					\
+ 	$(LIBXML2_CFLAGS)				\
+@@ -143,6 +144,7 @@ libfontconfig_la_SOURCES = \
+ 	fcformat.c \
+ 	fcfreetype.c \
+ 	fcfs.c \
++	fcgenericalias.c \
+ 	fcptrlist.c \
+ 	fchash.c \
+ 	fcinit.c \
+diff --git a/src/fcconffile.c b/src/fcconffile.c
+index bc36acae..9b9295de 100644
+--- a/src/fcconffile.c
++++ b/src/fcconffile.c
+@@ -2,8 +2,6 @@
+ /* SPDX-License-Identifier: HPND */
+ 
+ #include "fcint.h"
+-#include "fontconfig/fontconfig.h"
+-
+ 
+ static FcBool
+ FcConfigFileGenerateGenericAlias (FcConfig  *config,
+@@ -11,20 +9,20 @@ FcConfigFileGenerateGenericAlias (FcConfig  *config,
+                                   FcPattern *font,
+                                   FcStrBuf  *buf)
+ {
+-    FcChar8              *family = NULL, *file = NULL;
+-    const FcChar8        *gf, *s;
+-    int                   generic_family = FC_FAMILY_UNKNOWN;
+-    FcStrSet             *lset = NULL;
+-    FcStrList            *list = NULL;
+-    FcLangSet            *ls = NULL;
+-    FcBool                ret = FcTrue;
++    FcChar8       *family = NULL, *file = NULL;
++    const FcChar8 *gf, *s;
++    int            generic_family = FC_FAMILY_UNKNOWN;
++    FcStrSet      *lset = NULL;
++    FcStrList     *list = NULL;
++    FcLangSet     *ls = NULL;
++    FcBool         ret = FcTrue;
+ 
+     if (FcPatternObjectGetString (font, FC_FILE_OBJECT, 0, &file) != FcResultMatch) {
+ 	fprintf (stderr, "Fontconfig warning: no file object in the font metadata\n");
+ 	return FcFalse;
+     }
+     if (FcPatternObjectGetString (font, FC_FAMILY_OBJECT, 0, &family) != FcResultMatch) {
+-	fprintf(stderr, "Fontconfig warning: %s: no family object in the font metadata\n", file);
++	fprintf (stderr, "Fontconfig warning: %s: no family object in the font metadata\n", file);
+ 	return FcFalse;
+     }
+     FcPatternObjectGetInteger (font, FC_GENERIC_FAMILY_OBJECT, 0, &generic_family);
+@@ -41,17 +39,17 @@ FcConfigFileGenerateGenericAlias (FcConfig  *config,
+     }
+ 
+     if (ls) {
+-        lset = FcLangSetGetLangs (ls);
+-        if (!lset)
++	lset = FcLangSetGetLangs (ls);
++	if (!lset)
+ 	    return FcFalse;
+-        list = FcStrListCreate (lset);
+-        if (!list) {
+-            ret = FcFalse;
+-            goto bail;
++	list = FcStrListCreate (lset);
++	if (!list) {
++	    ret = FcFalse;
++	    goto bail;
+ 	}
+ 	if (lset->num == 0)
+ 	    goto nolang;
+-        while ((s = FcStrListNext (list))) {
++	while ((s = FcStrListNext (list))) {
+ 	    if (!FcStrBufFormat (buf,
+ 	                         "  <match pattern=\"pattern\">\n"
+ 	                         "    <test name=\"lang\" compare=\"contains\">\n"
+@@ -66,9 +64,9 @@ FcConfigFileGenerateGenericAlias (FcConfig  *config,
+ 	                         "  </match>\n\n",
+ 	                         s, gf, family)) {
+ 		ret = FcFalse;
+-	        goto bail;
++		goto bail;
+ 	    }
+-        }
++	}
+ 	if (!FcStrBufFormat (buf,
+ 	                     "  <alias>\n"
+ 	                     "    <family>%s</family>\n"
+@@ -77,7 +75,7 @@ FcConfigFileGenerateGenericAlias (FcConfig  *config,
+ 	                     family, gf)) {
+ 	    ret = FcFalse;
+ 	    goto bail;
+-        }
++	}
+     } else {
+     nolang:
+ 	if (!FcStrBufFormat (buf,
+@@ -96,64 +94,112 @@ FcConfigFileGenerateGenericAlias (FcConfig  *config,
+ 	                     gf, family, family, gf)) {
+ 	    ret = FcFalse;
+ 	    goto bail;
+-        }
++	}
+     }
+- bail:
++bail:
+     if (list)
+-	FcStrListDone(list);
++	FcStrListDone (list);
+     if (lset)
+ 	FcStrSetDestroy (lset);
+ 
+     return ret;
+ }
+ 
++static int
++_generate_generic_family_for_loop (const FcChar8 *file,
++                                   FcValueListPtr l,
++                                   FcStrBuf      *buf)
++{
++    int ret = 0;
++
++    if (l->next) {
++	if (!FcStrBufString (buf, (const FcChar8 *)"    <edit name=\"genericfamily\" mode=\"delete_all\"/>\n"
++	                                           "<edit name=\"genericfamily\" mode=\"append\">\n"))
++	    return -1;
++    } else {
++	if (!FcStrBufString (buf, (const FcChar8 *)"    <edit name=\"genericfamily\" mode=\"assign_replace\">\n"))
++	    return -1;
++    }
++    for (; l; l = FcValueListNext (l)) {
++	uint32_t       vi;
++	const FcChar8 *gf;
++
++	if (l->value.type == FcTypeDouble) {
++	    vi = (uint32_t)l->value.u.d;
++	} else if (l->value.type == FcTypeInteger) {
++	    vi = (uint32_t)l->value.u.i;
++	} else {
++	unknown_gf:
++	    fprintf (stderr, "Fontconfig warning: %s: Unknown generic family: ", file);
++	    FcValuePrintFile (stderr, l->value);
++	    fprintf (stderr, "\n");
++	    continue;
++	}
++	gf = FcNameGetConstantNameFromObject (FC_GENERIC_FAMILY_OBJECT, vi);
++	if (!gf) {
++	    goto unknown_gf;
++	}
++	if (!FcStrBufFormat (buf, "      <const>%s</const>\n", gf)) {
++	    return -1;
++	}
++	ret++;
++    }
++
++    return ret;
++}
++
+ static FcBool
+ FcConfigFileGenerateGenericFamily (FcConfig  *config,
+                                    FcPattern *pat,
+                                    FcPattern *font,
+                                    FcStrBuf  *buf)
+ {
+-    FcChar8              *family = NULL, *file = NULL;
+-    const FcChar8        *gf;
+-    int                   generic_family = FC_FAMILY_UNKNOWN;
+-    FcBool                ret = FcTrue;
++    FcChar8      *family = NULL, *file = NULL;
++    FcPatternIter iter;
+ 
+     if (FcPatternObjectGetString (font, FC_FILE_OBJECT, 0, &file) != FcResultMatch) {
+ 	fprintf (stderr, "Fontconfig warning: no file object in the font metadata\n");
+ 	return FcFalse;
+     }
+     if (FcPatternObjectGetString (font, FC_FAMILY_OBJECT, 0, &family) != FcResultMatch) {
+-	fprintf(stderr, "Fontconfig warning: %s: no family object in the font metadata\n", file);
++	fprintf (stderr, "Fontconfig warning: %s: no family object in the font metadata\n", file);
+ 	return FcFalse;
+     }
+-    FcPatternObjectGetInteger (font, FC_GENERIC_FAMILY_OBJECT, 0, &generic_family);
+-    if (generic_family == FC_FAMILY_UNKNOWN) {
+-	/* fallback to the value that is given by users */
+-	FcPatternObjectGetInteger (pat, FC_GENERIC_FAMILY_OBJECT, 0, &generic_family);
+-    }
+-    gf = FcNameGetConstantNameFromObject (FC_GENERIC_FAMILY_OBJECT,
+-                                          generic_family);
+-    if (!gf) {
+-	fprintf (stderr, "Fontconfig warning: %s: Unable to determine generic family from either of font nor pattern\n", file);
++    if (!FcStrBufFormat (buf,
++                         "  <match target=\"scan\">\n"
++                         "    <test name=\"family\">\n"
++                         "      <string>%s</string>\n"
++                         "    </test>\n",
++                         family)) {
+ 	return FcFalse;
+     }
++    FcPatternIterStart (pat, &iter);
++    if (FcPatternFindObjectIter (pat, &iter, FC_GENERIC_FAMILY_OBJECT)) {
++	int ret;
+ 
+-    if (!FcStrBufFormat (buf,
+-	                 "  <match target=\"scan\">\n"
+-	                 "    <test name=\"family\">\n"
+-	                 "      <string>%s</string>\n"
+-	                 "    </test>\n"
+-	                 "    <edit name=\"genericfamily\" mode=\"assign_replace\">\n"
+-	                 "      <const>%s</const>\n"
+-	                 "    </edit>\n"
+-	                 "  </match>\n",
+-	                 family, gf)) {
+-	ret = FcFalse;
+-	goto bail;
++	/* Use given values by users if any */
++	ret = _generate_generic_family_for_loop (file, FcPatternIterGetValues (pat, &iter), buf);
++	if (ret < 0)
++	    return FcFalse;
++	if (ret == 0)
++	    goto fallback;
++    } else {
++    fallback:
++	FcPatternIterStart (font, &iter);
++	if (FcPatternFindObjectIter (font, &iter, FC_GENERIC_FAMILY_OBJECT)) {
++	    if (!_generate_generic_family_for_loop (file, FcPatternIterGetValues (font, &iter), buf))
++		return FcFalse;
++	} else {
++	    fprintf (stderr, "Fontconfig warning: %s: Unable to determine generic family from either of font nor pattern\n", file);
++	    return FcFalse;
++	}
+     }
+- bail:
++    if (!FcStrBufString (buf,
++                         (const FcChar8 *)"    </edit>\n"
++                                          "  </match>\n"))
++	return FcFalse;
+ 
+-    return ret;
++    return FcTrue;
+ }
+ 
+ FcChar8 *
+@@ -161,33 +207,34 @@ FcConfigFileGenerate (FcConfig      *config,
+                       FcPattern     *pat,
+                       const FcChar8 *font_path)
+ {
+-    FcFontSet   *fs = NULL;
+-    int          i;
+-    FcStrBuf     buf;
++    FcFontSet *fs = NULL;
++    int        i;
++    FcStrBuf   buf;
+ 
+     FcStrBufInit (&buf, NULL, 0);
+     fs = FcFontSetCreate();
+ 
+     if (!FcFileIsDir (font_path)) {
+-        FcFileScan(fs, NULL, NULL, NULL, font_path, FcTrue);
++	FcFileScan (fs, NULL, NULL, NULL, font_path, FcTrue);
+     } else {
+-        FcStrSet *dirs = FcStrSetCreate();
+-        FcStrList *dirlist = FcStrListCreate (dirs);
++	FcStrSet  *dirs = FcStrSetCreate();
++	FcStrList *dirlist = FcStrListCreate (dirs);
+ 
+-        do {
++	do {
+ 	    FcDirScan (fs, dirs, NULL, NULL, font_path, FcTrue);
+-        } while ((font_path = FcStrListNext (dirlist)));
++	} while ((font_path = FcStrListNext (dirlist)));
+ 
+-        FcStrListDone (dirlist);
+-        FcStrSetDestroy (dirs);
++	FcStrListDone (dirlist);
++	FcStrSetDestroy (dirs);
+     }
+     if (fs->nfont > 0) {
+ 	FcHashTable *record = NULL;
+ 
+-        FcStrBufString (&buf,
+-                        (const FcChar8 *)"<?xml version=\"1.0\"?>\n"
+-	                                 "<!DOCTYPE fontconfig SYSTEM \"urn:fontconfig:fonts.dtd\">\n"
+-                                         "<fontconfig>\n");
++	FcStrBufString (&buf,
++	                (const FcChar8 *)
++	                    "<?xml version=\"1.0\"?>\n"
++	                    "<!DOCTYPE fontconfig SYSTEM \"urn:fontconfig:fonts.dtd\">\n"
++	                    "<fontconfig>\n");
+ 
+ 	record = FcHashTableCreate ((FcHashFunc)FcStrHashIgnoreBlanksAndCase,
+ 	                            (FcCompareFunc)FcStrCmpIgnoreBlanksAndCase,
+@@ -223,9 +270,9 @@ FcConfigFileGenerate (FcConfig      *config,
+ 	}
+ 	FcHashTableDestroy (record);
+ 
+-        FcStrBufString (&buf, (const FcChar8 *)"</fontconfig>\n");
++	FcStrBufString (&buf, (const FcChar8 *)"</fontconfig>\n");
+     }
+- bail:
++bail:
+     FcFontSetDestroy (fs);
+ 
+     return FcStrBufDone (&buf);
+diff --git a/src/fcfreetype.c b/src/fcfreetype.c
+index bf5ff6d3..ccf4a96c 100644
+--- a/src/fcfreetype.c
++++ b/src/fcfreetype.c
+@@ -1511,9 +1511,9 @@ FcFreeTypeQueryFaceInternal (const FT_Face   face,
+ 		    memmove (utf8, pp, len + 1);
+ 		    pp = utf8 + len;
+ 		    while (pp > utf8 &&
+-			   (*(pp - 1) == ' ' ||
+-			    *(pp - 1) == '\r' ||
+-			    *(pp - 1) == '\n'))
++		           (*(pp - 1) == ' ' ||
++		            *(pp - 1) == '\r' ||
++		            *(pp - 1) == '\n'))
+ 			pp--;
+ 		    *pp = 0;
+ 
+@@ -2081,37 +2081,52 @@ FcFreeTypeQueryFaceInternal (const FT_Face   face,
+ 	    goto bail2;
+ 
+     {
+-	FcPatternElt *elt;
++	FcPatternElt  *elt;
+ 	FcValueListPtr l;
+-	int generic_family = FC_FAMILY_UNKNOWN;
++	int            generic_family = FC_FAMILY_UNKNOWN;
+ 
+ 	elt = FcPatternObjectFindElt (pat, FC_FAMILY_OBJECT);
+ 	if (elt) {
++	    uint32_t memory = 0;
+ 	    for (l = FcPatternEltValues (elt); l; l = FcValueListNext (l)) {
+ 		FcValue v = FcValueCanonicalize (&l->value);
+ 
+ 		if (v.type == FcTypeString) {
+-		    if (FcStrStrIgnoreCase (v.u.s, (FcChar8 *)"mono")) {
+-			generic_family = FC_FAMILY_MONO;
+-			break;
+-		    } else if (FcStrStrIgnoreCase (v.u.s, (FcChar8 *)"sans")) {
+-			generic_family = FC_FAMILY_SANS;
+-			break;
+-		    } else if (FcStrStrIgnoreCase (v.u.s, (FcChar8 *)"serif")) {
+-			generic_family = FC_FAMILY_SERIF;
+-			break;
+-		    } else if (FcStrStrIgnoreCase (v.u.s, (FcChar8 *)"emoji")) {
+-			generic_family = FC_FAMILY_EMOJI;
+-			break;
+-		    } else if (FcStrStrIgnoreCase (v.u.s, (FcChar8 *)"math")) {
+-			generic_family = FC_FAMILY_MATH;
+-			break;
++		    uint32_t field = FcGenericAliasGetClassification ((const char *)v.u.s);
++
++		    if (field != 0) {
++			if ((memory | field) != memory) {
++			    for (int b = 0; b < 15; b++) {
++				if (((memory ^ field) & (1 << b)) != 0) {
++				    FcPatternObjectAddInteger (pat, FC_GENERIC_FAMILY_OBJECT, b + 1);
++				}
++			    }
++			    memory |= field;
++			}
++			goto skip_generic_family;
++		    } else {
++			if (FcStrStrIgnoreCase (v.u.s, (FcChar8 *)"mono")) {
++			    generic_family = FC_FAMILY_MONO;
++			    break;
++			} else if (FcStrStrIgnoreCase (v.u.s, (FcChar8 *)"sans")) {
++			    generic_family = FC_FAMILY_SANS;
++			    break;
++			} else if (FcStrStrIgnoreCase (v.u.s, (FcChar8 *)"serif")) {
++			    generic_family = FC_FAMILY_SERIF;
++			    break;
++			} else if (FcStrStrIgnoreCase (v.u.s, (FcChar8 *)"emoji")) {
++			    generic_family = FC_FAMILY_EMOJI;
++			    break;
++			} else if (FcStrStrIgnoreCase (v.u.s, (FcChar8 *)"math")) {
++			    generic_family = FC_FAMILY_MATH;
++			    break;
++			}
+ 		    }
+ 		}
+ 	    }
+ 	}
+-
+-	FcPatternObjectAddInteger(pat, FC_GENERIC_FAMILY_OBJECT, generic_family);
++	FcPatternObjectAddInteger (pat, FC_GENERIC_FAMILY_OBJECT, generic_family);
++    skip_generic_family:;
+     }
+ 
+     /*
+@@ -2707,7 +2722,7 @@ FcFontCapabilities (FT_Face face)
+ 	goto bail;
+ 
+     maxsize = (((FT_ULong)gpos_count + (FT_ULong)gsub_count) * OTLAYOUT_LEN +
+-               (issilgraphitefont ? strlen(fcSilfCapability) + 1: 0));
++               (issilgraphitefont ? strlen (fcSilfCapability) + 1 : 0));
+     complex_ = malloc (sizeof (FcChar8) * maxsize);
+     if (!complex_)
+ 	goto bail;
+diff --git a/src/fcgenericalias.c b/src/fcgenericalias.c
+new file mode 100644
+index 00000000..fb07dcad
+--- /dev/null
++++ b/src/fcgenericalias.c
+@@ -0,0 +1,40 @@
++/* Copyright (C) 2026 fontconfig Authors */
++/* SPDX-License-Identifier: HPND */
++
++#include "fcint.h"
++
++#include <stdint.h>
++
++static unsigned int
++fc_generic_family_hash (register const char *str, register FC_GPERF_SIZE_T len);
++
++static const struct FcGenericFamilyEntry *
++fc_generic_family_lookup (register const char *str, register FC_GPERF_SIZE_T len);
++
++#define GPERF_DOWNCASE    1
++#define GPERF_CASE_STRCMP 1
++static int
++gperf_case_strcmp (register const char *s1, register const char *s2)
++{
++    return FcStrCmpIgnoreBlanksAndCase ((const FcChar8 *)s1, (const FcChar8 *)s2);
++}
++
++#include "fcgenericfamily.h"
++
++uint32_t
++FcGenericAliasGetClassification (const char *family)
++{
++    const struct FcGenericFamilyEntry *entry;
++    size_t                             len;
++    uint32_t                           result = FC_FAMILY_UNKNOWN;
++
++    if (!family)
++	return FC_FAMILY_UNKNOWN;
++
++    len = strlen (family);
++    entry = fc_generic_family_lookup (family, len);
++    if (entry)
++	result = entry->classification;
++
++    return result;
++}
+diff --git a/src/fcint.h b/src/fcint.h
+index d3fcd1f7..59a8e1ff 100644
+--- a/src/fcint.h
++++ b/src/fcint.h
+@@ -1235,6 +1235,10 @@ FcFontSetSerialize (FcSerialize *serialize, const FcFontSet *s);
+ FcPrivate FcFontSet *
+ FcFontSetDeserialize (const FcFontSet *set);
+ 
++/* fcgenericalias.c */
++FcPrivate uint32_t
++FcGenericAliasGetClassification (const char *family);
++
+ /* fcplist.c */
+ FcPrivate FcPtrList *
+ FcPtrListCreate (FcDestroyFunc func);
+diff --git a/src/meson.build b/src/meson.build
+index 0f91d4bc..54fcc32d 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -30,6 +30,7 @@ fc_sources = files([
+   'fcformat.c',
+   'fcfreetype.c',
+   'fcfs.c',
++  'fcgenericalias.c',
+   'fcptrlist.c',
+   'fchash.c',
+   'fcinit.c',
+@@ -58,22 +59,36 @@ fcobjshash_gperf = custom_target(
+   build_by_default: true,
+ )
+ 
+-fcobjshash_h = custom_target('fcobjshash.h',
++fcobjshash_h = custom_target(
++  'fcobjshash.h',
+   input: fcobjshash_gperf,
+   output: 'fcobjshash.h',
+-  command: [gperf, '--pic', '-m', '100', '@INPUT@', '--output-file', '@OUTPUT@']
++  command: [gperf, '--pic', '-m', '100', '@INPUT@', '--output-file', '@OUTPUT@'],
+ )
+ 
+-lib_fontconfig_sources = [fc_sources, alias_headers, ft_alias_headers, fccase_h, fcconst_h, fclang_h, fcobjshash_h, fcstdint_h]
++lib_fontconfig_sources = [
++  fc_sources,
++  alias_headers,
++  ft_alias_headers,
++  fccase_h,
++  fcconst_h,
++  fcgenericfamily_h,
++  fclang_h,
++  fcobjshash_h,
++  fcstdint_h,
++]
+ lib_fontconfig_kwargs = {
+   'include_directories': incbase,
+   'dependencies': [deps, math_dep],
+   'link_with': [pattern_lib],
+ }
+ 
+-fcarch = executable('fcarch', ['fcarch.c', 'fcarch.h', fcstdint_h, fclang_h],
++fcarch = executable(
++  'fcarch',
++  ['fcarch.c', 'fcarch.h', fcstdint_h, fclang_h],
+   include_directories: [incbase, incsrc],
+   c_args: c_args,
+   dependencies: [libintl_dep],
+   install: false,
+-  install_tag: 'runtime')
++  install_tag: 'runtime',
++)
+diff --git a/test/test_genconf.py b/test/test_genconf.py
+index e610ec05..f8904f26 100644
+--- a/test/test_genconf.py
++++ b/test/test_genconf.py
+@@ -20,37 +20,49 @@ def fcfont():
+ def test_genconf(fctest, fcfont, parametrized_external_font):
+     font_path = Path(parametrized_external_font)
+ 
+-    extraconffile = NamedTemporaryFile(prefix='fontconfig.',
+-                                       suffix='.extra.conf',
+-                                       mode='w',
+-                                       delete_on_close=False)
+-    fctest._extra.append(f'<include ignore_missing="yes">{fctest.convert_path(extraconffile.name)}</include>')
++    extraconffile = NamedTemporaryFile(
++        prefix="fontconfig.", suffix=".extra.conf", mode="w", delete_on_close=False
++    )
++    fctest._extra.append(
++        f'<include ignore_missing="yes">{fctest.convert_path(extraconffile.name)}</include>'
++    )
+     fctest.setup()
+-    fctest.install_font(fcfont.fonts, '.')
+-    fctest.install_font(parametrized_external_font, '.')
++    fctest.install_font(fcfont.fonts, ".")
++    fctest.install_font(parametrized_external_font, ".")
+ 
+-    f = g = fmt = None
+-    for ret, stdout, stderr in fctest.run_query(['-f', '%{family}:%{genericfamily}\n', parametrized_external_font]):
++    gl = []
++    f = fmt = None
++    for ret, stdout, stderr in fctest.run_query(
++        ["-f", "%{family}:%{genericfamily}\n", parametrized_external_font]
++    ):
+         assert ret == 0, stderr
+         for l in stdout.strip().splitlines():
+-            f, g = l.split(':')
++            f, g = l.split(":")
+             assert f, stdout
+-            if not g or g == '0':
++            if not g or g == "0":
+                 # fallback if missing
+-                g = '2'
+-                fmt = ':family=sans-serif'
++                gl = ["2"]
++                fmt = ":family=sans-serif"
+             else:
+-                fmt = f':genericfamily={g}'
++                for gg in g.split(","):
++                    gl += [gg]
++                fmt = f":genericfamily={','.join(g)}"
+ 
+-    for ret, stdout, stderr in fctest.run_genconf(['-g', g, '-f', f, '-o', extraconffile.name, parametrized_external_font]):
++    for ret, stdout, stderr in fctest.run_genconf(
++        [item for s in gl for item in ("-g", s)]
++        + ["-f", f, "-o", extraconffile.name, parametrized_external_font]
++    ):
+         assert ret == 0, stderr
+ 
+-    for ret, stdout, stderr in fctest.run_match(['-f', '%{file}\n', fmt]):
++    for ret, stdout, stderr in fctest.run_match(["-f", "%{file}\n", fmt]):
+         assert ret == 0, stderr
+         if Path(stdout.strip().splitlines()[0]).name != font_path.name:
+             assert ret == 0, stderr
+ 
+-    for ret, stdout, stderr in fctest.run_scan(['-f', '%{genericfamily}\n', parametrized_external_font]):
++    for ret, stdout, stderr in fctest.run_scan(
++        ["-f", "%{genericfamily}\n", parametrized_external_font]
++    ):
+         assert ret == 0, stderr
+         for l in stdout.strip().splitlines():
+-            assert g == l, stdout
++            l = l.split(",")
++            assert gl == l, stdout
+-- 
+GitLab
+
+
+From 4e062619d85f874f82f3024b3b8d858f1a14904b Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Mon, 29 Jun 2026 18:13:57 +0900
+Subject: [PATCH 3/3] Add Nerd Fonts to the table
+
+Fixes https://gitlab.freedesktop.org/fontconfig/fontconfig/-/work_items/530
+
+Changelog: fixed
+---
+ fc-genericfamily/monospace.txt  | 112 ++++++++++++++++++++++++++++++++
+ fc-genericfamily/sans-serif.txt |   5 ++
+ fc-genericfamily/serif.txt      |   2 +
+ 3 files changed, 119 insertions(+)
+
+diff --git a/fc-genericfamily/monospace.txt b/fc-genericfamily/monospace.txt
+index a7ba2d40..387af3bf 100644
+--- a/fc-genericfamily/monospace.txt
++++ b/fc-genericfamily/monospace.txt
+@@ -136,3 +136,115 @@ Noto Sans Mono CJK TC
+ RIT Meera New  # FIXME: sans-serif
+ TeX Gyre Cursor
+ Miriam Mono CLM
++# Nerd Fonts - patched programming fonts
++Agave
++AurulentSansMono
++BigBlueTerminal
++CodeNewRoman
++ComicShannsMono
++DaddyTimeMono
++EnvyCodeR
++FantasqueSansMono
++Fira Mono
++Go Mono
++Gohu
++Hasklig
++HeavyData
++iA Writer Mono
++iA Writer Duo
++iA Writer Quattro
++IBM Plex Mono
++Inconsolata Go
++InconsolataGo
++InconsolataLGC
++Iosevka
++Iosevka Term
++IosevkaTerm
++Lekton
++Lilex
++Meslo
++Monofur
++Monoid
++Mononoki
++M+ 1m
++M+ 1mn
++M+ 2m
++MPlus
++OpenDyslexic
++OpenDyslexicMono
++ProFont
++ProggyClean
++ShareTechMono
++Share Tech Mono
++Space Mono
++SpaceMono
++Victor Mono
++VictorMono
++# Nerd Fonts - Nerd Font variants (with NF suffix)
++3270 Nerd Font
++3270 Nerd Font Mono
++Agave Nerd Font
++Agave Nerd Font Mono
++AnonymicePro Nerd Font
++AnonymicePro Nerd Font Mono
++Arimo Nerd Font
++AurulentSansMono Nerd Font
++BigBlueTerminal Nerd Font
++BitstreamVeraSansMono Nerd Font
++CaskaydiaCove Nerd Font
++CaskaydiaCove Nerd Font Mono
++CodeNewRoman Nerd Font
++CodeNewRoman Nerd Font Mono
++ComicShannsMono Nerd Font
++Cousine Nerd Font
++DaddyTimeMono Nerd Font
++DejaVuSansM Nerd Font
++DejaVuSansMono Nerd Font
++DroidSansM Nerd Font
++DroidSansMono Nerd Font
++EnvyCodeR Nerd Font
++FantasqueSansMono Nerd Font
++FiraCode Nerd Font
++FiraCode Nerd Font Mono
++FiraMono Nerd Font
++GeistMono Nerd Font
++Go Mono Nerd Font
++GoMono Nerd Font
++Gohu Nerd Font
++Hasklug Nerd Font
++HeavyData Nerd Font
++Hurmit Nerd Font
++iM Writing Nerd Font
++iM Writing Nerd Font Mono
++IBM 3270 Nerd Font
++IBMPlexMono Nerd Font
++Inconsolata Nerd Font
++InconsolataGo Nerd Font
++InconsolataLGC Nerd Font
++Iosevka Nerd Font
++Iosevka Nerd Font Mono
++IosevkaTerm Nerd Font
++JetBrainsMono Nerd Font
++Lekton Nerd Font
++LiberationMono Nerd Font
++Lilex Nerd Font
++Meslo Nerd Font
++Monofur Nerd Font
++Monoid Nerd Font
++Mononoki Nerd Font
++MPlus Nerd Font
++NotoMono Nerd Font
++OpenDyslexic Nerd Font
++OpenDyslexicMono Nerd Font
++Overpass Nerd Font
++ProggyClean Nerd Font
++ProFont Nerd Font
++RobotoMono Nerd Font
++ShareTechMono Nerd Font
++SourceCodePro Nerd Font
++SpaceMono Nerd Font
++Terminess Nerd Font
++Tinos Nerd Font
++Ubuntu Nerd Font
++UbuntuMono Nerd Font
++VictorMono Nerd Font
+diff --git a/fc-genericfamily/sans-serif.txt b/fc-genericfamily/sans-serif.txt
+index 948fb251..fad0efb0 100644
+--- a/fc-genericfamily/sans-serif.txt
++++ b/fc-genericfamily/sans-serif.txt
+@@ -312,3 +312,8 @@ TeX Gyre Heros
+ TeX Gyre Heros Cn
+ URW Gothic
+ Madan2
++# Nerd Fonts - sans-serif variants
++Ubuntu
++Ubuntu Condensed
++# Nerd Fonts - Nerd Font sans-serif variants
++Ubuntu Nerd Font
+diff --git a/fc-genericfamily/serif.txt b/fc-genericfamily/serif.txt
+index f3e866e1..9b346fe6 100644
+--- a/fc-genericfamily/serif.txt
++++ b/fc-genericfamily/serif.txt
+@@ -238,3 +238,5 @@ PakType Naskh Basic Wide
+ GB_SS_GB18030
+ GB_SS_GB18030_Extended
+ GB_SS_GB18030_ExtendedK
++# Nerd Fonts - Nerd Font serif variants
++Tinos Nerd Font
+-- 
+GitLab
+

--- a/packages/f/fontconfig/package.yml
+++ b/packages/f/fontconfig/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fontconfig
 version    : 2.18.1
-release    : 53
+release    : 54
 source     :
     - https://gitlab.freedesktop.org/api/v4/projects/890/packages/generic/fontconfig/2.18.1/fontconfig-2.18.1.tar.xz : 2300f3dbfa7253b3a44f4feecdbc8dfa45dde5dc2cfb71fceaf31f394cb41031
 homepage   : https://www.freedesktop.org/wiki/Software/fontconfig/
@@ -28,6 +28,21 @@ rundeps    :
 setup      : |
     %patch -p1 -i ${pkgfiles}/0003-Support-local-configs-too-for-stateless-implementati.patch
     %patch -p1 -i ${pkgfiles}/fontconfig-2.17.1-prefer-hack.patch
+
+    # Patches to fix detection of Hack as a monospace font
+    # (and likely others).
+    %patch -p1 -i ${pkgfiles}/528.patch
+    %patch -p1 -i ${pkgfiles}/529.patch
+    %patch -p1 -i ${pkgfiles}/531.patch
+    %patch -p1 -i ${pkgfiles}/535.patch
+
+    # Patching doesn't want to create these files, presumably because they
+    # are empty.
+    touch \
+        fc-genericfamily/ui-monospace.txt \
+        fc-genericfamily/ui-rounded.txt \
+        fc-genericfamily/ui-sans-serif.txt \
+        fc-genericfamily/ui-serif.txt \
 
     %meson_configure \
         -Dbaseconfig-dir=/etc/fonts \

--- a/packages/f/fontconfig/pspec_x86_64.xml
+++ b/packages/f/fontconfig/pspec_x86_64.xml
@@ -129,7 +129,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="53">fontconfig</Dependency>
+            <Dependency release="54">fontconfig</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfontconfig.so.1</Path>
@@ -143,8 +143,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="53">fontconfig-32bit</Dependency>
-            <Dependency release="53">fontconfig-devel</Dependency>
+            <Dependency release="54">fontconfig-32bit</Dependency>
+            <Dependency release="54">fontconfig-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfontconfig.so</Path>
@@ -158,7 +158,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="53">fontconfig</Dependency>
+            <Dependency release="54">fontconfig</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/fontconfig/fcfreetype.h</Path>
@@ -399,8 +399,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="53">
-            <Date>2026-07-06</Date>
+        <Update release="54">
+            <Date>2026-07-08</Date>
             <Version>2.18.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
2.18.0 introduced `fc-genericfamily` to try to generically match fonts. This mechanism, on release, breaks detection of Hack as our default monospace font, and likely other fonts for other font types. This set of patches at least fixes the case of Hack not being chosen as the monospace font.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

1. Ran `fc-match monospace` with the old package installed and saw Noto Sans Mono or whatever.
2. Install new packages.
3. Ran `sudo fc-cache -r`.
4. Ran `fc-match monospace` and saw Hack returned as the font.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
