### PR TITLE
openvpn: Update to v2.7.5

### DIFF
--- a/packages/o/openvpn/abi_libs
+++ b/packages/o/openvpn/abi_libs
@@ -1,3 +1,2 @@
-openvpn
 openvpn-plugin-auth-pam.so
 openvpn-plugin-down-root.so

--- a/packages/o/openvpn/abi_symbols
+++ b/packages/o/openvpn/abi_symbols
@@ -1,4 +1,3 @@
-openvpn:_IO_stdin_used
 openvpn-plugin-auth-pam.so:openvpn_plugin_abort_v1
 openvpn-plugin-auth-pam.so:openvpn_plugin_close_v1
 openvpn-plugin-auth-pam.so:openvpn_plugin_func_v1

--- a/packages/o/openvpn/package.yml
+++ b/packages/o/openvpn/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openvpn
-version    : 2.7.2
-release    : 40
+version    : 2.7.5
+release    : 41
 source     :
-    - https://github.com/OpenVPN/openvpn/archive/v2.7.2.tar.gz : a65cdcb2c4d911fab73daf13a4cf109dc9664e28c094f77aafcd39c7e9d5023e
+    - https://github.com/OpenVPN/openvpn/archive/v2.7.5.tar.gz : ef91ff9a6b2ed360931d6b96899f6039e18fc708915ba8094771657a136dae1c
 homepage   : https://openvpn.net/community/
 license    :
     - GPL-2.0-only

--- a/packages/o/openvpn/pspec_x86_64.xml
+++ b/packages/o/openvpn/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>openvpn</Name>
         <Homepage>https://openvpn.net/community/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>BSD-4-Clause</License>
@@ -43,7 +43,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="40">openvpn</Dependency>
+            <Dependency release="41">openvpn</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openvpn-msg.h</Path>
@@ -51,12 +51,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2026-04-23</Date>
-            <Version>2.7.2</Version>
+        <Update release="41">
+            <Date>2026-07-15</Date>
+            <Version>2.7.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://community.openvpn.net/ReleaseHistory#openvpn-275-released-1-july-2026).

**Security**
Includes fixes for:
- CVE-2026-13379
- CVE-2026-12996
- CVE-2026-13117
- CVE-2026-13122
- CVE-2026-12932
- CVE-2026-11771
- CVE-2026-13698

**Test Plan**

Passed self-tests

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
