### PR TITLE
tzdata: Update to 2026c

### DIFF
--- a/packages/t/tzdata/package.yml
+++ b/packages/t/tzdata/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : tzdata
-version    : 2026b
-release    : 32
+version    : 2026c
+release    : 33
 source     :
-    - https://data.iana.org/time-zones/releases/tzdata2026b.tar.gz : 114543d9f19a6bfeb5bca43686aea173d38755a3db1f2eec112647ae92c6f544
-    - https://data.iana.org/time-zones/releases/tzcode2026b.tar.gz : 37e9ed8427f5d3521c22fc58e293cbfb043d70eedf1003870b33f363f61ca344
+    - https://data.iana.org/time-zones/releases/tzdata2026c.tar.gz : e4a178a4477f3d0ea77cc31828ff72aa38feff8d61aa13e7e99e142e9d902be4
+    - https://data.iana.org/time-zones/releases/tzcode2026c.tar.gz : b1cffc3ace4c4c7cd0efba2f7add86ec3d0b79da48bcf03582671fd3c8feace8
 homepage   : https://www.iana.org/time-zones
 license    : Public-Domain
 component  : system.base

--- a/packages/t/tzdata/pspec_x86_64.xml
+++ b/packages/t/tzdata/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>tzdata</Name>
         <Homepage>https://www.iana.org/time-zones</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>Public-Domain</License>
         <PartOf>system.base</PartOf>
@@ -1823,12 +1823,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2026-04-27</Date>
-            <Version>2026b</Version>
+        <Update release="33">
+            <Date>2026-07-11</Date>
+            <Version>2026c</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- [Change Log](https://lists.iana.org/hyperkitty/list/tz-announce@iana.org/thread/NVHSX2PAQIT44U5FCCEVNJJYXQMMTJSA/)

**Test Plan**
- Install and reboot
- Test with zdump -V -c 2026,2028 America/New_York

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
