### PR TITLE
dua-cli: Update to v2.38.1

### DIFF
--- a/packages/d/dua-cli/package.yml
+++ b/packages/d/dua-cli/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dua-cli
-version    : 2.38.0
-release    : 6
+version    : 2.38.1
+release    : 7
 source     :
-    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.38.0.tar.gz : 3972a34ffaaeb3c24d0693e13386a4578530333789b467c83f1686584f314291
+    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.38.1.tar.gz : b30d76e60be8f4928c3b7d5c3cd2d9034d60ad09c7e044bf2056f01e8596f46e
 homepage   : https://github.com/Byron/dua-cli
 license    : MIT
 component  : system.utils

--- a/packages/d/dua-cli/pspec_x86_64.xml
+++ b/packages/d/dua-cli/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-07-15</Date>
-            <Version>2.38.0</Version>
+        <Update release="7">
+            <Date>2026-07-20</Date>
+            <Version>2.38.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Byron/dua-cli/releases/tag/v2.38.1).

**Test Plan**

Saw file sizes. browsed file system

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
