### PR TITLE
fsearch: Update to v0.3.1

### DIFF
--- a/packages/f/fsearch/abi_used_symbols
+++ b/packages/f/fsearch/abi_used_symbols
@@ -150,6 +150,8 @@ libgio-2.0.so.0:g_file_info_get_icon
 libgio-2.0.so.0:g_file_new_build_filename
 libgio-2.0.so.0:g_file_new_for_path
 libgio-2.0.so.0:g_file_query_info
+libgio-2.0.so.0:g_file_query_info_async
+libgio-2.0.so.0:g_file_query_info_finish
 libgio-2.0.so.0:g_file_trash
 libgio-2.0.so.0:g_icon_equal
 libgio-2.0.so.0:g_icon_hash

--- a/packages/f/fsearch/package.yml
+++ b/packages/f/fsearch/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fsearch
-version    : '0.3'
-release    : 15
+version    : 0.3.1
+release    : 16
 source     :
-    - https://github.com/cboxdoerfer/fsearch/archive/refs/tags/0.3.tar.gz : 17e9bb26f0c6077192dc1f40800c5c2e6074d93ef0e7f95b42180eb6b143b556
+    - https://github.com/cboxdoerfer/fsearch/archive/refs/tags/0.3.1.tar.gz : b16ab75556d841bf858633710d71c92f35d34362614b8584b0a5b71690a72c39
 homepage   : https://github.com/cboxdoerfer/fsearch
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/f/fsearch/pspec_x86_64.xml
+++ b/packages/f/fsearch/pspec_x86_64.xml
@@ -34,7 +34,6 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/io.github.cboxdoerfer.FSearch.svg</Path>
             <Path fileType="data">/usr/share/licenses/fsearch/LICENSE</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/fsearch.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/ber/LC_MESSAGES/fsearch.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/fsearch.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/fsearch.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/fsearch.mo</Path>
@@ -81,9 +80,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2026-07-15</Date>
-            <Version>0.3</Version>
+        <Update release="16">
+            <Date>2026-07-17</Date>
+            <Version>0.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/cboxdoerfer/fsearch/releases/tag/0.3.1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open FSearch, search for a package.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
