### PR TITLE
python-setuptools: Update to v83.0.0

### DIFF
--- a/packages/py/python-setuptools/package.yml
+++ b/packages/py/python-setuptools/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 # NOTE: Also update python-types-setuptools when updating this package.
 name       : python-setuptools
-version    : 82.0.1
-release    : 27
+version    : 83.0.0
+release    : 28
 source     :
-    - https://pypi.debian.net/setuptools/setuptools-82.0.1.tar.gz : 7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9
+    - https://pypi.debian.net/setuptools/setuptools-83.0.0.tar.gz : 025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef
 homepage   : https://github.com/pypa/setuptools
 license    : MIT
 component  : programming.python

--- a/packages/py/python-setuptools/pspec_x86_64.xml
+++ b/packages/py/python-setuptools/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-setuptools</Name>
         <Homepage>https://github.com/pypa/setuptools</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -27,12 +27,12 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/_distutils_hack/__pycache__/override.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/_distutils_hack/override.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/distutils-precedence.pth</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-82.0.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-82.0.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-82.0.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-82.0.1.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-82.0.1.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-82.0.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-83.0.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-83.0.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-83.0.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-83.0.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-83.0.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-83.0.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/__pycache__/__init__.cpython-314.pyc</Path>
@@ -251,6 +251,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/compilers/C/cygwin.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/compilers/C/errors.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/compilers/C/msvc.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/compilers/C/py.typed</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/compilers/C/tests/__pycache__/test_base.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/compilers/C/tests/__pycache__/test_base.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/compilers/C/tests/__pycache__/test_cygwin.cpython-314.opt-1.pyc</Path>
@@ -280,6 +281,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/file_util.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/filelist.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/log.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/py.typed</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/spawn.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/sysconfig.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools/_distutils/tests/__init__.py</Path>
@@ -1100,12 +1102,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2026-06-05</Date>
-            <Version>82.0.1</Version>
+        <Update release="28">
+            <Date>2026-07-13</Date>
+            <Version>83.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/py/python-types-setuptools/package.yml
+++ b/packages/py/python-types-setuptools/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-types-setuptools
-version    : 82.0.0.20260408
-release    : 2
+version    : 83.0.0.20260706
+release    : 3
 source     :
-    - https://pypi.python.org/packages/source/t/types-setuptools/types_setuptools-82.0.0.20260408.tar.gz : 036c68caf7e672a699f5ebbf914708d40644c14e05298bc49f7272be91cf43d3
+    - https://pypi.python.org/packages/source/t/types-setuptools/types_setuptools-83.0.0.20260706.tar.gz : 9e586ac6c1eb504d28b5f06aced1d705e0043839413219ee3c08d16625fbb4ff
 homepage   : https://github.com/python/typeshed
 license    : Apache-2.0
 component  : programming.python

--- a/packages/py/python-types-setuptools/pspec_x86_64.xml
+++ b/packages/py/python-types-setuptools/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-types-setuptools</Name>
         <Homepage>https://github.com/python/typeshed</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -146,20 +146,20 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-stubs/warnings.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-stubs/wheel.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/setuptools-stubs/windows_support.pyi</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/types_setuptools-82.0.0.20260408.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/types_setuptools-82.0.0.20260408.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/types_setuptools-82.0.0.20260408.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/types_setuptools-82.0.0.20260408.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/types_setuptools-82.0.0.20260408.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/types_setuptools-83.0.0.20260706.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/types_setuptools-83.0.0.20260706.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/types_setuptools-83.0.0.20260706.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/types_setuptools-83.0.0.20260706.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/types_setuptools-83.0.0.20260706.dist-info/top_level.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2026-06-05</Date>
-            <Version>82.0.0.20260408</Version>
+        <Update release="3">
+            <Date>2026-07-15</Date>
+            <Version>83.0.0.20260706</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes for `python-setuptools` can be found [here](https://setuptools.pypa.io/en/stable/history.html).
- Release notes for `python-types-setuptools` can be found [here](https://setuptools.pypa.io/en/stable/history.html).

**Security**
Includes fixes for:
- CVE-2026-59890

**Test Plan**

Smoke test the version. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
