### PR TITLE
uv: update to 0.11.28

### DIFF
--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -2,10 +2,10 @@
 #
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : uv
-version    : 0.11.25
-release    : 17
+version    : 0.11.28
+release    : 18
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.25.tar.gz : c59d0903cb163fdd50f3284c3d1d4cfc927d83ca0314f5a443fcc1d3c906cb62
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.28.tar.gz : 556c6cb42a2101c690704b08d0d3c5d596ea94e69353a820664568f0fcd62fd4
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -23,12 +23,12 @@
         <Files>
             <Path fileType="executable">/usr/bin/uv</Path>
             <Path fileType="executable">/usr/bin/uvx</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/licenses/LICENSE-MIT</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/sboms/uv.cyclonedx.json</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/sboms/uv.cyclonedx.json</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -48,9 +48,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2026-06-27</Date>
-            <Version>0.11.25</Version>
+        <Update release="18">
+            <Date>2026-07-09</Date>
+            <Version>0.11.28</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
## Summary

- **Security:** Harden ZIP archive handling and reject malformed or ambiguous archives more safely.
- Improve dependency resolution and package management performance.
- Enhance reliability when handling package metadata, lockfiles, and cache operations.
- Improve error reporting and overall usability across package management workflows.

Release notes:
    - [0.11.28](https://github.com/astral-sh/uv/releases/tag/0.11.28)
    - [0.11.27](https://github.com/astral-sh/uv/releases/tag/0.11.27)
    - [0.11.26](https://github.com/astral-sh/uv/releases/tag/0.11.26)

## Test Plan

- Run smoke tests defined in source
- Installed locally and run some commands

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
