### PR TITLE
Split terminfos and update ncurses

### DIFF
--- a/packages/f/foot/abi_used_libs
+++ b/packages/f/foot/abi_used_libs
@@ -1,4 +1,3 @@
-UNKNOWN
 libc.so.6
 libfcft.so.4
 libfontconfig.so.1

--- a/packages/f/foot/abi_used_symbols
+++ b/packages/f/foot/abi_used_symbols
@@ -1,12 +1,3 @@
-UNKNOWN:ceil
-UNKNOWN:ceilf
-UNKNOWN:floor
-UNKNOWN:floorf
-UNKNOWN:fmax
-UNKNOWN:fmaxf
-UNKNOWN:round
-UNKNOWN:roundf
-UNKNOWN:sqrt
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_get_mb_cur_max
 libc.so.6:__environ
@@ -209,8 +200,13 @@ libfontconfig.so.1:FcPatternDuplicate
 libfontconfig.so.1:FcPatternGetDouble
 libfontconfig.so.1:FcPatternGetInteger
 libfontconfig.so.1:FcPatternRemove
+libm.so.6:fmax
+libm.so.6:fmaxf
 libm.so.6:fmod
 libm.so.6:log10f
+libm.so.6:round
+libm.so.6:roundf
+libm.so.6:sqrt
 libpixman-1.so.0:pixman_composite_trapezoids
 libpixman-1.so.0:pixman_composite_triangles
 libpixman-1.so.0:pixman_f_transform_init_scale

--- a/packages/f/foot/package.yml
+++ b/packages/f/foot/package.yml
@@ -1,61 +1,69 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : foot
 version    : 1.27.0
-release    : 1
+release    : 2
 source     :
-    - https://codeberg.org/dnkl/foot/archive/1.27.0.tar.gz : 4e6131cc859ec6a36569f1978cf3617cc3836a681d13d228ded1b4885dab7770
+    - https://codeberg.org/dnkl/foot/archive/1.27.0.tar.gz : f5917cad2d7b723b99873e53d78fd10ea202923d189aed5086591fc53b70b7e3
 homepage   : https://codeberg.org/dnkl/foot
 license    : MIT
-component  : system.utils
-summary    : Fast, lightweight, and minimalistic Wayland terminal emulator
-description: |
-    foot is a fast, lightweight and minimalistic Wayland terminal emulator. It is Wayland-native, DE-agnostic, and supports features such as server/daemon mode, scrollback search, sixel images, synchronized updates, and on-the-fly font resizing.
+component  :
+    - terminfo : system.base
+    - system.utils
+summary    :
+    - terminfo: Terminfo file for foot
+    - Fast, lightweight, and minimalistic Wayland terminal emulator
+description:
+    - terminfo : Terminfo for foot, split out so that it can be used from ncurses
+    - |
+      foot is a fast, lightweight and minimalistic Wayland terminal emulator. It is Wayland-native, DE-agnostic, and supports features such as server/daemon mode, scrollback search, sixel images, synchronized updates, and on-the-fly font resizing.
 
-    Launch foot from the application menu or run `foot` in a shell. For server mode, enable the `foot-server` user systemd socket or run `foot --server` and open windows with `footclient`.
+      Launch foot from the application menu or run `foot` in a shell. For server mode, enable the `foot-server` user systemd socket or run `foot --server` and open windows with `footclient`.
 builddeps  :
     - pkgconfig(fcft)
     - pkgconfig(fontconfig)
+    - pkgconfig(freetype2)
     - pkgconfig(libutf8proc)
+    - pkgconfig(ncurses)
     - pkgconfig(pixman-1)
+    - pkgconfig(systemd)
     - pkgconfig(tllist)
     - pkgconfig(wayland-client)
     - pkgconfig(wayland-cursor)
     - pkgconfig(wayland-protocols)
     - pkgconfig(wayland-scanner)
     - pkgconfig(xkbcommon)
-    - dejavu-fonts-ttf
-    - llvm-devel
-    - ncurses
     - scdoc
-    - sway
-    - xorg-xwayland
 rundeps    :
+    - foot-terminfo
     - libnotify
     - libutempter
     - xdg-utils
+optimize   :
+    - lto
+    - speed
+setup      : |
+    %meson_configure
 build      : |
-    export LC_CTYPE=en_US.UTF-8
-    fc-cache -f
-    ./pgo/pgo.sh full-headless-sway . solusBuildDir \
-        -Dterminfo-base-name=foot-extra \
-        --prefix=/usr \
-        --sysconfdir=/usr/share/defaults/etc \
-        --wrap-mode=nodownload
+    %ninja_build
 install    : |
     %ninja_install
 
+    # Stateless
+    # The included config is an example; everything is commented out
+    rm -v ${installdir}/etc/xdg/foot/foot.ini
+    rmdir -v ${installdir}/etc/xdg/foot \
+             ${installdir}/etc/xdg \
+             ${installdir}/etc
+    install -Dm 00644 foot.ini ${installdir}/usr/share/defaults/foot/foot.ini
+
     # Only page.codeberg.dnkl.foot.desktop in the app menu; server-mode users use
     # foot-server.{service,socket} or `foot --server` / `footclient` from the shell
-    rm -f ${installdir}/usr/share/applications/footclient.desktop \
-          ${installdir}/usr/share/applications/foot-server.desktop
+    rm -vf ${installdir}/usr/share/applications/footclient.desktop \
+           ${installdir}/usr/share/applications/foot-server.desktop
 
     # Match the desktop-id naming in the appstream metainfo
     mv ${installdir}/usr/share/applications/foot.desktop \
        ${installdir}/usr/share/applications/page.codeberg.dnkl.foot.desktop
-
-    # Standard foot terminfo ships in ncurses; keep foot-extra for non-standard capabilities
-    rm -rf ${installdir}/usr/share/terminfo/
-    install -Dm00644 solusBuildDir/f/foot-extra* -t ${installdir}/usr/share/terminfo/f/
 
     # Put license in /usr/share/licenses
     rm -f ${installdir}/usr/share/doc/foot/LICENSE
@@ -65,3 +73,6 @@ install    : |
         -t ${installdir}/usr/share/metainfo/
 check      : |
     %ninja_check
+patterns   :
+    - terminfo :
+        - /usr/share/terminfo

--- a/packages/f/foot/pspec_x86_64.xml
+++ b/packages/f/foot/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>foot</Name>
         <Homepage>https://codeberg.org/dnkl/foot</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -23,6 +23,9 @@ Launch foot from the application menu or run `foot` in a shell. For server mode,
 Launch foot from the application menu or run `foot` in a shell. For server mode, enable the `foot-server` user systemd socket or run `foot --server` and open windows with `footclient`.
 </Description>
         <PartOf>system.utils</PartOf>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="2">foot-terminfo</Dependency>
+        </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/foot</Path>
             <Path fileType="executable">/usr/bin/footclient</Path>
@@ -31,7 +34,7 @@ Launch foot from the application menu or run `foot` in a shell. For server mode,
             <Path fileType="data">/usr/share/applications/page.codeberg.dnkl.foot.desktop</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/foot</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/footclient</Path>
-            <Path fileType="data">/usr/share/defaults/etc/xdg/foot/foot.ini</Path>
+            <Path fileType="data">/usr/share/defaults/foot/foot.ini</Path>
             <Path fileType="doc">/usr/share/doc/foot/CHANGELOG.md</Path>
             <Path fileType="doc">/usr/share/doc/foot/README.md</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/foot.fish</Path>
@@ -128,19 +131,27 @@ Launch foot from the application menu or run `foot` in a shell. For server mode,
             <Path fileType="man">/usr/share/man/man5/foot.ini.5.zst</Path>
             <Path fileType="man">/usr/share/man/man7/foot-ctlseqs.7.zst</Path>
             <Path fileType="data">/usr/share/metainfo/page.codeberg.dnkl.foot.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/terminfo/f/foot-extra</Path>
-            <Path fileType="data">/usr/share/terminfo/f/foot-extra-direct</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_foot</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_footclient</Path>
         </Files>
     </Package>
+    <Package>
+        <Name>foot-terminfo</Name>
+        <Summary xml:lang="en">Terminfo file for foot</Summary>
+        <Description xml:lang="en">Terminfo for foot, split out so that it can be used from ncurses</Description>
+        <PartOf>system.base</PartOf>
+        <Files>
+            <Path fileType="data">/usr/share/terminfo/f/foot</Path>
+            <Path fileType="data">/usr/share/terminfo/f/foot-direct</Path>
+        </Files>
+    </Package>
     <History>
-        <Update release="1">
-            <Date>2026-05-18</Date>
+        <Update release="2">
+            <Date>2026-07-19</Date>
             <Version>1.27.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : kitty
 version    : 0.48.0
-release    : 100
+release    : 101
 source     :
     - https://github.com/kovidgoyal/kitty/releases/download/v0.48.0/kitty-0.48.0.tar.xz : ef62a622fd40c3f51f7719a9bc18764b9c5e4e2babcadb7fb95d6c1d8ba68f82
     - https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/NerdFontsSymbolsOnly.tar.xz : 7f8c090da3b0eaa7108646bf34cbbb6ed13d5358a72460522108b06c7ecd716a
@@ -9,12 +9,18 @@ homepage   : https://sw.kovidgoyal.net/kitty/
 license    :
     - GPL-3.0-only
     - MIT
-summary    : A fast and featureful GPU-based terminal emulator
-component  : system.utils
-description: |
-    Kitty is designed for power keyboard users. To that end all its controls work with the keyboard (although it fully supports mouse interactions as well). Its configuration is a simple, human editable, single file for easy reproducibility.
+component  :
+    - terminfo : system.base
+    - system.utils
+summary    :
+    - terminfo: Terminfo for kitty
+    - A fast and featureful GPU-based terminal emulator
+description:
+    - terminfo : Terminfo for kitty, split out so that it can be used from ncurses
+    - |
+      Kitty is designed for power keyboard users. To that end all its controls work with the keyboard (although it fully supports mouse interactions as well). Its configuration is a simple, human editable, single file for easy reproducibility.
 
-    Kitty is designed from the ground up to support all modern terminal features, such as unicode, true color, bold/italic fonts, text formatting, etc. It even extends existing text formatting escape codes, to add support for features not available elsewhere, such as colored and styled (curly) underlines. One of the design goals of Kitty is to be easily extensible so that new features can be added in the future with relatively less effort.
+      Kitty is designed from the ground up to support all modern terminal features, such as unicode, true color, bold/italic fonts, text formatting, etc. It even extends existing text formatting escape codes, to add support for features not available elsewhere, such as colored and styled (curly) underlines. One of the design goals of Kitty is to be easily extensible so that new features can be added in the future with relatively less effort.
 networking : true
 builddeps  :
     - pkgconfig(cairo-fc)
@@ -34,6 +40,7 @@ builddeps  :
     - pkgconfig(xrandr)
     - golang
 rundeps    :
+    - kitty-terminfo
     - libcanberra
     - libpng
     - pygments
@@ -62,3 +69,6 @@ install    : |
 
     # install AppStream metainfo
     install -Dm00644 ${pkgfiles}/net.kovidgoyal.kitty.metainfo.xml -t ${installdir}/usr/share/metainfo
+patterns   :
+    - terminfo :
+        - /usr/share/terminfo

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>kitty</Name>
         <Homepage>https://sw.kovidgoyal.net/kitty/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <License>MIT</License>
@@ -24,6 +24,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
 Kitty is designed from the ground up to support all modern terminal features, such as unicode, true color, bold/italic fonts, text formatting, etc. It even extends existing text formatting escape codes, to add support for features not available elsewhere, such as colored and styled (curly) underlines. One of the design goals of Kitty is to be easily extensible so that new features can be added in the future with relatively less effort.
 </Description>
         <PartOf>system.utils</PartOf>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="101">kitty-terminfo</Dependency>
+        </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/kitten</Path>
             <Path fileType="executable">/usr/bin/kitty</Path>
@@ -1164,17 +1167,25 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="man">/usr/share/man/man1/kitty.1.zst</Path>
             <Path fileType="man">/usr/share/man/man5/kitty.conf.5.zst</Path>
             <Path fileType="data">/usr/share/metainfo/net.kovidgoyal.kitty.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/terminfo/x/xterm-kitty</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_kitty</Path>
         </Files>
     </Package>
+    <Package>
+        <Name>kitty-terminfo</Name>
+        <Summary xml:lang="en">Terminfo for kitty</Summary>
+        <Description xml:lang="en">Terminfo for kitty, split out so that it can be used from ncurses</Description>
+        <PartOf>system.base</PartOf>
+        <Files>
+            <Path fileType="data">/usr/share/terminfo/x/xterm-kitty</Path>
+        </Files>
+    </Package>
     <History>
-        <Update release="100">
-            <Date>2026-07-18</Date>
+        <Update release="101">
+            <Date>2026-07-20</Date>
             <Version>0.48.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/k/kmscon/package.yml
+++ b/packages/k/kmscon/package.yml
@@ -1,17 +1,23 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : kmscon
 version    : 10.0.0
-release    : 12
+release    : 13
 source     :
     - https://github.com/kmscon/kmscon/archive/refs/tags/v10.0.0.tar.gz : 7074956472c42d14977922f9ef6d2ec101f8d88e549f0108c1f51cb9d2b437dd
 homepage   : https://www.freedesktop.org/wiki/Software/kmscon
 license    :
     - MIT
     - LGPL-2.1-or-later # external/htable.* external/dbus-loop.*
-component  : system.utils
-summary    : Linux KMS/DRM based virtual Console Emulator
-description: |
-    kmscon is a system console for linux. It does not depend on any graphics-server on your system (like X.org), but instead provides a raw console layer that can be used independently. It can replace the linux kernel console entirely but was designed to work well side-by-side, too. Even though initially targeted at providing internationalization to the system-console, it has grown into a fully modularized console layer including features like multi-head support, internationalized font rendering, XKB-compatible keyboard handling, hardware-accelerated graphics access and more.
+component  :
+    - terminfo : system.base
+    - system.utils
+summary    :
+    - terminfo : Terminfo for kmscon
+    - Linux KMS/DRM based virtual Console Emulator
+description:
+    - terminfo : Terminfo for kmscon, split out so that it can be used from ncurses
+    - |
+      kmscon is a system console for linux. It does not depend on any graphics-server on your system (like X.org), but instead provides a raw console layer that can be used independently. It can replace the linux kernel console entirely but was designed to work well side-by-side, too. Even though initially targeted at providing internationalization to the system-console, it has grown into a fully modularized console layer including features like multi-head support, internationalized font rendering, XKB-compatible keyboard handling, hardware-accelerated graphics access and more.
 builddeps  :
     - pkgconfig(egl)
     - pkgconfig(fontconfig)
@@ -25,6 +31,8 @@ builddeps  :
     - pkgconfig(libudev)
     - pkgconfig(pangoft2)
     - pkgconfig(xkbcommon)
+rundeps    :
+    - kmscon-terminfo
 checkdeps  :
     - pkgconfig(check)
 setup      : |
@@ -55,3 +63,6 @@ install    : |
     install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/60-kmscon.preset
 check      : |
     %ninja_check
+patterns   :
+    - terminfo :
+        - /usr/share/terminfo

--- a/packages/k/kmscon/pspec_x86_64.xml
+++ b/packages/k/kmscon/pspec_x86_64.xml
@@ -20,6 +20,9 @@
         <Description xml:lang="en">kmscon is a system console for linux. It does not depend on any graphics-server on your system (like X.org), but instead provides a raw console layer that can be used independently. It can replace the linux kernel console entirely but was designed to work well side-by-side, too. Even though initially targeted at providing internationalization to the system-console, it has grown into a fully modularized console layer including features like multi-head support, internationalized font rendering, XKB-compatible keyboard handling, hardware-accelerated graphics access and more.
 </Description>
         <PartOf>system.utils</PartOf>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="13">kmscon-terminfo</Dependency>
+        </RuntimeDependencies>
         <Files>
             <Path fileType="config">/etc/systemd/system/autovt@.service</Path>
             <Path fileType="executable">/usr/bin/kmscon</Path>
@@ -33,12 +36,20 @@
             <Path fileType="library">/usr/lib64/kmscon/mod-unifont.so</Path>
             <Path fileType="library">/usr/lib64/systemd/system-preset/60-kmscon.preset</Path>
             <Path fileType="data">/usr/share/licenses/kmscon/COPYING</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>kmscon-terminfo</Name>
+        <Summary xml:lang="en">Terminfo for kmscon</Summary>
+        <Description xml:lang="en">Terminfo for kmscon, split out so that it can be used from ncurses</Description>
+        <PartOf>system.base</PartOf>
+        <Files>
             <Path fileType="data">/usr/share/terminfo/k/kmscon</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2026-06-26</Date>
+        <Update release="13">
+            <Date>2026-07-20</Date>
             <Version>10.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/n/ncurses/abi_symbols
+++ b/packages/n/ncurses/abi_symbols
@@ -19,6 +19,7 @@ libformw.so.6:NCURSES6_TINFO_6.2.20200212
 libformw.so.6:NCURSES6_TINFO_6.2.20211010
 libformw.so.6:NCURSES6_TINFO_6.5.20240427
 libformw.so.6:NCURSES6_TINFO_6.6.20251230
+libformw.so.6:NCURSES6_TINFO_6.6.current
 libformw.so.6:NCURSESW6_5.1.20000708
 libformw.so.6:NCURSESW6_5.3.20021019
 libformw.so.6:NCURSESW6_5.4.20040208
@@ -133,6 +134,7 @@ libmenuw.so.6:NCURSES6_TINFO_6.2.20200212
 libmenuw.so.6:NCURSES6_TINFO_6.2.20211010
 libmenuw.so.6:NCURSES6_TINFO_6.5.20240427
 libmenuw.so.6:NCURSES6_TINFO_6.6.20251230
+libmenuw.so.6:NCURSES6_TINFO_6.6.current
 libmenuw.so.6:NCURSESW6_5.1.20000708
 libmenuw.so.6:NCURSESW6_5.3.20021019
 libmenuw.so.6:NCURSESW6_5.4.20040208
@@ -441,6 +443,7 @@ libncursesw.so.6:NCURSES6_TINFO_6.2.20200212
 libncursesw.so.6:NCURSES6_TINFO_6.2.20211010
 libncursesw.so.6:NCURSES6_TINFO_6.5.20240427
 libncursesw.so.6:NCURSES6_TINFO_6.6.20251230
+libncursesw.so.6:NCURSES6_TINFO_6.6.current
 libncursesw.so.6:NCURSESW6_5.1.20000708
 libncursesw.so.6:NCURSESW6_5.3.20021019
 libncursesw.so.6:NCURSESW6_5.4.20040208
@@ -462,6 +465,8 @@ libncursesw.so.6:_nc_align_termtype
 libncursesw.so.6:_nc_basename
 libncursesw.so.6:_nc_capcmp
 libncursesw.so.6:_nc_check_termtype2
+libncursesw.so.6:_nc_cookie_allowed
+libncursesw.so.6:_nc_cookie_init
 libncursesw.so.6:_nc_copy_termtype
 libncursesw.so.6:_nc_copy_termtype2
 libncursesw.so.6:_nc_curr_col
@@ -1195,6 +1200,7 @@ libpanelw.so.6:NCURSES6_TINFO_6.2.20200212
 libpanelw.so.6:NCURSES6_TINFO_6.2.20211010
 libpanelw.so.6:NCURSES6_TINFO_6.5.20240427
 libpanelw.so.6:NCURSES6_TINFO_6.6.20251230
+libpanelw.so.6:NCURSES6_TINFO_6.6.current
 libpanelw.so.6:NCURSESW6_5.1.20000708
 libpanelw.so.6:NCURSESW6_5.3.20021019
 libpanelw.so.6:NCURSESW6_5.4.20040208

--- a/packages/n/ncurses/abi_symbols32
+++ b/packages/n/ncurses/abi_symbols32
@@ -19,6 +19,7 @@ libformw.so.6:NCURSES6_TINFO_6.2.20200212
 libformw.so.6:NCURSES6_TINFO_6.2.20211010
 libformw.so.6:NCURSES6_TINFO_6.5.20240427
 libformw.so.6:NCURSES6_TINFO_6.6.20251230
+libformw.so.6:NCURSES6_TINFO_6.6.current
 libformw.so.6:NCURSESW6_5.1.20000708
 libformw.so.6:NCURSESW6_5.3.20021019
 libformw.so.6:NCURSESW6_5.4.20040208
@@ -133,6 +134,7 @@ libmenuw.so.6:NCURSES6_TINFO_6.2.20200212
 libmenuw.so.6:NCURSES6_TINFO_6.2.20211010
 libmenuw.so.6:NCURSES6_TINFO_6.5.20240427
 libmenuw.so.6:NCURSES6_TINFO_6.6.20251230
+libmenuw.so.6:NCURSES6_TINFO_6.6.current
 libmenuw.so.6:NCURSESW6_5.1.20000708
 libmenuw.so.6:NCURSESW6_5.3.20021019
 libmenuw.so.6:NCURSESW6_5.4.20040208
@@ -441,6 +443,7 @@ libncursesw.so.6:NCURSES6_TINFO_6.2.20200212
 libncursesw.so.6:NCURSES6_TINFO_6.2.20211010
 libncursesw.so.6:NCURSES6_TINFO_6.5.20240427
 libncursesw.so.6:NCURSES6_TINFO_6.6.20251230
+libncursesw.so.6:NCURSES6_TINFO_6.6.current
 libncursesw.so.6:NCURSESW6_5.1.20000708
 libncursesw.so.6:NCURSESW6_5.3.20021019
 libncursesw.so.6:NCURSESW6_5.4.20040208
@@ -462,6 +465,8 @@ libncursesw.so.6:_nc_align_termtype
 libncursesw.so.6:_nc_basename
 libncursesw.so.6:_nc_capcmp
 libncursesw.so.6:_nc_check_termtype2
+libncursesw.so.6:_nc_cookie_allowed
+libncursesw.so.6:_nc_cookie_init
 libncursesw.so.6:_nc_copy_termtype
 libncursesw.so.6:_nc_copy_termtype2
 libncursesw.so.6:_nc_curr_col
@@ -1195,6 +1200,7 @@ libpanelw.so.6:NCURSES6_TINFO_6.2.20200212
 libpanelw.so.6:NCURSES6_TINFO_6.2.20211010
 libpanelw.so.6:NCURSES6_TINFO_6.5.20240427
 libpanelw.so.6:NCURSES6_TINFO_6.6.20251230
+libpanelw.so.6:NCURSES6_TINFO_6.6.current
 libpanelw.so.6:NCURSESW6_5.1.20000708
 libpanelw.so.6:NCURSESW6_5.3.20021019
 libpanelw.so.6:NCURSESW6_5.4.20040208

--- a/packages/n/ncurses/package.yml
+++ b/packages/n/ncurses/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ncurses
-version    : 6.6.20260502
-release    : 35
+version    : 6.6.20260711
+release    : 36
 source     :
     # They seem to prune these from time to time. Might be smarter to host the archives ourselves
-    - https://invisible-island.net/archives/ncurses/current/ncurses-6.6-20260502.tgz : c83054552a299b06a41a9464742908291d50994fefce1f5aa4b322fc8f8b4938
+    - https://invisible-island.net/archives/ncurses/current/ncurses-6.6-20260711.tgz : dd48b94a0919c00f747bcef75f6c19502c61b3d55f4dd11aa2f7d70b7f8a9864
 homepage   : https://invisible-island.net/ncurses/announce.html
 license    : MIT-open-group
 component  : system.base
@@ -18,62 +18,81 @@ builddeps  :
     - glibc-32bit-devel
     - libgcc-32bit
     - libstdc++-32bit
+rundeps    :
+    - foot-terminfo
+    # - ghostty-terminfo
+    - kitty-terminfo
+    - kmscon-terminfo
 optimize   :
     - speed
     - lto
 setup      : |
-    %patch -p1 -i $pkgfiles/pkgconfig.patch
+    %patch -p1 -i ${pkgfiles}/pkgconfig.patch
 
     %configure \
-               --with-cxx-binding \
-               --with-cxx-shared \
-               --with-manpage-format=normal \
-               --with-pkg-config-libdir=%libdir%/pkgconfig \
-               --with-shared \
-               --with-terminfo-dirs='/etc/terminfo:/usr/share/terminfo' \
-               --with-versioned-syms \
-               --without-ada \
-               --without-debug \
-               --without-normal \
-               --enable-colorfgbg \
-               --enable-hard-tabs \
-               --enable-largefile \
-               --enable-pc-files \
-               --enable-xmc-glitch \
-               --enable-widec \
-               --disable-rpath \
-               --disable-root-access \
-               --disable-root-environ \
-               --disable-setuid-environ \
-               --disable-stripping
+        --with-cxx-binding \
+        --with-cxx-shared \
+        --with-manpage-format=normal \
+        --with-pkg-config-libdir=%libdir%/pkgconfig \
+        --with-shared \
+        --with-terminfo-dirs='/etc/terminfo:/usr/share/terminfo' \
+        --with-versioned-syms \
+        --without-ada \
+        --without-debug \
+        --without-normal \
+        --enable-colorfgbg \
+        --enable-hard-tabs \
+        --enable-largefile \
+        --enable-pc-files \
+        --enable-xmc-glitch \
+        --enable-widec \
+        --disable-rpath \
+        --disable-root-access \
+        --disable-root-environ \
+        --disable-setuid-environ \
+        --disable-stripping
 build      : |
     %make
 install    : |
     # Ensure that the later symlink of terminfo succeeds
-    install -dm00755 $installdir/usr/lib
+    install -dm00755 ${installdir}/usr/lib
 
     %make_install
 
     %install_license COPYING
-    
+
     # Link against wide if anything otherwise tries to link against non-wide
     for lib in ncurses ncurses++ form panel menu; do
-        ln -sv lib${lib}w.so $installdir/%libdir%/lib${lib}.so
-        ln -sv ${lib}w.pc $installdir/%libdir%/pkgconfig/${lib}.pc
+        ln -sv lib${lib}w.so ${installdir}/%libdir%/lib${lib}.so
+        ln -sv ${lib}w.pc ${installdir}/%libdir%/pkgconfig/${lib}.pc
     done
 
     # Compat links for anything trying to link with -lcurses
-    ln -sv libncurses.so $installdir/%libdir%/libcurses.so
-    ln -sv libncursesw.so $installdir/%libdir%/libcursesw.so
+    ln -sv libncurses.so ${installdir}/%libdir%/libcurses.so
+    ln -sv libncursesw.so ${installdir}/%libdir%/libcursesw.so
 
     # Needs to match ABI version
     abi=6
     # tic and tinfo are built in by default
     for lib in tic tinfo; do
-        ln -sv libncursesw.so.${abi} $installdir/%libdir%/lib${lib}.so.${abi}
-        ln -sv lib${lib}.so.${abi} $installdir/%libdir%/lib${lib}.so
-        ln -sv ncursesw.pc $installdir/%libdir%/pkgconfig/${lib}.pc
+        ln -sv libncursesw.so.${abi} ${installdir}/%libdir%/lib${lib}.so.${abi}
+        ln -sv lib${lib}.so.${abi} ${installdir}/%libdir%/lib${lib}.so
+        ln -sv ncursesw.pc ${installdir}/%libdir%/pkgconfig/${lib}.pc
     done
+
+    # Remove duplicate terminfo that is provided by various terminals. Package-provided terminfo should be preferred over ncurses
+    _terminfodir=${installdir}/usr/share/terminfo
+    # terminfo-foot
+    rm -v ${_terminfodir}/f/foot*
+    # terminfo-ghostty
+    # TODO: Ghostty doesn't build against our Zig version,
+    # so uncomment this after it has been updated for newer Zig.
+    # rm -v ${_terminfodir}/g/ghostty
+    # terminfo-kmscon
+    rm -v ${_terminfodir}/k/kmscon
+
+    # Unused
+    rm -r ${installdir}/%libdir%/terminfo || true
 patterns   :
     - devel :
         - /usr/bin/ncursesw6-config

--- a/packages/n/ncurses/pspec_x86_64.xml
+++ b/packages/n/ncurses/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ncurses</Name>
         <Homepage>https://invisible-island.net/ncurses/announce.html</Homepage>
         <Packager>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT-open-group</License>
         <PartOf>system.base</PartOf>
@@ -991,9 +991,6 @@
             <Path fileType="data">/usr/share/terminfo/f/fenix</Path>
             <Path fileType="data">/usr/share/terminfo/f/fenixw</Path>
             <Path fileType="data">/usr/share/terminfo/f/fixterm</Path>
-            <Path fileType="data">/usr/share/terminfo/f/foot</Path>
-            <Path fileType="data">/usr/share/terminfo/f/foot+base</Path>
-            <Path fileType="data">/usr/share/terminfo/f/foot-direct</Path>
             <Path fileType="data">/usr/share/terminfo/f/fortune</Path>
             <Path fileType="data">/usr/share/terminfo/f/fos</Path>
             <Path fileType="data">/usr/share/terminfo/f/fox</Path>
@@ -1717,6 +1714,7 @@
             <Path fileType="data">/usr/share/terminfo/o/otek4113</Path>
             <Path fileType="data">/usr/share/terminfo/o/otek4114</Path>
             <Path fileType="data">/usr/share/terminfo/o/otek4115</Path>
+            <Path fileType="data">/usr/share/terminfo/o/otty</Path>
             <Path fileType="data">/usr/share/terminfo/o/owl</Path>
             <Path fileType="data">/usr/share/terminfo/p/p12</Path>
             <Path fileType="data">/usr/share/terminfo/p/p12-m</Path>
@@ -2420,6 +2418,8 @@
             <Path fileType="data">/usr/share/terminfo/v/vt100</Path>
             <Path fileType="data">/usr/share/terminfo/v/vt100+</Path>
             <Path fileType="data">/usr/share/terminfo/v/vt100+4bsd</Path>
+            <Path fileType="data">/usr/share/terminfo/v/vt100+apparrows</Path>
+            <Path fileType="data">/usr/share/terminfo/v/vt100+arrows</Path>
             <Path fileType="data">/usr/share/terminfo/v/vt100+enq</Path>
             <Path fileType="data">/usr/share/terminfo/v/vt100+fnkeys-sco</Path>
             <Path fileType="data">/usr/share/terminfo/v/vt100+keypad</Path>
@@ -2979,6 +2979,8 @@
             <Path fileType="data">/usr/share/terminfo/z/ztx</Path>
             <Path fileType="data">/usr/share/terminfo/z/ztx-1-a</Path>
             <Path fileType="data">/usr/share/terminfo/z/ztx11</Path>
+            <Path fileType="data">/usr/share/terminfo/z/zutty</Path>
+            <Path fileType="data">/usr/share/terminfo/z/zutty-256color</Path>
         </Files>
     </Package>
     <Package>
@@ -2988,7 +2990,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">ncurses</Dependency>
+            <Dependency release="36">ncurses</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libformw.so.6</Path>
@@ -3012,8 +3014,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">ncurses-devel</Dependency>
-            <Dependency release="35">ncurses-32bit</Dependency>
+            <Dependency release="36">ncurses-devel</Dependency>
+            <Dependency release="36">ncurses-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcurses.so</Path>
@@ -3051,7 +3053,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">ncurses</Dependency>
+            <Dependency release="36">ncurses</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/ncursesw6-config</Path>
@@ -4020,12 +4022,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2026-05-04</Date>
-            <Version>6.6.20260502</Version>
+        <Update release="36">
+            <Date>2026-07-19</Date>
+            <Version>6.6.20260711</Version>
             <Comment>Packaging update</Comment>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- **foot: Split terminfo into subpackage**
- **kitty: Split terminfo into subpackage**
- **kmscon: Split terminfo into subpackage**
- **ncurses: Update to v6.6.20260711**

This also reworks the `foot` package a little. Refer to the commit message for details.
cc: @Jaredy899 for the `foot` changes

**Test Plan**

Put all packages into a local repo, update, and restart my feet terminals. Use `helix`, `bat`, `delta`, and other terminal applications.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
