### PR TITLE
qmapshack: Update to v1.20.3

### DIFF
--- a/packages/q/qmapshack/abi_libs
+++ b/packages/q/qmapshack/abi_libs
@@ -1,4 +1,1 @@
 qmapshack
-qmaptool
-qmt_map2jnx
-qmt_rgb2pct

--- a/packages/q/qmapshack/abi_symbols
+++ b/packages/q/qmapshack/abi_symbols
@@ -1,4 +1,1 @@
 qmapshack:_IO_stdin_used
-qmaptool:_IO_stdin_used
-qmt_map2jnx:_IO_stdin_used
-qmt_rgb2pct:_IO_stdin_used

--- a/packages/q/qmapshack/abi_used_symbols
+++ b/packages/q/qmapshack/abi_used_symbols
@@ -2,6 +2,7 @@ libQt6Core.so.6:_Z11qUncompressPKhx
 libQt6Core.so.6:_Z15compareThreeWayRK9QDateTimeS1_
 libQt6Core.so.6:_Z17qFormatLogMessage9QtMsgTypeRK18QMessageLogContextRK7QString
 libQt6Core.so.6:_Z18qSetMessagePatternRK7QString
+libQt6Core.so.6:_Z20qEnvironmentVariablePKc
 libQt6Core.so.6:_Z20qt_qFindChild_helperPK7QObject14QAnyStringViewRK11QMetaObject6QFlagsIN2Qt15FindChildOptionEE
 libQt6Core.so.6:_Z21qRegisterResourceDataiPKhS0_S0_
 libQt6Core.so.6:_Z22qInstallMessageHandlerPFv9QtMsgTypeRK18QMessageLogContextRK7QStringE
@@ -280,6 +281,7 @@ libQt6Core.so.6:_ZN7QBuffer6bufferEv
 libQt6Core.so.6:_ZN7QBufferC1EP10QByteArrayP7QObject
 libQt6Core.so.6:_ZN7QBufferC1EP7QObject
 libQt6Core.so.6:_ZN7QBufferD1Ev
+libQt6Core.so.6:_ZN7QLocale1cEv
 libQt6Core.so.6:_ZN7QLocale6systemEv
 libQt6Core.so.6:_ZN7QLocaleC1ENS_8LanguageENS_6ScriptENS_7CountryE
 libQt6Core.so.6:_ZN7QLocaleC1ENS_8LanguageENS_7CountryE
@@ -898,6 +900,7 @@ libQt6Gui.so.6:_ZN12QActionGroup9triggeredEP7QAction
 libQt6Gui.so.6:_ZN12QActionGroupC1EP7QObject
 libQt6Gui.so.6:_ZN12QFontMetricsC1ERK5QFont
 libQt6Gui.so.6:_ZN12QFontMetricsD1Ev
+libQt6Gui.so.6:_ZN12QKeySequenceC1E15QKeyCombinationS0_S0_S0_
 libQt6Gui.so.6:_ZN12QKeySequenceC1ERK7QStringNS_14SequenceFormatE
 libQt6Gui.so.6:_ZN12QKeySequenceC1Eiiii
 libQt6Gui.so.6:_ZN12QKeySequenceD1Ev
@@ -963,6 +966,7 @@ libQt6Gui.so.6:_ZN5QFontC1ERKS_
 libQt6Gui.so.6:_ZN5QFontC1Ev
 libQt6Gui.so.6:_ZN5QFontD1Ev
 libQt6Gui.so.6:_ZN5QFontaSERKS_
+libQt6Gui.so.6:_ZN5QIcon16staticMetaObjectE
 libQt6Gui.so.6:_ZN5QIcon7addFileERK7QStringRK5QSizeNS_4ModeENS_5StateE
 libQt6Gui.so.6:_ZN5QIconC1ERK7QPixmap
 libQt6Gui.so.6:_ZN5QIconC1ERK7QString
@@ -1052,6 +1056,7 @@ libQt6Gui.so.6:_ZN7QPixmapaSERKS_
 libQt6Gui.so.6:_ZN7QRegionC1Ev
 libQt6Gui.so.6:_ZN7QRegionD1Ev
 libQt6Gui.so.6:_ZN7QWindow5closeEv
+libQt6Gui.so.6:_ZN8QPainter10doSetBrushERK6QBrushPS0_
 libQt6Gui.so.6:_ZN8QPainter10drawPixmapERK6QRectFRK7QPixmapS2_
 libQt6Gui.so.6:_ZN8QPainter10drawPixmapERK7QPointFRK7QPixmap
 libQt6Gui.so.6:_ZN8QPainter10setOpacityEd
@@ -1075,11 +1080,11 @@ libQt6Gui.so.6:_ZN8QPainter5beginEP12QPaintDevice
 libQt6Gui.so.6:_ZN8QPainter5scaleEdd
 libQt6Gui.so.6:_ZN8QPainter6rotateEd
 libQt6Gui.so.6:_ZN8QPainter6setPenEN2Qt8PenStyleE
-libQt6Gui.so.6:_ZN8QPainter6setPenERK4QPen
 libQt6Gui.so.6:_ZN8QPainter6setPenERK6QColor
 libQt6Gui.so.6:_ZN8QPainter7drawArcERK6QRectFii
 libQt6Gui.so.6:_ZN8QPainter7restoreEv
 libQt6Gui.so.6:_ZN8QPainter7setFontERK5QFont
+libQt6Gui.so.6:_ZN8QPainter8doSetPenERK4QPenPS0_
 libQt6Gui.so.6:_ZN8QPainter8drawPathERK12QPainterPath
 libQt6Gui.so.6:_ZN8QPainter8drawTextERK5QRectiRK7QStringPS0_
 libQt6Gui.so.6:_ZN8QPainter8drawTextERK6QRectFRK7QStringRK11QTextOption
@@ -1088,7 +1093,6 @@ libQt6Gui.so.6:_ZN8QPainter8fillRectERK5QRectRK6QBrush
 libQt6Gui.so.6:_ZN8QPainter8fillRectERK5QRectRK6QColor
 libQt6Gui.so.6:_ZN8QPainter8setBrushE6QColor
 libQt6Gui.so.6:_ZN8QPainter8setBrushEN2Qt10BrushStyleE
-libQt6Gui.so.6:_ZN8QPainter8setBrushERK6QBrush
 libQt6Gui.so.6:_ZN8QPainter9drawImageERK6QRectFRK6QImageS2_6QFlagsIN2Qt19ImageConversionFlagEE
 libQt6Gui.so.6:_ZN8QPainter9drawImageERK7QPointFRK6QImage
 libQt6Gui.so.6:_ZN8QPainter9drawLinesEPK5QLinei
@@ -2021,6 +2025,7 @@ libQt6Widgets.so.6:_ZN7QWidget7setFontERK5QFont
 libQt6Widgets.so.6:_ZN7QWidget8setFocusEN2Qt11FocusReasonE
 libQt6Widgets.so.6:_ZN7QWidget9addActionEP7QAction
 libQt6Widgets.so.6:_ZN7QWidget9addActionERK5QIconRK7QString
+libQt6Widgets.so.6:_ZN7QWidget9addActionERK5QIconRK7QStringRK12QKeySequence
 libQt6Widgets.so.6:_ZN7QWidget9addActionERK7QString
 libQt6Widgets.so.6:_ZN7QWidget9dropEventEP10QDropEvent
 libQt6Widgets.so.6:_ZN7QWidget9hideEventEP10QHideEvent
@@ -2234,6 +2239,7 @@ libQt6Widgets.so.6:_ZN9QTextEdit21cursorPositionChangedEv
 libQt6Widgets.so.6:_ZN9QTextEdit21mouseDoubleClickEventEP11QMouseEvent
 libQt6Widgets.so.6:_ZN9QTextEdit22mergeCurrentCharFormatERK15QTextCharFormat
 libQt6Widgets.so.6:_ZN9QTextEdit24currentCharFormatChangedERK15QTextCharFormat
+libQt6Widgets.so.6:_ZN9QTextEdit25createStandardContextMenuEv
 libQt6Widgets.so.6:_ZN9QTextEdit3cutEv
 libQt6Widgets.so.6:_ZN9QTextEdit4copyEv
 libQt6Widgets.so.6:_ZN9QTextEdit4redoEv
@@ -2333,6 +2339,8 @@ libQt6Widgets.so.6:_ZNK11QTreeWidget9itemBelowEPK15QTreeWidgetItem
 libQt6Widgets.so.6:_ZNK11QTreeWidget9mimeTypesEv
 libQt6Widgets.so.6:_ZNK11QWizardPage6nextIdEv
 libQt6Widgets.so.6:_ZNK11QWizardPage6wizardEv
+libQt6Widgets.so.6:_ZNK12QTextBrowser18isForwardAvailableEv
+libQt6Widgets.so.6:_ZNK12QTextBrowser19isBackwardAvailableEv
 libQt6Widgets.so.6:_ZNK13QDateTimeEdit8dateTimeEv
 libQt6Widgets.so.6:_ZNK13QGestureEvent7gestureEN2Qt11GestureTypeE
 libQt6Widgets.so.6:_ZNK13QPinchGesture11centerPointEv
@@ -2651,7 +2659,6 @@ libc.so.6:free
 libc.so.6:fseeko
 libc.so.6:ftello
 libc.so.6:fwrite
-libc.so.6:getenv
 libc.so.6:malloc
 libc.so.6:memchr
 libc.so.6:memcmp

--- a/packages/q/qmapshack/package.yml
+++ b/packages/q/qmapshack/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : qmapshack
-version    : 1.20.2
-release    : 22
+version    : 1.20.3
+release    : 23
 source     :
-    - https://github.com/Maproom/qmapshack/archive/refs/tags/V_1.20.2.tar.gz : e7271b9370577377bb2608d82e89cbc0a8a309100dbb51d97291f6bfbedce05c
+    - https://github.com/Maproom/qmapshack/archive/refs/tags/V_1.20.3.tar.gz : faae6d10c8aa3fd00efad5f571697aa56ae71543cebbc1a52130ec545a2208b0
 homepage   : https://github.com/Maproom/qmapshack
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/q/qmapshack/pspec_x86_64.xml
+++ b/packages/q/qmapshack/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>qmapshack</Name>
         <Homepage>https://github.com/Maproom/qmapshack</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop</PartOf>
@@ -78,12 +78,14 @@
             <Path fileType="data">/usr/share/qmapshack/translations/qmapshack_de.qm</Path>
             <Path fileType="data">/usr/share/qmapshack/translations/qmapshack_es.qm</Path>
             <Path fileType="data">/usr/share/qmapshack/translations/qmapshack_fr.qm</Path>
+            <Path fileType="data">/usr/share/qmapshack/translations/qmapshack_hr.qm</Path>
             <Path fileType="data">/usr/share/qmapshack/translations/qmapshack_it.qm</Path>
             <Path fileType="data">/usr/share/qmapshack/translations/qmapshack_nl.qm</Path>
             <Path fileType="data">/usr/share/qmapshack/translations/qmapshack_ru.qm</Path>
             <Path fileType="data">/usr/share/qmaptool/translations/qmaptool.qm</Path>
             <Path fileType="data">/usr/share/qmaptool/translations/qmaptool_de.qm</Path>
             <Path fileType="data">/usr/share/qmaptool/translations/qmaptool_es.qm</Path>
+            <Path fileType="data">/usr/share/qmaptool/translations/qmaptool_hr.qm</Path>
             <Path fileType="data">/usr/share/qmaptool/translations/qmaptool_it.qm</Path>
             <Path fileType="data">/usr/share/qmaptool/translations/qmaptool_ru.qm</Path>
             <Path fileType="data">/usr/share/qmt_rgb2pct/translations/qmt_rgb2pct.qm</Path>
@@ -91,12 +93,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2026-05-10</Date>
-            <Version>1.20.2</Version>
+        <Update release="23">
+            <Date>2026-07-10</Date>
+            <Version>1.20.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Maproom/qmapshack/releases/tag/V_1.20.3).
- Resolves: #9567 

**Test Plan**

Open qmapshack and qmaptool, check version, click around. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
