### PR TITLE
wireshark: Update to 4.6.7

### DIFF
--- a/packages/w/wireshark/abi_symbols
+++ b/packages/w/wireshark/abi_symbols
@@ -3299,7 +3299,6 @@ randpkt:ws_optind
 randpkt:ws_optopt
 randpktdump:ws_optarg
 randpktdump:ws_optind
-rawshark:_IO_stdin_used
 rawshark:stderr
 rawshark:stdout
 rawshark:ws_optarg
@@ -3312,7 +3311,6 @@ sbc.so:plugin_register
 sbc.so:plugin_version
 sbc.so:plugin_want_major
 sbc.so:plugin_want_minor
-sdjournal:_IO_stdin_used
 sdjournal:ws_optarg
 sdjournal:ws_opterr
 sdjournal:ws_optind
@@ -3367,7 +3365,6 @@ transum.so:plugin_register
 transum.so:plugin_version
 transum.so:plugin_want_major
 transum.so:plugin_want_minor
-tshark:_IO_stdin_used
 tshark:expert_group_vals
 tshark:g_ascii_table
 tshark:gbl_resolv_flags
@@ -3417,5 +3414,4 @@ wimaxmacphy.so:plugin_register
 wimaxmacphy.so:plugin_version
 wimaxmacphy.so:plugin_want_major
 wimaxmacphy.so:plugin_want_minor
-wireshark:_IO_stdin_used
 wireshark:main

--- a/packages/w/wireshark/abi_used_symbols
+++ b/packages/w/wireshark/abi_used_symbols
@@ -103,7 +103,7 @@ libQt6Core.so.6:_ZN11QTextStreamlsEy
 libQt6Core.so.6:_ZN11QThreadPool11waitForDoneE14QDeadlineTimer
 libQt6Core.so.6:_ZN11QThreadPool14globalInstanceEv
 libQt6Core.so.6:_ZN11QThreadPool5startEP9QRunnablei
-libQt6Core.so.6:_ZN11QTranslator4loadERK7QStringS2_S2_S2_
+libQt6Core.so.6:_ZN11QTranslator4loadERK7QLocaleRK7QStringS5_S5_S5_
 libQt6Core.so.6:_ZN11QTranslatorC1EP7QObject
 libQt6Core.so.6:_ZN11QTranslatorD1Ev
 libQt6Core.so.6:_ZN12QEasingCurveC1ENS_4TypeE

--- a/packages/w/wireshark/package.yml
+++ b/packages/w/wireshark/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : wireshark
-version    : 4.6.6
-release    : 104
+version    : 4.6.7
+release    : 105
 source     :
-    - https://gitlab.com/wireshark/wireshark/-/archive/v4.6.6/wireshark-v4.6.6.tar.gz : c9a7f7ab4fab1624781b4df9bd89d724f2d8632d19c69663c42e03830d341b52
+    - https://gitlab.com/wireshark/wireshark/-/archive/v4.6.7/wireshark-v4.6.7.tar.gz : fcd09518b4b5a1fb799c084e8cede9d4ed85b78eccee879e463da15072508914
 homepage   : https://www.wireshark.org/
 license    :
     - GPL-2.0-or-later
@@ -42,6 +42,7 @@ rundeps    :
     - qt6-multimedia
     - qt6-svg
 setup      : |
+    export CFLAGS="${CFLAGS} -Wno-error=incompatible-pointer-types"
     %cmake_ninja -D BUILD_tfshark=ON
 build      : |
     %ninja_build

--- a/packages/w/wireshark/pspec_x86_64.xml
+++ b/packages/w/wireshark/pspec_x86_64.xml
@@ -38,10 +38,10 @@
             <Path fileType="executable">/usr/bin/wireshark</Path>
             <Path fileType="library">/usr/lib64/libwireshark.so</Path>
             <Path fileType="library">/usr/lib64/libwireshark.so.19</Path>
-            <Path fileType="library">/usr/lib64/libwireshark.so.19.0.6</Path>
+            <Path fileType="library">/usr/lib64/libwireshark.so.19.0.7</Path>
             <Path fileType="library">/usr/lib64/libwiretap.so</Path>
             <Path fileType="library">/usr/lib64/libwiretap.so.16</Path>
-            <Path fileType="library">/usr/lib64/libwiretap.so.16.0.6</Path>
+            <Path fileType="library">/usr/lib64/libwiretap.so.16.0.7</Path>
             <Path fileType="library">/usr/lib64/libwsutil.so</Path>
             <Path fileType="library">/usr/lib64/libwsutil.so.17</Path>
             <Path fileType="library">/usr/lib64/libwsutil.so.17.0.0</Path>
@@ -465,9 +465,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="104">
-            <Date>2026-06-01</Date>
-            <Version>4.6.6</Version>
+        <Update release="105">
+            <Date>2026-07-12</Date>
+            <Version>4.6.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**
- [Change Log](https://www.wireshark.org/docs/relnotes/wireshark-4.6.7.html)

**Security**
- wnpa-sec-2026-52
- wnpa-sec-2026-53
- wnpa-sec-2026-54
- wnpa-sec-2026-55
- wnpa-sec-2026-56
- wnpa-sec-2026-57
- wnpa-sec-2026-58
- wnpa-sec-2026-59
- wnpa-sec-2026-60
- wnpa-sec-2026-61
- wnpa-sec-2026-62
- wnpa-sec-2026-63

**Test Plan**
- Install, open wireshark, test basic funcitons

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
