### PR TITLE
stripe-cli: Update to 1.43.8

### DIFF
--- a/packages/s/stripe-cli/files/0001-version.patch
+++ b/packages/s/stripe-cli/files/0001-version.patch
@@ -1,0 +1,17 @@
+Index: pkg/version/version.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/version/version.go b/pkg/version/version.go
+--- a/pkg/version/version.go	(revision b437c31f21478a16d1139af09aa31a8da6657cc7)
++++ b/pkg/version/version.go	(date 1784513134073)
+@@ -17,7 +17,7 @@
+ // This is set to the actual version by GoReleaser, identify by the
+ // git tag assigned to the release. Versions built from source will
+ // always show master.
+-var Version = "master"
++var Version = "1.43.8"
+
+ // Template for the version string.
+ var Template = fmt.Sprintf("stripe version %s\n", Version)

--- a/packages/s/stripe-cli/package.yml
+++ b/packages/s/stripe-cli/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : stripe-cli
-version    : 1.40.9
-release    : 2
+version    : 1.43.8
+release    : 3
 source     :
-    - https://github.com/stripe/stripe-cli/archive/refs/tags/v1.40.9.tar.gz : dcb2890fadc1a6ef008cc316f61f1025c7a412c9bd9766a5a61c098813b05ff4
+    - https://github.com/stripe/stripe-cli/archive/refs/tags/v1.43.8.tar.gz : 0be76f37ee06bac6ad5e56ec542be71e828356e37f36f721a3b8b7afedefe78d
 homepage   : https://stripe.com
 license    : Apache-2.0
 component  : programming.tools
@@ -13,6 +13,8 @@ description: |
 networking : true
 builddeps  :
     - golang
+setup      : |
+    %patch -p1 -i $pkgfiles/0001-version.patch
 build      : |
     %make
 install    : |

--- a/packages/s/stripe-cli/pspec_x86_64.xml
+++ b/packages/s/stripe-cli/pspec_x86_64.xml
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2026-05-07</Date>
-            <Version>1.40.9</Version>
+        <Update release="3">
+            <Date>2026-07-20</Date>
+            <Version>1.43.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Trevor Busk</Name>
             <Email>trevor@tbusk.com</Email>


### PR DESCRIPTION
**Summary**

One small fix to the versioning outside of regular updates - patched the version to now show up as the version instead of `master.

Full release notes:

- [1.43.8](https://github.com/stripe/stripe-cli/releases/tag/v1.43.8)

**Test Plan**

<!-- Short description of how the package was tested -->

- [X] Ran: stripe version, whoami, docs, open, and get

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
