### PR TITLE
fastfetch: Update to v2.66.0

### DIFF
--- a/packages/f/fastfetch/package.yml
+++ b/packages/f/fastfetch/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fastfetch
-version    : 2.65.2
-release    : 78
+version    : 2.66.0
+release    : 79
 source     :
-    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.65.2.tar.gz : d0b318c33cf6c8bbae1162325f91624762a040a60f748941cbf1b4b99a75fa30
+    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.66.0.tar.gz : 547883c2f0dbc85a4545d4533f5b812fbc4c8ffe1271056de18b51994acbf474
 homepage   : https://github.com/fastfetch-cli/fastfetch
 license    : MIT
 component  : system.utils

--- a/packages/f/fastfetch/pspec_x86_64.xml
+++ b/packages/f/fastfetch/pspec_x86_64.xml
@@ -67,9 +67,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="78">
-            <Date>2026-06-28</Date>
-            <Version>2.65.2</Version>
+        <Update release="79">
+            <Date>2026-07-10</Date>
+            <Version>2.66.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.66.0).

**Test Plan**

See `fastfetch` output

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
