### PR TITLE
wayland: Update to 1.26.0

### DIFF
--- a/packages/w/wayland/abi_symbols
+++ b/packages/w/wayland/abi_symbols
@@ -17,8 +17,10 @@ libwayland-client.so.0:wl_display_create_queue_with_name
 libwayland-client.so.0:wl_display_disconnect
 libwayland-client.so.0:wl_display_dispatch
 libwayland-client.so.0:wl_display_dispatch_pending
+libwayland-client.so.0:wl_display_dispatch_pending_single
 libwayland-client.so.0:wl_display_dispatch_queue
 libwayland-client.so.0:wl_display_dispatch_queue_pending
+libwayland-client.so.0:wl_display_dispatch_queue_pending_single
 libwayland-client.so.0:wl_display_dispatch_queue_timeout
 libwayland-client.so.0:wl_display_dispatch_timeout
 libwayland-client.so.0:wl_display_flush
@@ -146,6 +148,7 @@ libwayland-server.so.0:wl_display_init_shm
 libwayland-server.so.0:wl_display_interface
 libwayland-server.so.0:wl_display_next_serial
 libwayland-server.so.0:wl_display_remove_global
+libwayland-server.so.0:wl_display_remove_socket_fd
 libwayland-server.so.0:wl_display_run
 libwayland-server.so.0:wl_display_set_default_max_buffer_size
 libwayland-server.so.0:wl_display_set_global_filter
@@ -165,6 +168,7 @@ libwayland-server.so.0:wl_event_source_check
 libwayland-server.so.0:wl_event_source_fd_update
 libwayland-server.so.0:wl_event_source_remove
 libwayland-server.so.0:wl_event_source_timer_update
+libwayland-server.so.0:wl_fixes_handle_ack_global_remove
 libwayland-server.so.0:wl_fixes_interface
 libwayland-server.so.0:wl_global_create
 libwayland-server.so.0:wl_global_destroy
@@ -175,6 +179,7 @@ libwayland-server.so.0:wl_global_get_user_data
 libwayland-server.so.0:wl_global_get_version
 libwayland-server.so.0:wl_global_remove
 libwayland-server.so.0:wl_global_set_user_data
+libwayland-server.so.0:wl_global_set_withdrawn_listener
 libwayland-server.so.0:wl_keyboard_interface
 libwayland-server.so.0:wl_list_empty
 libwayland-server.so.0:wl_list_init

--- a/packages/w/wayland/abi_symbols32
+++ b/packages/w/wayland/abi_symbols32
@@ -17,8 +17,10 @@ libwayland-client.so.0:wl_display_create_queue_with_name
 libwayland-client.so.0:wl_display_disconnect
 libwayland-client.so.0:wl_display_dispatch
 libwayland-client.so.0:wl_display_dispatch_pending
+libwayland-client.so.0:wl_display_dispatch_pending_single
 libwayland-client.so.0:wl_display_dispatch_queue
 libwayland-client.so.0:wl_display_dispatch_queue_pending
+libwayland-client.so.0:wl_display_dispatch_queue_pending_single
 libwayland-client.so.0:wl_display_dispatch_queue_timeout
 libwayland-client.so.0:wl_display_dispatch_timeout
 libwayland-client.so.0:wl_display_flush
@@ -146,6 +148,7 @@ libwayland-server.so.0:wl_display_init_shm
 libwayland-server.so.0:wl_display_interface
 libwayland-server.so.0:wl_display_next_serial
 libwayland-server.so.0:wl_display_remove_global
+libwayland-server.so.0:wl_display_remove_socket_fd
 libwayland-server.so.0:wl_display_run
 libwayland-server.so.0:wl_display_set_default_max_buffer_size
 libwayland-server.so.0:wl_display_set_global_filter
@@ -165,6 +168,7 @@ libwayland-server.so.0:wl_event_source_check
 libwayland-server.so.0:wl_event_source_fd_update
 libwayland-server.so.0:wl_event_source_remove
 libwayland-server.so.0:wl_event_source_timer_update
+libwayland-server.so.0:wl_fixes_handle_ack_global_remove
 libwayland-server.so.0:wl_fixes_interface
 libwayland-server.so.0:wl_global_create
 libwayland-server.so.0:wl_global_destroy
@@ -175,6 +179,7 @@ libwayland-server.so.0:wl_global_get_user_data
 libwayland-server.so.0:wl_global_get_version
 libwayland-server.so.0:wl_global_remove
 libwayland-server.so.0:wl_global_set_user_data
+libwayland-server.so.0:wl_global_set_withdrawn_listener
 libwayland-server.so.0:wl_keyboard_interface
 libwayland-server.so.0:wl_list_empty
 libwayland-server.so.0:wl_list_init

--- a/packages/w/wayland/abi_used_symbols
+++ b/packages/w/wayland/abi_used_symbols
@@ -41,10 +41,13 @@ libc.so.6:ftruncate64
 libc.so.6:getenv
 libc.so.6:getopt_long
 libc.so.6:getsockopt
+libc.so.6:gettid
+libc.so.6:isatty
 libc.so.6:listen
 libc.so.6:lseek64
 libc.so.6:lstat64
 libc.so.6:malloc
+libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memfd_create
 libc.so.6:memset
@@ -92,7 +95,6 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strndup
-libc.so.6:strstr
 libc.so.6:strtol
 libc.so.6:timerfd_create
 libc.so.6:timerfd_settime

--- a/packages/w/wayland/abi_used_symbols32
+++ b/packages/w/wayland/abi_used_symbols32
@@ -24,6 +24,7 @@ libc.so.6:epoll_wait
 libc.so.6:eventfd
 libc.so.6:fclose
 libc.so.6:fcntl64
+libc.so.6:fileno
 libc.so.6:flock
 libc.so.6:fopen64
 libc.so.6:fread
@@ -33,9 +34,12 @@ libc.so.6:fstat64
 libc.so.6:ftruncate64
 libc.so.6:getenv
 libc.so.6:getsockopt
+libc.so.6:gettid
+libc.so.6:isatty
 libc.so.6:listen
 libc.so.6:lstat64
 libc.so.6:malloc
+libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memfd_create
 libc.so.6:mkostemp64
@@ -76,7 +80,6 @@ libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
-libc.so.6:strstr
 libc.so.6:timerfd_create
 libc.so.6:timerfd_settime
 libc.so.6:unlink

--- a/packages/w/wayland/package.yml
+++ b/packages/w/wayland/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : wayland
-version    : 1.25.0
-release    : 35
+version    : 1.26.0
+release    : 36
 source     :
-    - https://gitlab.freedesktop.org/wayland/wayland/-/archive/1.24.0/wayland-1.24.0.tar.gz : 7800858844751fc7113d7df3678dc6b58b26a056176a65c49a059763045bffd5
+    - https://gitlab.freedesktop.org/wayland/wayland/-/archive/1.26.0/wayland-1.26.0.tar.gz : 56b3a985cbfe17a926e3bcf037e4d374f44eaa33f3a4b364549dddf0d324cebc
 homepage   : https://wayland.freedesktop.org/
 license    :
     - MIT
@@ -24,6 +24,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 patterns   :
     - devel :
         - /usr/bin

--- a/packages/w/wayland/pspec_x86_64.xml
+++ b/packages/w/wayland/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wayland</Name>
         <Homepage>https://wayland.freedesktop.org/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.wayland</PartOf>
@@ -21,13 +21,14 @@
         <PartOf>desktop.wayland</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libwayland-client.so.0</Path>
-            <Path fileType="library">/usr/lib64/libwayland-client.so.0.24.0</Path>
+            <Path fileType="library">/usr/lib64/libwayland-client.so.0.26.0</Path>
             <Path fileType="library">/usr/lib64/libwayland-cursor.so.0</Path>
-            <Path fileType="library">/usr/lib64/libwayland-cursor.so.0.24.0</Path>
+            <Path fileType="library">/usr/lib64/libwayland-cursor.so.0.26.0</Path>
             <Path fileType="library">/usr/lib64/libwayland-egl.so.1</Path>
-            <Path fileType="library">/usr/lib64/libwayland-egl.so.1.24.0</Path>
+            <Path fileType="library">/usr/lib64/libwayland-egl.so.1.26.0</Path>
             <Path fileType="library">/usr/lib64/libwayland-server.so.0</Path>
-            <Path fileType="library">/usr/lib64/libwayland-server.so.0.24.0</Path>
+            <Path fileType="library">/usr/lib64/libwayland-server.so.0.26.0</Path>
+            <Path fileType="data">/usr/share/licenses/wayland/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -37,17 +38,17 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">wayland</Dependency>
+            <Dependency release="36">wayland</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libwayland-client.so.0</Path>
-            <Path fileType="library">/usr/lib32/libwayland-client.so.0.24.0</Path>
+            <Path fileType="library">/usr/lib32/libwayland-client.so.0.26.0</Path>
             <Path fileType="library">/usr/lib32/libwayland-cursor.so.0</Path>
-            <Path fileType="library">/usr/lib32/libwayland-cursor.so.0.24.0</Path>
+            <Path fileType="library">/usr/lib32/libwayland-cursor.so.0.26.0</Path>
             <Path fileType="library">/usr/lib32/libwayland-egl.so.1</Path>
-            <Path fileType="library">/usr/lib32/libwayland-egl.so.1.24.0</Path>
+            <Path fileType="library">/usr/lib32/libwayland-egl.so.1.26.0</Path>
             <Path fileType="library">/usr/lib32/libwayland-server.so.0</Path>
-            <Path fileType="library">/usr/lib32/libwayland-server.so.0.24.0</Path>
+            <Path fileType="library">/usr/lib32/libwayland-server.so.0.26.0</Path>
         </Files>
     </Package>
     <Package>
@@ -57,8 +58,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">wayland-devel</Dependency>
-            <Dependency release="35">wayland-32bit</Dependency>
+            <Dependency release="36">wayland-32bit</Dependency>
+            <Dependency release="36">wayland-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libwayland-client.so</Path>
@@ -80,7 +81,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">wayland</Dependency>
+            <Dependency release="36">wayland</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wayland-scanner</Path>
@@ -113,12 +114,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2026-03-23</Date>
-            <Version>1.25.0</Version>
+        <Update release="36">
+            <Date>2026-07-19</Date>
+            <Version>1.26.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add License
- Bump to latest
- Current package.yml actually had version set to 1.25.0 but the source was still 1.24.0
- [1.26.0 Change Log](https://lore.freedesktop.org/wayland-devel/5On45eE2mxDczYfK0kAKrM_Bf7fI0NV07MXCBmsfDLplHSIU3cn-8JoaUj6zURfuWVB7pHDaBIPSXKenUGUdQeAZ51wpzMtGf_W-BdLgNC0=@emersion.fr/T/#u)
- [1.25.0 Change Log](https://lore.freedesktop.org/wayland-devel/Xc5mzCaUxqhO0w-Dls241-PmLXWdFT2DLLkz0Lhr4LAhDTZxiZfrDZeq9lCGGn2V8nxqcMZDTn6vSCdClRYkQ7vCUMPKwQokYhCjf93xRx4=@emersion.fr/T/#u)

**Test Plan**
- Install and reboot to make sure everything works
- Check version
- Enable debug and open app
- Check journalctl --user -b -u plasma-kwin_wayland -f

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
