### PR TITLE
glibc: Update to 2.43+git.1c9988e5

### DIFF
--- a/packages/g/glibc/package.yml
+++ b/packages/g/glibc/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : glibc
 version    : '2.43'
-release    : 141
+release    : 142
 source     :
     # release/2.43/master
-    - git|https://sourceware.org/git/glibc.git : 4070d808bea1c077eb7e7d52b52b91cae98205d5
+    - git|https://sourceware.org/git/glibc.git : 1c9988e52540c844928c6d93ff45305adc2c24a0
 homepage   : https://www.gnu.org/software/libc/
 license    :
     - GPL-2.0-or-later

--- a/packages/g/glibc/pspec_x86_64.xml
+++ b/packages/g/glibc/pspec_x86_64.xml
@@ -7020,7 +7020,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="141">glibc</Dependency>
+            <Dependency release="142">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib32/ld-linux.so.2</Path>
@@ -7321,8 +7321,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="141">glibc-devel</Dependency>
-            <Dependency release="141">glibc-32bit</Dependency>
+            <Dependency release="142">glibc-32bit</Dependency>
+            <Dependency release="142">glibc-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/Mcrt1.o</Path>
@@ -7856,7 +7856,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="141">glibc</Dependency>
+            <Dependency release="142">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mtrace</Path>
@@ -8377,8 +8377,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="141">
-            <Date>2026-05-10</Date>
+        <Update release="142">
+            <Date>2026-07-20</Date>
             <Version>2.43</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- rtld: cache cpuid results on the stack for intel
- posix: Fix stack overflow in wordexp tilde expansion
- resolv: Add test case tst-ns_sprintrr
- resolv: More types as unknown in ns_sprintrrf
- resolv: Check for inet_ntop failure in ns_sprintrrf
- resolv: Improve formatting of unknown records in ns_sprintrrf
- resolv: Fix ns_sprintrrf formatting of class, type values
- resolv: Declare __p_class_syms, __p_type_syms for internal use
- hppa: Fix missing call to __feraiseexcept
- iconv: Suppress intermediate errors with //TRANSLIT
- elf: don't clobber ld.so.conf in tst-glibc-hwcaps-prepend-cache
- Rename __unused fields to __glibc_reserved
- math: Fix fma alignment when exponent difference is exactly 64
- stdio-common: Fix buffer overflow in scanf %mc
- libio: Fix ungetwc operating on byte stream

**Security**
- CVE-2026-6791
- CVE-2026-5435

**Test Plan**

Build a program.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
