### PR TITLE
libreswan: Update to v5.3.1

### DIFF
--- a/packages/l/libreswan/abi_used_symbols
+++ b/packages/l/libreswan/abi_used_symbols
@@ -300,7 +300,6 @@ libnss3.so:PK11_SignWithMechanism
 libnss3.so:PK11_SignatureLen
 libnss3.so:PK11_TraverseSlotCerts
 libnss3.so:PK11_Verify
-libnss3.so:PK11_VerifyRecover
 libnss3.so:PK11_VerifyWithMechanism
 libnss3.so:PK11_WrapSymKey
 libnss3.so:PORT_ArenaZAlloc

--- a/packages/l/libreswan/package.yml
+++ b/packages/l/libreswan/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libreswan
-version    : '5.3'
-release    : 14
+version    : 5.3.1
+release    : 15
 source     :
-    - https://download.libreswan.org/libreswan-5.3.tar.gz : c1d350c3f3296fd21b9db0794e23d3f319b292f880bf8178b82ef5c6391c60c0
+    - https://download.libreswan.org/libreswan-5.3.1.tar.gz : e3f0e51d8b642bf693a6a8cc6f1e62a764cff4180a023bf3c7e42d43a62dfe9e
 homepage   : https://libreswan.org/
 license    : GPL-2.0-or-later
 component  : network.util

--- a/packages/l/libreswan/pspec_x86_64.xml
+++ b/packages/l/libreswan/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libreswan</Name>
         <Homepage>https://libreswan.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.util</PartOf>
@@ -141,12 +141,12 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2025-12-20</Date>
-            <Version>5.3</Version>
+        <Update release="15">
+            <Date>2026-07-09</Date>
+            <Version>5.3.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/libreswan/libreswan/releases/tag/v5.3.1).

**Security**
Includes fixes for:
- CVE-2026-12413
- CVE-2026-50721
- CVE-2026-50722

**Test Plan**

`sudo ipsec trafficstatus`, `sudo ipsec briefstatus`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
