### PR TITLE
czkawka: Update to v12.0.0

### DIFF
--- a/packages/c/czkawka/abi_used_symbols
+++ b/packages/c/czkawka/abi_used_symbols
@@ -10,6 +10,7 @@ libc.so.6:calloc
 libc.so.6:chdir
 libc.so.6:chroot
 libc.so.6:clock_gettime
+libc.so.6:clock_nanosleep
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:connect
@@ -35,6 +36,7 @@ libc.so.6:freeaddrinfo
 libc.so.6:fstat64
 libc.so.6:fstatat64
 libc.so.6:ftruncate64
+libc.so.6:futimens
 libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
 libc.so.6:getauxval
@@ -55,7 +57,6 @@ libc.so.6:kill
 libc.so.6:linkat
 libc.so.6:lseek64
 libc.so.6:lstat64
-libc.so.6:lutimes
 libc.so.6:madvise
 libc.so.6:malloc
 libc.so.6:memcmp
@@ -66,7 +67,6 @@ libc.so.6:mkdir
 libc.so.6:mmap64
 libc.so.6:mprotect
 libc.so.6:munmap
-libc.so.6:nanosleep
 libc.so.6:open
 libc.so.6:open64
 libc.so.6:openat64
@@ -140,8 +140,6 @@ libc.so.6:uname
 libc.so.6:unlink
 libc.so.6:unlinkat
 libc.so.6:unsetenv
-libc.so.6:utimensat
-libc.so.6:utimes
 libc.so.6:waitid
 libc.so.6:waitpid
 libc.so.6:write
@@ -271,6 +269,7 @@ libgtk-4.so.1:gtk_box_new
 libgtk-4.so.1:gtk_builder_get_object
 libgtk-4.so.1:gtk_builder_new_from_string
 libgtk-4.so.1:gtk_button_get_type
+libgtk-4.so.1:gtk_button_new_with_label
 libgtk-4.so.1:gtk_button_set_label
 libgtk-4.so.1:gtk_cell_renderer_text_new
 libgtk-4.so.1:gtk_cell_renderer_toggle_new
@@ -305,9 +304,7 @@ libgtk-4.so.1:gtk_get_micro_version
 libgtk-4.so.1:gtk_get_minor_version
 libgtk-4.so.1:gtk_grid_attach
 libgtk-4.so.1:gtk_grid_get_type
-libgtk-4.so.1:gtk_image_get_paintable
 libgtk-4.so.1:gtk_image_get_type
-libgtk-4.so.1:gtk_image_new
 libgtk-4.so.1:gtk_image_set_from_pixbuf
 libgtk-4.so.1:gtk_is_initialized
 libgtk-4.so.1:gtk_justification_get_type
@@ -315,7 +312,14 @@ libgtk-4.so.1:gtk_label_get_label
 libgtk-4.so.1:gtk_label_get_type
 libgtk-4.so.1:gtk_label_new
 libgtk-4.so.1:gtk_label_set_label
+libgtk-4.so.1:gtk_label_set_markup
 libgtk-4.so.1:gtk_label_set_text
+libgtk-4.so.1:gtk_label_set_wrap
+libgtk-4.so.1:gtk_list_box_append
+libgtk-4.so.1:gtk_list_box_new
+libgtk-4.so.1:gtk_list_box_row_new
+libgtk-4.so.1:gtk_list_box_row_set_child
+libgtk-4.so.1:gtk_list_box_set_selection_mode
 libgtk-4.so.1:gtk_list_store_append
 libgtk-4.so.1:gtk_list_store_clear
 libgtk-4.so.1:gtk_list_store_get_type
@@ -333,7 +337,9 @@ libgtk-4.so.1:gtk_notebook_get_type
 libgtk-4.so.1:gtk_orientable_set_orientation
 libgtk-4.so.1:gtk_picture_get_paintable
 libgtk-4.so.1:gtk_picture_get_type
+libgtk-4.so.1:gtk_picture_new
 libgtk-4.so.1:gtk_picture_new_for_pixbuf
+libgtk-4.so.1:gtk_picture_set_can_shrink
 libgtk-4.so.1:gtk_picture_set_paintable
 libgtk-4.so.1:gtk_picture_set_pixbuf
 libgtk-4.so.1:gtk_popover_get_type
@@ -395,6 +401,7 @@ libgtk-4.so.1:gtk_widget_get_first_child
 libgtk-4.so.1:gtk_widget_get_name
 libgtk-4.so.1:gtk_widget_get_next_sibling
 libgtk-4.so.1:gtk_widget_get_parent
+libgtk-4.so.1:gtk_widget_get_type
 libgtk-4.so.1:gtk_widget_grab_focus
 libgtk-4.so.1:gtk_widget_hide
 libgtk-4.so.1:gtk_widget_is_sensitive
@@ -408,6 +415,7 @@ libgtk-4.so.1:gtk_widget_set_margin_start
 libgtk-4.so.1:gtk_widget_set_margin_top
 libgtk-4.so.1:gtk_widget_set_name
 libgtk-4.so.1:gtk_widget_set_sensitive
+libgtk-4.so.1:gtk_widget_set_size_request
 libgtk-4.so.1:gtk_widget_set_tooltip_text
 libgtk-4.so.1:gtk_widget_set_valign
 libgtk-4.so.1:gtk_widget_set_vexpand

--- a/packages/c/czkawka/package.yml
+++ b/packages/c/czkawka/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : czkawka
-version    : 11.0.1
-release    : 11
+version    : 12.0.0
+release    : 12
 source     :
-    - https://github.com/qarmin/czkawka/archive/refs/tags/11.0.1.tar.gz : 8a6e3f634bfd2b6ed9b7f8634e7405ebb6d756f20bcdd99d15028ffb6b030eca
+    - https://github.com/qarmin/czkawka/archive/refs/tags/12.0.0.tar.gz : cc5183c2ad251bc83d67dc6b12205a0d3d41a568ef89f16db27eb81f15c20e02
 homepage   : https://github.com/qarmin/czkawka
 license    :
     - CC-BY-4.0
@@ -30,6 +30,7 @@ install    : |
     install -Dm00644 data/icons/*.github.qarmin.*.svg -t $installdir/usr/share/icons/hicolor/scalable/apps
     install -Dm00644 data/icons/com.github.qarmin.czkawka-symbolic.svg -t $installdir//usr/share/icons/hicolor/symbolic/apps
     install -Dm00644 data/*.github.qarmin.*.metainfo.xml -t $installdir/usr/share/metainfo
+    %install_license LICENSE*
 patterns   :
     - ^krokiet :
         - /usr/bin/krokiet

--- a/packages/c/czkawka/pspec_x86_64.xml
+++ b/packages/c/czkawka/pspec_x86_64.xml
@@ -4,7 +4,7 @@
         <Homepage>https://github.com/qarmin/czkawka</Homepage>
         <Packager>
             <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>CC-BY-4.0</License>
         <License>MIT</License>
@@ -28,6 +28,8 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/com.github.qarmin.czkawka.Devel.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/com.github.qarmin.czkawka.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/symbolic/apps/com.github.qarmin.czkawka-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/licenses/czkawka/LICENSE_CC_BY_4_ICONS</Path>
+            <Path fileType="data">/usr/share/licenses/czkawka/LICENSE_MIT_EVERYTHING_OUTSIDE_ANY_CARGO_APP_LIBRARY</Path>
             <Path fileType="data">/usr/share/metainfo/com.github.qarmin.czkawka.metainfo.xml</Path>
         </Files>
     </Package>
@@ -44,12 +46,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2026-02-22</Date>
-            <Version>11.0.1</Version>
+        <Update release="12">
+            <Date>2026-07-11</Date>
+            <Version>12.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Version 12.0 is the last released version of Czkawka GTK. No new binaries will be provided from this point on. All users are encouraged to migrate to Krokiet, the new Slint-based GUI frontend

[Changelog](https://github.com/qarmin/czkawka/blob/12.0.0/Changelog.md)

**Test Plan**

<!-- Short description of how the package was tested -->
Launch app

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
