### PR TITLE
minor docker updates

### DIFF
--- a/packages/c/containerd/package.yml
+++ b/packages/c/containerd/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : containerd
-version    : 2.3.2
-release    : 74
+version    : 2.3.3
+release    : 75
 source     :
-    - https://github.com/containerd/containerd/archive/refs/tags/v2.3.2.tar.gz : 1a215ae4acb184192668b21f8b8375ceb6e86f8832a97fe6f7ab53ad79bb2cee
+    - https://github.com/containerd/containerd/archive/refs/tags/v2.3.3.tar.gz : fcff2096ef20f1bc1d939bc55a8b831ea3eface574463fd7dc770b33ffe317b2
 license    : Apache-2.0
 component  : virt
 homepage   : https://containerd.io/

--- a/packages/c/containerd/pspec_x86_64.xml
+++ b/packages/c/containerd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>containerd</Name>
         <Homepage>https://containerd.io/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>virt</PartOf>
@@ -36,12 +36,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="74">
-            <Date>2026-06-19</Date>
-            <Version>2.3.2</Version>
+        <Update release="75">
+            <Date>2026-07-10</Date>
+            <Version>2.3.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/d/docker-compose/package.yml
+++ b/packages/d/docker-compose/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker-compose
-version    : 5.3.0
-release    : 64
+version    : 5.3.1
+release    : 65
 source     :
-    - https://github.com/docker/compose/archive/refs/tags/v5.3.0.tar.gz : 496ee43bc6ecee6fbac28e93f6e784a7b0207baec7ae2b0ffb57cfd83bc92874
+    - https://github.com/docker/compose/archive/refs/tags/v5.3.1.tar.gz : 1823e1b09c4082779fdf5cc9f3d8453b95dba3d939105b39366175ce12fdb6c7
 homepage   : https://docs.docker.com/compose/
 license    : Apache-2.0
 component  : virt

--- a/packages/d/docker-compose/pspec_x86_64.xml
+++ b/packages/d/docker-compose/pspec_x86_64.xml
@@ -28,9 +28,9 @@ With Compose, you use a Compose file to configure your application&#x2019;s serv
         </Files>
     </Package>
     <History>
-        <Update release="64">
-            <Date>2026-07-02</Date>
-            <Version>5.3.0</Version>
+        <Update release="65">
+            <Date>2026-07-10</Date>
+            <Version>5.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes for `containerd` can be found [here](https://github.com/containerd/containerd/releases/tag/v2.3.3).
- Release notes for `docker-compose` can be found [here](https://github.com/docker/compose/releases/tag/v5.3.1).

**Test Plan**

See that docker works. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
