### PR TITLE
broot: Update to v1.58.0

### DIFF
--- a/packages/b/broot/package.yml
+++ b/packages/b/broot/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : broot
-version    : 1.57.0
-release    : 35
+version    : 1.58.0
+release    : 36
 source     :
-    - https://github.com/Canop/broot/archive/refs/tags/v1.57.0.tar.gz : 28d576f218a92bbb3543124296fb24b40a323b21f586017d073155c44f1cb786
+    - https://github.com/Canop/broot/archive/refs/tags/v1.58.0.tar.gz : 2e61f7cddafa39417ff1484d24773190c6a472975a400204d901080a6335a652
 homepage   : https://dystroy.org/broot/
 license    : MIT
 component  : system.utils

--- a/packages/b/broot/pspec_x86_64.xml
+++ b/packages/b/broot/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2026-06-01</Date>
-            <Version>1.57.0</Version>
+        <Update release="36">
+            <Date>2026-07-10</Date>
+            <Version>1.58.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Canop/broot/releases/tag/v1.58.0).

**Test Plan**

Went around file system. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
