### PR TITLE
libxfont2: Update to v2.0.8

### DIFF
--- a/packages/l/libxfont2/abi_used_symbols
+++ b/packages/l/libxfont2/abi_used_symbols
@@ -6,6 +6,8 @@ libc.so.6:__isoc23_fscanf
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__memcpy_chk
+libc.so.6:__memmove_chk
+libc.so.6:__memset_chk
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
@@ -60,6 +62,7 @@ libc.so.6:strcasecmp
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strdup
+libc.so.6:strerror
 libc.so.6:strlcat
 libc.so.6:strlcpy
 libc.so.6:strlen
@@ -77,7 +80,6 @@ libc.so.6:write
 libc.so.6:writev
 libfontenc.so.1:FontEncFind
 libfontenc.so.1:FontEncFromXLFD
-libfontenc.so.1:FontEncIdentify
 libfontenc.so.1:FontEncName
 libfontenc.so.1:FontEncRecode
 libfreetype.so.6:FT_Activate_Size
@@ -107,6 +109,7 @@ libfreetype.so.6:FT_Set_Charmap
 libfreetype.so.6:FT_Set_Pixel_Sizes
 libfreetype.so.6:FT_Set_Transform
 libfreetype.so.6:FT_Vector_Transform
+libm.so.6:ceil
 libm.so.6:floor
 libm.so.6:hypot
 libm.so.6:sin

--- a/packages/l/libxfont2/abi_used_symbols32
+++ b/packages/l/libxfont2/abi_used_symbols32
@@ -6,6 +6,8 @@ libc.so.6:__isoc23_fscanf
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__memcpy_chk
+libc.so.6:__memmove_chk
+libc.so.6:__memset_chk
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
@@ -60,6 +62,7 @@ libc.so.6:strcasecmp
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strdup
+libc.so.6:strerror
 libc.so.6:strlcat
 libc.so.6:strlcpy
 libc.so.6:strlen
@@ -77,7 +80,6 @@ libc.so.6:write
 libc.so.6:writev
 libfontenc.so.1:FontEncFind
 libfontenc.so.1:FontEncFromXLFD
-libfontenc.so.1:FontEncIdentify
 libfontenc.so.1:FontEncName
 libfontenc.so.1:FontEncRecode
 libfreetype.so.6:FT_Activate_Size

--- a/packages/l/libxfont2/package.yml
+++ b/packages/l/libxfont2/package.yml
@@ -1,12 +1,18 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libxfont2
-version    : 2.0.7
-release    : 13
+version    : 2.0.8
+release    : 14
 source     :
-    - https://www.x.org/releases/individual/lib/libXfont2-2.0.7.tar.gz : 90b331c2fd2d0420767c4652e007d054c97a3f03a88c55e3b986bd3acfd7e338
-license    : MIT
-component  : xorg.library
+    - https://www.x.org/releases/individual/lib/libXfont2-2.0.8.tar.gz : a53d621b6ceb1dcbd05a0b9bd7f13c34efa40401cd5c05af904035c567a30f18
 homepage   : https://www.x.org/
+license    :
+    - BSD-3-Clause
+    - BSD-4-Clause-UC
+    - HPND-sell-variant
+    - MIT-open-group
+    - SMLNJ
+    - X11
+component  : xorg.library
 summary    : libXfont provides the core of the legacy X11 font system, handling the index files (fonts.dir, fonts.alias, fonts.scale), the various font file formats, and rasterizing them.
 description: |
     libXfont provides the core of the legacy X11 font system, handling the index files (fonts.dir, fonts.alias, fonts.scale), the various font file formats, and rasterizing them.
@@ -15,8 +21,8 @@ optimize   :
     - no-symbolic
 emul32     : true
 builddeps  :
-    - pkgconfig32(freetype2)
     - pkgconfig32(fontenc)
+    - pkgconfig32(freetype2)
     - pkgconfig32(zlib)
     - pkgconfig(xproto)
     - pkgconfig(xtrans)
@@ -26,3 +32,4 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING

--- a/packages/l/libxfont2/pspec_x86_64.xml
+++ b/packages/l/libxfont2/pspec_x86_64.xml
@@ -3,10 +3,15 @@
         <Name>libxfont2</Name>
         <Homepage>https://www.x.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
-        <License>MIT</License>
+        <License>BSD-3-Clause</License>
+        <License>BSD-4-Clause-UC</License>
+        <License>HPND-sell-variant</License>
+        <License>MIT-open-group</License>
+        <License>SMLNJ</License>
+        <License>X11</License>
         <PartOf>xorg.library</PartOf>
         <Summary xml:lang="en">libXfont provides the core of the legacy X11 font system, handling the index files (fonts.dir, fonts.alias, fonts.scale), the various font file formats, and rasterizing them.</Summary>
         <Description xml:lang="en">libXfont provides the core of the legacy X11 font system, handling the index files (fonts.dir, fonts.alias, fonts.scale), the various font file formats, and rasterizing them.
@@ -22,6 +27,7 @@
         <Files>
             <Path fileType="library">/usr/lib64/libXfont2.so.2</Path>
             <Path fileType="library">/usr/lib64/libXfont2.so.2.0.0</Path>
+            <Path fileType="data">/usr/share/licenses/libxfont2/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -31,7 +37,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">libxfont2</Dependency>
+            <Dependency release="14">libxfont2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libXfont2.so.2</Path>
@@ -45,8 +51,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">libxfont2-devel</Dependency>
-            <Dependency release="13">libxfont2-32bit</Dependency>
+            <Dependency release="14">libxfont2-32bit</Dependency>
+            <Dependency release="14">libxfont2-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libXfont2.so</Path>
@@ -60,7 +66,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">libxfont2</Dependency>
+            <Dependency release="14">libxfont2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/X11/fonts/libxfont2.h</Path>
@@ -69,12 +75,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2024-08-02</Date>
-            <Version>2.0.7</Version>
+        <Update release="14">
+            <Date>2026-07-09</Date>
+            <Version>2.0.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
No changelog provided.

**Security**
- CVE-2026-56001
- CVE-2026-56002
- CVE-2026-56003

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild a reverse dependency against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
