### PR TITLE
docker security updates

### DIFF
--- a/packages/b/buildkit/package.yml
+++ b/packages/b/buildkit/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : buildkit
-version    : 0.31.1
-release    : 11
+version    : 0.31.2
+release    : 12
 source     :
-    - https://github.com/moby/buildkit/archive/refs/tags/v0.31.1.tar.gz : b733b9243017cb2b8f9cb1a6bd5125a2bde5680d4063412dbc159402bffbaf1e
+    - https://github.com/moby/buildkit/archive/refs/tags/v0.31.2.tar.gz : 3085082772044c5cf0431d969603618ff7519d6c82dc1fe19ae83803d8973aa1
 homepage   : https://github.com/moby/buildkit
 license    : Apache-2.0
 component  : virt

--- a/packages/b/buildkit/pspec_x86_64.xml
+++ b/packages/b/buildkit/pspec_x86_64.xml
@@ -30,9 +30,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2026-06-29</Date>
-            <Version>0.31.1</Version>
+        <Update release="12">
+            <Date>2026-07-16</Date>
+            <Version>0.31.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/d/docker/package.yml
+++ b/packages/d/docker/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker
-version    : 29.6.1
-release    : 78
+version    : 29.6.2
+release    : 79
 source     :
-    - https://github.com/docker/cli/archive/refs/tags/v29.6.1.tar.gz : 74d14dd212b07cd3328989dc6a029dde2ebbe6a878199eaaafad54916f456194
+    - https://github.com/docker/cli/archive/refs/tags/v29.6.2.tar.gz : 11aef3484c38d39d291a54a73a4d9dd2bb3c000d9a3fc3862bd03fe899594f2c
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt

--- a/packages/d/docker/pspec_x86_64.xml
+++ b/packages/d/docker/pspec_x86_64.xml
@@ -218,9 +218,9 @@ Docker containers are both hardware-agnostic and platform-agnostic. This means t
         </Files>
     </Package>
     <History>
-        <Update release="78">
-            <Date>2026-06-29</Date>
-            <Version>29.6.1</Version>
+        <Update release="79">
+            <Date>2026-07-16</Date>
+            <Version>29.6.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/m/moby/package.yml
+++ b/packages/m/moby/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : moby
-version    : 29.6.1
-release    : 34
+version    : 29.6.2
+release    : 35
 source     :
-    - https://github.com/moby/moby/archive/refs/tags/docker-v29.6.1.tar.gz : a97bd870c4b072b7d9cc053b2a806ca3d920f192f9dc6a662e17c1b69f56f2e1
+    - https://github.com/moby/moby/archive/refs/tags/docker-v29.6.2.tar.gz : 8b64afb7562347d2ce9f1027e326ce9a45c8f41a486106ce2034f7eb1abe0e0f
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt

--- a/packages/m/moby/pspec_x86_64.xml
+++ b/packages/m/moby/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2026-06-29</Date>
-            <Version>29.6.1</Version>
+        <Update release="35">
+            <Date>2026-07-16</Date>
+            <Version>29.6.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/moby/buildkit/releases/tag/v0.31.2).

**Security**
Includes fixes for:
- CVE-2026-15793
- CVE-2026-15792
- CVE-2026-15791
- CVE-2026-15789
- CVE-2026-15788

**Test Plan**

Run docker container. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
