### PR TITLE
netbird: Update to v0.74.6

### DIFF
--- a/packages/n/netbird/package.yml
+++ b/packages/n/netbird/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : netbird
-version    : 0.71.4
-release    : 1
+version    : 0.74.6
+release    : 2
 source     :
-    - https://github.com/netbirdio/netbird/archive/refs/tags/v0.71.4.tar.gz : 91b1977e177a40c2fec6f13ebb7e102b0abd8734569bdb211eed21f3ac8f14db
+    - https://github.com/netbirdio/netbird/archive/refs/tags/v0.74.6.tar.gz : 5411df9359174be55f4cb6aab48ee4d0a51bea27a7cd36c8dcf3615e3848d7cd
 homepage   : https://netbird.io/
 license    :
     - BSD-3-Clause
@@ -21,12 +21,9 @@ builddeps  :
     - pkgconfig(xkbcommon)
     - golang
 networking : true
-patterns  :
-    - ui:
-        - /usr/bin/netbird-ui
-        - /usr/share/applications
-        - /usr/share/icons
-        - /usr/share/metainfo
+rundeps    :
+    - ui :
+        - netbird
 build      : |
     pushd client
     go build
@@ -52,3 +49,9 @@ install    : |
     ${workdir}/client/client completion bash | install -Dm00644 /dev/stdin ${installdir}/usr/share/bash-completion/completions/netbird
     ${workdir}/client/client completion zsh | install -Dm00644 /dev/stdin ${installdir}/usr/share/zsh/site-functions/_netbird
     ${workdir}/client/client completion fish | install -Dm00644 /dev/stdin ${installdir}/usr/share/fish/vendor_completions.d/netbird.fish
+patterns   :
+    - ui :
+        - /usr/bin/netbird-ui
+        - /usr/share/applications
+        - /usr/share/icons
+        - /usr/share/metainfo

--- a/packages/n/netbird/pspec_x86_64.xml
+++ b/packages/n/netbird/pspec_x86_64.xml
@@ -3,7 +3,7 @@
         <Name>netbird</Name>
         <Homepage>https://netbird.io/</Homepage>
         <Packager>
-            <Name>Hans Kelson</Name>
+            <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
@@ -37,6 +37,9 @@
         <Summary xml:lang="en">Configuration-free peer-to-peer private network</Summary>
         <Description xml:lang="en">NetBird combines a configuration-free peer-to-peer private network and a centralized access control system in a single platform, making it easy to create secure private networks for your organization or home.
 </Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="2">netbird</Dependency>
+        </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/netbird-ui</Path>
             <Path fileType="data">/usr/share/applications/io.netbird.netbird_ui.desktop</Path>
@@ -45,11 +48,11 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2026-06-24</Date>
-            <Version>0.71.4</Version>
+        <Update release="2">
+            <Date>2026-07-16</Date>
+            <Version>0.74.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hans Kelson</Name>
+            <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/netbirdio/netbird/releases/tag/v0.74.6).
- Also resolves an unreported issue where `netbird-ui` did not depend on `netbird`.

**Test Plan**
- Build and install `netbird` and `netbird-ui` from this PR.
- Try it.
- See that it works.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
