### PR TITLE
libraw: Update to v0.22.2

### DIFF
--- a/packages/l/libraw/abi_symbols
+++ b/packages/l/libraw/abi_symbols
@@ -9,7 +9,7 @@ libraw.so.25:_Z12crxParamInitP8CrxImagePP12CrxBandParammmjjbj
 libraw.so.25:_Z12unsigned_cmpPKvS0_
 libraw.so.25:_Z13crxDecodeLineP12CrxBandParam
 libraw.so.25:_Z13crxDecodeLineP12CrxBandParamPh
-libraw.so.25:_Z13decode_S_typeiPjPt
+libraw.so.25:_Z13decode_S_typeiPjPtm
 libraw.so.25:_Z13sget_fixed32usPh
 libraw.so.25:_Z14ifd_size_t_cmpPKvS0_
 libraw.so.25:_Z15AngleConversionsPh
@@ -20,7 +20,7 @@ libraw.so.25:_Z16crxDecodeTopLineP12CrxBandParam
 libraw.so.25:_Z16crxFreeImageDataP8CrxImage
 libraw.so.25:_Z16init_main_qtableP22fuji_compressed_paramsh
 libraw.so.25:_Z17AngleConversion_asPh
-libraw.so.25:_Z17crxSetupImageDataP17crx_data_header_tP8CrxImagePsllPhi
+libraw.so.25:_Z17crxSetupImageDataP17crx_data_header_tP8CrxImagePsllPhij
 libraw.so.25:_Z18crxDecodeGolombTopP12CrxBitstreamiPiS1_
 libraw.so.25:_Z18crxFreeSubbandDataP8CrxImageP12CrxPlaneComp
 libraw.so.25:_Z18crxProcessSubbandsP17crx_data_header_tP8CrxImageP7CrxTileP12CrxPlaneComp
@@ -644,7 +644,7 @@ libraw_r.so.25:_Z12crxParamInitP8CrxImagePP12CrxBandParammmjjbj
 libraw_r.so.25:_Z12unsigned_cmpPKvS0_
 libraw_r.so.25:_Z13crxDecodeLineP12CrxBandParam
 libraw_r.so.25:_Z13crxDecodeLineP12CrxBandParamPh
-libraw_r.so.25:_Z13decode_S_typeiPjPt
+libraw_r.so.25:_Z13decode_S_typeiPjPtm
 libraw_r.so.25:_Z13sget_fixed32usPh
 libraw_r.so.25:_Z14ifd_size_t_cmpPKvS0_
 libraw_r.so.25:_Z15AngleConversionsPh
@@ -655,7 +655,7 @@ libraw_r.so.25:_Z16crxDecodeTopLineP12CrxBandParam
 libraw_r.so.25:_Z16crxFreeImageDataP8CrxImage
 libraw_r.so.25:_Z16init_main_qtableP22fuji_compressed_paramsh
 libraw_r.so.25:_Z17AngleConversion_asPh
-libraw_r.so.25:_Z17crxSetupImageDataP17crx_data_header_tP8CrxImagePsllPhi
+libraw_r.so.25:_Z17crxSetupImageDataP17crx_data_header_tP8CrxImagePsllPhij
 libraw_r.so.25:_Z18crxDecodeGolombTopP12CrxBitstreamiPiS1_
 libraw_r.so.25:_Z18crxFreeSubbandDataP8CrxImageP12CrxPlaneComp
 libraw_r.so.25:_Z18crxProcessSubbandsP17crx_data_header_tP8CrxImageP7CrxTileP12CrxPlaneComp

--- a/packages/l/libraw/package.yml
+++ b/packages/l/libraw/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libraw
-version    : 0.22.1
-release    : 22
+version    : 0.22.2
+release    : 23
 source     :
-    - https://github.com/LibRaw/LibRaw/archive/refs/tags/0.22.1.tar.gz : e676248284075605aa2697a66eeed7dc258820bd1d4988c724d29edffd726726
+    - https://github.com/LibRaw/LibRaw/archive/refs/tags/0.22.2.tar.gz : 627928088300ecde6ca91ffd202e189203f04ad61ad12f0fe9dc57b9a7a0fb3c
 homepage   : https://www.libraw.org/
 license    :
     - CDDL-1.0
@@ -24,12 +24,16 @@ builddeps  :
     - pkgconfig(jasper)
     - pkgconfig(lcms2)
     - pkgconfig(libturbojpeg)
-patterns   :
-    - utils : /usr/bin
 setup      : |
-    %reconfigure --disable-static --enable-jasper
+    %reconfigure \
+        --disable-static \
+        --enable-jasper
 build      : |
     %make
 install    : |
     %make_install
-    rm -rf $installdir/usr/share
+    %install_license LICENSE* COPYRIGHT
+    # Remove the license files from the share directory.
+    rm -rf ${installdir}/usr/share/doc
+patterns   :
+    - utils : /usr/bin

--- a/packages/l/libraw/pspec_x86_64.xml
+++ b/packages/l/libraw/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libraw</Name>
         <Homepage>https://www.libraw.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>CDDL-1.0</License>
         <License>LGPL-2.1-or-later</License>
@@ -27,6 +27,9 @@
             <Path fileType="library">/usr/lib64/libraw.so.25.0.0</Path>
             <Path fileType="library">/usr/lib64/libraw_r.so.25</Path>
             <Path fileType="library">/usr/lib64/libraw_r.so.25.0.0</Path>
+            <Path fileType="data">/usr/share/licenses/libraw/COPYRIGHT</Path>
+            <Path fileType="data">/usr/share/licenses/libraw/LICENSE.CDDL</Path>
+            <Path fileType="data">/usr/share/licenses/libraw/LICENSE.LGPL</Path>
         </Files>
     </Package>
     <Package>
@@ -35,7 +38,7 @@
         <Description xml:lang="en">LibRaw is a library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others).</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="22">libraw</Dependency>
+            <Dependency release="23">libraw</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libraw/libraw.h</Path>
@@ -57,7 +60,7 @@
         <Description xml:lang="en">Tools for Libraw</Description>
         <PartOf>multimedia.graphics</PartOf>
         <RuntimeDependencies>
-            <Dependency release="22">libraw</Dependency>
+            <Dependency release="23">libraw</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/4channels</Path>
@@ -74,12 +77,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2026-05-12</Date>
-            <Version>0.22.1</Version>
+        <Update release="23">
+            <Date>2026-07-19</Date>
+            <Version>0.22.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.libraw.org/news/libraw-0-22-2-release).

**Security**
Includes fixes for:
- CVE-2026-20884
- CVE-2026-20911
- CVE-2026-21413
- CVE-2026-24450

**Test Plan**

Smoke test the utils with sample raw files. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
