### PR TITLE
dua-cli: Update to v2.38.0

### DIFF
--- a/packages/d/dua-cli/package.yml
+++ b/packages/d/dua-cli/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dua-cli
-version    : 2.37.1
-release    : 5
+version    : 2.38.0
+release    : 6
 source     :
-    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.37.1.tar.gz : 309194f35a6cabe8a91046641680862cbe1e1379f55c88c94337b541ce987969
+    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.38.0.tar.gz : 3972a34ffaaeb3c24d0693e13386a4578530333789b467c83f1686584f314291
 homepage   : https://github.com/Byron/dua-cli
 license    : MIT
 component  : system.utils

--- a/packages/d/dua-cli/pspec_x86_64.xml
+++ b/packages/d/dua-cli/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-06-29</Date>
-            <Version>2.37.1</Version>
+        <Update release="6">
+            <Date>2026-07-15</Date>
+            <Version>2.38.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Byron/dua-cli/releases/tag/v2.38.0).

**Test Plan**

Saw file sizes and went around folders using `dua i`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
