### PR TITLE
ripgrep: Update to v15.2.0

### DIFF
--- a/packages/r/ripgrep/abi_used_symbols
+++ b/packages/r/ripgrep/abi_used_symbols
@@ -9,11 +9,13 @@ libc.so.6:calloc
 libc.so.6:chdir
 libc.so.6:chroot
 libc.so.6:clock_gettime
+libc.so.6:clock_nanosleep
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:dirfd
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
+libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:execvp
@@ -31,9 +33,11 @@ libc.so.6:getpid
 libc.so.6:getpwuid_r
 libc.so.6:getuid
 libc.so.6:gnu_get_libc_version
+libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:lseek64
 libc.so.6:lstat64
+libc.so.6:madvise
 libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
@@ -42,7 +46,6 @@ libc.so.6:memset
 libc.so.6:mmap64
 libc.so.6:mprotect
 libc.so.6:munmap
-libc.so.6:nanosleep
 libc.so.6:open64
 libc.so.6:opendir
 libc.so.6:pause
@@ -85,6 +88,7 @@ libc.so.6:sendmsg
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
+libc.so.6:setsid
 libc.so.6:setuid
 libc.so.6:sigaction
 libc.so.6:sigaddset

--- a/packages/r/ripgrep/package.yml
+++ b/packages/r/ripgrep/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ripgrep
-version    : 15.1.0
-release    : 20
+version    : 15.2.0
+release    : 21
 source     :
-    - https://github.com/BurntSushi/ripgrep/archive/refs/tags/15.1.0.tar.gz : 046fa01a216793b8bd2750f9d68d4ad43986eb9c0d6122600f993906012972e8
+    - https://github.com/BurntSushi/ripgrep/archive/refs/tags/15.2.0.tar.gz : 7605249d3eb0d5f170e3414498e3344e26b1e7a147aec518b57090b80036a562
 homepage   : https://github.com/BurntSushi/ripgrep
 license    : MIT
 component  : programming.tools
@@ -21,6 +21,7 @@ build      : |
     %cargo_build --features 'pcre2'
 install    : |
     %cargo_install rg
+    %install_license LICENSE-MIT COPYING UNLICENSE
 
     # Generate completions
     install -dm00644 $installdir/usr/share/zsh/site-functions

--- a/packages/r/ripgrep/pspec_x86_64.xml
+++ b/packages/r/ripgrep/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ripgrep</Name>
         <Homepage>https://github.com/BurntSushi/ripgrep</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
@@ -23,17 +23,20 @@
             <Path fileType="executable">/usr/bin/rg</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/rg</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/rg.fish</Path>
+            <Path fileType="data">/usr/share/licenses/ripgrep/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/ripgrep/LICENSE-MIT</Path>
+            <Path fileType="data">/usr/share/licenses/ripgrep/UNLICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/rg.1.zst</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_rg</Path>
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-10-23</Date>
-            <Version>15.1.0</Version>
+        <Update release="21">
+            <Date>2026-07-15</Date>
+            <Version>15.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/BurntSushi/ripgrep/releases/tag/15.2.0).

**Test Plan**

`rg` some stuff.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
