### PR TITLE
usysconf: Fix path matching for fontconfig

### DIFF
--- a/packages/u/usysconf/files/0001-fonts-Fix-paths-for-fontconfig-directories.patch
+++ b/packages/u/usysconf/files/0001-fonts-Fix-paths-for-fontconfig-directories.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Thu, 9 Jul 2026 19:18:23 -0400
+Subject: [PATCH] fonts: Fix paths for fontconfig directories
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ src/handlers/xdg/fonts.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/handlers/xdg/fonts.c b/src/handlers/xdg/fonts.c
+index e4d2ccd..195a9e8 100644
+--- a/src/handlers/xdg/fonts.c
++++ b/src/handlers/xdg/fonts.c
+@@ -18,8 +18,8 @@
+ static const char *font_paths[] = {
+         "/usr/share/fonts/*/*",
+         "/usr/share/fonts/*",
+-        "/usr/share/fontconfig/conf.avail/*",
+-        "/usr/share/fontconfig/conf.default/*",
++        "/usr/share/fontconfig/conf.avail",
++        "/usr/share/fontconfig/conf.default",
+ };
+ 
+ /**

--- a/packages/u/usysconf/package.yml
+++ b/packages/u/usysconf/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : usysconf
 version    : 0.5.16
-release    : 53
+release    : 54
 source     :
     - https://github.com/getsolus/usysconf/releases/download/v0.5.16/usysconf-v0.5.16.tar.xz : e9f6b75625ddc21730f10ebdd29981f70ae8ab5aee417dbb090e9380ec6d017d
 homepage   : https://github.com/getsolus/usysconf/
@@ -23,6 +23,8 @@ optimize   :
     - size
     - lto
 setup      : |
+    %patch -p1 -i ${pkgfiles}/0001-fonts-Fix-paths-for-fontconfig-directories.patch
+
     export CC=musl-gcc
     %meson_configure \
         -Dwith-static-binary=true \

--- a/packages/u/usysconf/pspec_x86_64.xml
+++ b/packages/u/usysconf/pspec_x86_64.xml
@@ -40,7 +40,7 @@ usysconf is a Solus project.
         </Files>
     </Package>
     <History>
-        <Update release="53">
+        <Update release="54">
             <Date>2026-07-09</Date>
             <Version>0.5.16</Version>
             <Comment>Packaging update</Comment>


### PR DESCRIPTION
**Summary**

Turns out that trigger wants directories, not files.

**Test Plan**

Update fontconfig, see that the trigger ran.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
