### PR TITLE
python-httplib2: Update to v0.32.0

### DIFF
--- a/packages/py/python-httplib2/package.yml
+++ b/packages/py/python-httplib2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-httplib2
-version    : 0.22.0
-release    : 13
+version    : 0.32.0
+release    : 14
 source     :
-    - https://github.com/httplib2/httplib2/archive/refs/tags/v0.22.0.tar.gz : f0463bc04d2546325eaba1da15f8e45763ed2a52b47c0331c721f1c85470c9ca
+    - https://github.com/httplib2/httplib2/archive/refs/tags/v0.32.0.tar.gz : 14e842d2041ae3cf11f2e82f1b3454e0283050cc38599ed87d116e005097e470
 homepage   : https://github.com/httplib2/httplib2
 license    : MIT
 component  : programming.python

--- a/packages/py/python-httplib2/pspec_x86_64.xml
+++ b/packages/py/python-httplib2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-httplib2</Name>
         <Homepage>https://github.com/httplib2/httplib2</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2-0.22.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2-0.22.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2-0.22.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2-0.22.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2-0.22.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2-0.32.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2-0.32.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2-0.32.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2-0.32.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2-0.32.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/__init__.cpython-314.pyc</Path>
@@ -32,27 +32,27 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/auth.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/certs.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/certs.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/decode.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/decode.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/error.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/error.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/iri2uri.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/iri2uri.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/socks.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/__pycache__/socks.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/auth.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/cacerts.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/certs.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/decode.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/error.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/iri2uri.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/httplib2/socks.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-06-06</Date>
-            <Version>0.22.0</Version>
+        <Update release="14">
+            <Date>2026-07-13</Date>
+            <Version>0.32.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/httplib2/httplib2/blob/master/CHANGELOG).

**Security**
Includes fixes for:
- CVE-2026-59939

**Test Plan**

Smoke test the version. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
