### PR TITLE
mozilla-vpn-client: Update to 2.38.0

### DIFF
--- a/packages/m/mozilla-vpn-client/abi_used_libs
+++ b/packages/m/mozilla-vpn-client/abi_used_libs
@@ -12,7 +12,6 @@ libQt6Test.so.6
 libQt6WebSockets.so.6
 libQt6Widgets.so.6
 libc.so.6
-libcap.so.2
 libgcc_s.so.1
 libglib-2.0.so.0
 libgobject-2.0.so.0

--- a/packages/m/mozilla-vpn-client/abi_used_symbols
+++ b/packages/m/mozilla-vpn-client/abi_used_symbols
@@ -47,7 +47,6 @@ libQt6Core.so.6:_ZN10QEventLoopC1EP7QObject
 libQt6Core.so.6:_ZN10QEventLoopD1Ev
 libQt6Core.so.6:_ZN10QJsonArray6appendERK10QJsonValue
 libQt6Core.so.6:_ZN10QJsonArray6detachEx
-libQt6Core.so.6:_ZN10QJsonArrayC1ESt16initializer_listI10QJsonValueE
 libQt6Core.so.6:_ZN10QJsonArrayC1Ev
 libQt6Core.so.6:_ZN10QJsonArrayD1Ev
 libQt6Core.so.6:_ZN10QJsonValue11fromVariantERK8QVariant
@@ -76,6 +75,7 @@ libQt6Core.so.6:_ZN11QDataStreamlsEx
 libQt6Core.so.6:_ZN11QDataStreamrsERa
 libQt6Core.so.6:_ZN11QDataStreamrsERi
 libQt6Core.so.6:_ZN11QDataStreamrsERx
+libQt6Core.so.6:_ZN11QFileDevice16staticMetaObjectE
 libQt6Core.so.6:_ZN11QFileDevice4seekEx
 libQt6Core.so.6:_ZN11QFileDevice5closeEv
 libQt6Core.so.6:_ZN11QFileDevice5flushEv
@@ -200,7 +200,6 @@ libQt6Core.so.6:_ZN18QAbstractListModel12dropMimeDataEPK9QMimeDataN2Qt10DropActi
 libQt6Core.so.6:_ZN18QAbstractListModel16staticMetaObjectE
 libQt6Core.so.6:_ZN18QAbstractListModelC2EP7QObject
 libQt6Core.so.6:_ZN18QAbstractListModelD2Ev
-libQt6Core.so.6:_ZN18QCommandLineOption15setDefaultValueERK7QString
 libQt6Core.so.6:_ZN18QCommandLineOptionC1ERK5QListI7QStringERKS1_S6_S6_
 libQt6Core.so.6:_ZN18QCommandLineOptionD1Ev
 libQt6Core.so.6:_ZN18QCommandLineParser11showVersionEv
@@ -318,7 +317,6 @@ libQt6Core.so.6:_ZN6QTimer7timeoutENS_14QPrivateSignalE
 libQt6Core.so.6:_ZN6QTimerC1EP7QObject
 libQt6Core.so.6:_ZN6QTimerD1Ev
 libQt6Core.so.6:_ZN7QBuffer4openE6QFlagsIN13QIODeviceBase12OpenModeFlagEE
-libQt6Core.so.6:_ZN7QBuffer7setDataEPKcx
 libQt6Core.so.6:_ZN7QBufferC1EP10QByteArrayP7QObject
 libQt6Core.so.6:_ZN7QBufferC1EP7QObject
 libQt6Core.so.6:_ZN7QBufferD1Ev
@@ -377,7 +375,6 @@ libQt6Core.so.6:_ZN7QString6appendE5QChar
 libQt6Core.so.6:_ZN7QString6appendERKS_
 libQt6Core.so.6:_ZN7QString6assignE14QAnyStringView
 libQt6Core.so.6:_ZN7QString6insertEx5QChar
-libQt6Core.so.6:_ZN7QString6numberEdci
 libQt6Core.so.6:_ZN7QString6numberEii
 libQt6Core.so.6:_ZN7QString6numberEji
 libQt6Core.so.6:_ZN7QString6numberExi
@@ -402,6 +399,7 @@ libQt6Core.so.6:_ZN7QThread4waitE14QDeadlineTimer
 libQt6Core.so.6:_ZN7QThread5eventEP6QEvent
 libQt6Core.so.6:_ZN7QThread5startENS_8PriorityE
 libQt6Core.so.6:_ZN7QThread6msleepEm
+libQt6Core.so.6:_ZN7QThread9terminateEv
 libQt6Core.so.6:_ZN7QThreadC1EP7QObject
 libQt6Core.so.6:_ZN7QThreadC2EP7QObject
 libQt6Core.so.6:_ZN7QThreadD1Ev
@@ -521,7 +519,6 @@ libQt6Core.so.6:_ZN9QtPrivate19QStringList_indexOfERK5QListI7QStringE11QStringVi
 libQt6Core.so.6:_ZN9QtPrivate20QStringList_containsEPK5QListI7QStringE11QStringViewN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI10QByteArrayE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI10QJsonValueE8metaTypeE
-libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI11QJsonObjectE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI4QMapI7QString8QVariantEE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI4QUrlE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI5QListI7QStringEE8metaTypeE
@@ -544,7 +541,6 @@ libQt6Core.so.6:_ZN9QtPrivate54hasRegisteredMutableViewFunctionToIterableMetaSeq
 libQt6Core.so.6:_ZN9QtPrivate8qustrchrE11QStringViewDs
 libQt6Core.so.6:_ZNK10QByteArray10toLongLongEPbi
 libQt6Core.so.6:_ZNK10QByteArray5splitEc
-libQt6Core.so.6:_ZNK10QByteArray5toHexEc
 libQt6Core.so.6:_ZNK10QByteArray8toBase64E6QFlagsINS_12Base64OptionEE
 libQt6Core.so.6:_ZNK10QByteArray8toDoubleEPb
 libQt6Core.so.6:_ZNK10QJsonArray2atEx
@@ -582,7 +578,6 @@ libQt6Core.so.6:_ZNK11QMetaObject6methodEi
 libQt6Core.so.6:_ZNK11QMetaObject8propertyEi
 libQt6Core.so.6:_ZNK11QMetaObject9classNameEv
 libQt6Core.so.6:_ZNK11QObjectData17dynamicMetaObjectEv
-libQt6Core.so.6:_ZNK11QTextStream5atEndEv
 libQt6Core.so.6:_ZNK11QTranslator7isEmptyEv
 libQt6Core.so.6:_ZNK11QTranslator9translateEPKcS1_S1_i
 libQt6Core.so.6:_ZNK12QDirIterator7hasNextEv
@@ -597,7 +592,6 @@ libQt6Core.so.6:_ZNK13QJsonDocumentixERK7QString
 libQt6Core.so.6:_ZNK13QJsonValueRef7toArrayEv
 libQt6Core.so.6:_ZNK13QJsonValueRef7toValueEv
 libQt6Core.so.6:_ZNK13QJsonValueRef8toObjectEv
-libQt6Core.so.6:_ZNK13QJsonValueRef9toVariantEv
 libQt6Core.so.6:_ZNK13QMetaProperty10isReadableEv
 libQt6Core.so.6:_ZNK13QMetaProperty4nameEv
 libQt6Core.so.6:_ZNK13QMetaProperty4readEPK7QObject
@@ -616,7 +610,6 @@ libQt6Core.so.6:_ZNK14QMessageLogger7warningEPKcz
 libQt6Core.so.6:_ZNK14QMessageLogger7warningEv
 libQt6Core.so.6:_ZNK14QMessageLogger8criticalEv
 libQt6Core.so.6:_ZNK14QVersionNumber8toStringEv
-libQt6Core.so.6:_ZNK16QLoggingCategory9isEnabledE9QtMsgType
 libQt6Core.so.6:_ZNK18QAbstractItemModel10headerDataEiN2Qt11OrientationEi
 libQt6Core.so.6:_ZNK18QAbstractItemModel12canFetchMoreERK11QModelIndex
 libQt6Core.so.6:_ZNK18QAbstractItemModel15canDropMimeDataEPK9QMimeDataN2Qt10DropActionEiiRK11QModelIndex
@@ -676,7 +669,6 @@ libQt6Core.so.6:_ZNK23QRegularExpressionMatch17lastCapturedIndexEv
 libQt6Core.so.6:_ZNK23QRegularExpressionMatch8capturedEi
 libQt6Core.so.6:_ZNK23QRegularExpressionMatch8hasMatchEv
 libQt6Core.so.6:_ZNK26QMessageAuthenticationCode6resultEv
-libQt6Core.so.6:_ZNK4QDir12absolutePathEv
 libQt6Core.so.6:_ZNK4QDir13entryInfoListERK5QListI7QStringE6QFlagsINS_6FilterEES5_INS_8SortFlagEE
 libQt6Core.so.6:_ZNK4QDir16absoluteFilePathERK7QString
 libQt6Core.so.6:_ZNK4QDir16relativeFilePathERK7QString
@@ -690,12 +682,10 @@ libQt6Core.so.6:_ZNK4QDir8filePathERK7QString
 libQt6Core.so.6:_ZNK4QDir9entryListE6QFlagsINS_6FilterEES0_INS_8SortFlagEE
 libQt6Core.so.6:_ZNK4QUrl4hostE6QFlagsINS_25ComponentFormattingOptionEE
 libQt6Core.so.6:_ZNK4QUrl4pathE6QFlagsINS_25ComponentFormattingOptionEE
-libQt6Core.so.6:_ZNK4QUrl4portEi
 libQt6Core.so.6:_ZNK4QUrl5queryE6QFlagsINS_25ComponentFormattingOptionEE
 libQt6Core.so.6:_ZNK4QUrl6schemeEv
 libQt6Core.so.6:_ZNK4QUrl7isValidEv
 libQt6Core.so.6:_ZNK4QUrl8fileNameE6QFlagsINS_25ComponentFormattingOptionEE
-libQt6Core.so.6:_ZNK4QUrl8hasQueryEv
 libQt6Core.so.6:_ZNK4QUrl8toStringE12QUrlTwoFlagsINS_19UrlFormattingOptionENS_25ComponentFormattingOptionEE
 libQt6Core.so.6:_ZNK4QUrl9authorityE6QFlagsINS_25ComponentFormattingOptionEE
 libQt6Core.so.6:_ZNK4QUrl9toEncodedE12QUrlTwoFlagsINS_19UrlFormattingOptionENS_25ComponentFormattingOptionEE
@@ -720,7 +710,6 @@ libQt6Core.so.6:_ZNK7QLocale13textDirectionEv
 libQt6Core.so.6:_ZNK7QLocale14currencySymbolENS_20CurrencySymbolFormatE
 libQt6Core.so.6:_ZNK7QLocale16toCurrencyStringEdRK7QStringi
 libQt6Core.so.6:_ZNK7QLocale18nativeLanguageNameEv
-libQt6Core.so.6:_ZNK7QLocale4nameENS_12TagSeparatorE
 libQt6Core.so.6:_ZNK7QLocale7dayNameEiNS_10FormatTypeE
 libQt6Core.so.6:_ZNK7QLocale7toUpperERK7QString
 libQt6Core.so.6:_ZNK7QLocale8languageEv
@@ -745,6 +734,7 @@ libQt6Core.so.6:_ZNK7QString8arg_implEyii5QChar
 libQt6Core.so.6:_ZNK7QString8endsWithE5QCharN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString8endsWithERKS_N2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString8toDoubleEPb
+libQt6Core.so.6:_ZNK7QThread9isRunningEv
 libQt6Core.so.6:_ZNK8QProcess5errorEv
 libQt6Core.so.6:_ZNK8QVariant10toDateTimeEv
 libQt6Core.so.6:_ZNK8QVariant10toLongLongEPb
@@ -927,7 +917,6 @@ libQt6DBus.so.6:_ZNK15QDBusConnection11isConnectedEv
 libQt6DBus.so.6:_ZNK15QDBusConnection22connectionCapabilitiesEv
 libQt6DBus.so.6:_ZNK15QDBusConnection4callERK12QDBusMessageN5QDBus8CallModeEi
 libQt6DBus.so.6:_ZNK15QDBusConnection9asyncCallERK12QDBusMessagei
-libQt6DBus.so.6:_ZNK15QDBusConnection9interfaceEv
 libQt6DBus.so.6:_ZNK15QDBusConnection9lastErrorEv
 libQt6DBus.so.6:_ZNK16QDBusPendingCall5errorEv
 libQt6DBus.so.6:_ZNK16QDBusPendingCall7isErrorEv
@@ -936,7 +925,6 @@ libQt6DBus.so.6:_ZNK21QDBusPendingReplyBase10argumentAtEi
 libQt6DBus.so.6:_ZNK22QDBusAbstractInterface10connectionEv
 libQt6DBus.so.6:_ZNK22QDBusAbstractInterface7isValidEv
 libQt6DBus.so.6:_ZNK22QDBusAbstractInterface9interfaceEv
-libQt6DBus.so.6:_ZNK24QDBusConnectionInterface10servicePidERK7QString
 libQt6DBus.so.6:_ZTI20QDBusAbstractAdaptor
 libQt6DBus.so.6:_ZTI22QDBusAbstractInterface
 libQt6DBus.so.6:_Zls6QDebugRK12QDBusMessage
@@ -1095,12 +1083,10 @@ libQt6Network.so.6:_ZN15QAbstractSocket9connectedEv
 libQt6Network.so.6:_ZN15QNetworkRequest12setAttributeENS_9AttributeERK8QVariant
 libQt6Network.so.6:_ZN15QNetworkRequest12setRawHeaderERK10QByteArrayS2_
 libQt6Network.so.6:_ZN15QNetworkRequest17setPeerVerifyNameERK7QString
-libQt6Network.so.6:_ZN15QNetworkRequest18setTransferTimeoutENSt6chrono8durationIlSt5ratioILl1ELl1000EEEE
 libQt6Network.so.6:_ZN15QNetworkRequest20setOriginatingObjectEP7QObject
 libQt6Network.so.6:_ZN15QNetworkRequest26setMaximumRedirectsAllowedEi
 libQt6Network.so.6:_ZN15QNetworkRequest6setUrlERK4QUrl
 libQt6Network.so.6:_ZN15QNetworkRequest9setHeaderENS_12KnownHeadersERK8QVariant
-libQt6Network.so.6:_ZN15QNetworkRequestC1ERK4QUrl
 libQt6Network.so.6:_ZN15QNetworkRequestC1Ev
 libQt6Network.so.6:_ZN15QNetworkRequestD1Ev
 libQt6Network.so.6:_ZN15QSslCertificateD1Ev
@@ -1108,7 +1094,6 @@ libQt6Network.so.6:_ZN16QNetworkDatagram7destroyEP23QNetworkDatagramPrivate
 libQt6Network.so.6:_ZN17QNetworkInterface13allInterfacesEv
 libQt6Network.so.6:_ZN17QNetworkInterfaceC1ERKS_
 libQt6Network.so.6:_ZN17QNetworkInterfaceD1Ev
-libQt6Network.so.6:_ZN17QPasswordDigestor15deriveKeyPbkdf2EN18QCryptographicHash9AlgorithmERK10QByteArrayS4_iy
 libQt6Network.so.6:_ZN19QNetworkInformation18loadDefaultBackendEv
 libQt6Network.so.6:_ZN19QNetworkInformation8instanceEv
 libQt6Network.so.6:_ZN20QNetworkAddressEntryC1ERKS_
@@ -1122,7 +1107,6 @@ libQt6Network.so.6:_ZN21QNetworkAccessManager4postERK15QNetworkRequestP9QIODevic
 libQt6Network.so.6:_ZN21QNetworkAccessManager4postERK15QNetworkRequestRK10QByteArray
 libQt6Network.so.6:_ZN21QNetworkAccessManager8finishedEP13QNetworkReply
 libQt6Network.so.6:_ZN21QNetworkAccessManagerC1EP7QObject
-libQt6Network.so.6:_ZN21QNetworkAccessManagerD1Ev
 libQt6Network.so.6:_ZN9QHostInfo10lookupHostERK7QStringPK7QObjectPKc
 libQt6Network.so.6:_ZN9QHostInfo15abortHostLookupEi
 libQt6Network.so.6:_ZN9QSslErrorD1Ev
@@ -1130,6 +1114,7 @@ libQt6Network.so.6:_ZNK10QTcpServer10serverPortEv
 libQt6Network.so.6:_ZNK10QUdpSocket19hasPendingDatagramsEv
 libQt6Network.so.6:_ZNK12QHostAddress10isLoopbackEv
 libQt6Network.so.6:_ZNK12QHostAddress11isBroadcastEv
+libQt6Network.so.6:_ZNK12QHostAddress11isLinkLocalEv
 libQt6Network.so.6:_ZNK12QHostAddress13toIPv4AddressEPb
 libQt6Network.so.6:_ZNK12QHostAddress13toIPv6AddressEv
 libQt6Network.so.6:_ZNK12QHostAddress6isNullEv
@@ -1264,12 +1249,10 @@ libQt6Qml.so.6:_ZN9QJSEngine9newObjectEv
 libQt6Qml.so.6:_ZNK10QQmlEngine11rootContextEv
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext13getEnumLookupEjPv
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext14getValueLookupEjPvS1_
-libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext14writeToConsoleE9QtMsgTypeRK7QStringPK16QLoggingCategory
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext15getObjectLookupEjP7QObjectPv
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext15setObjectLookupEjP7QObjectPv
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext15storeNameSloppyEjPv9QMetaType
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext17initGetEnumLookupEjPK11QMetaObjectPKcS5_
-libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext18constructValueTypeE9QMetaTypePK11QMetaObjectiPPv
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext18initGetValueLookupEjPK11QMetaObject
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext18loadAttachedLookupEjP7QObjectPv
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext19initGetObjectLookupEjP7QObject
@@ -1279,7 +1262,6 @@ libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext19loadSingletonLookupEjPv
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext20lookupResultMetaTypeEj
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext21setInstructionPointerEi
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext22initLoadAttachedLookupEjjP7QObject
-libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext22resolveLoggingCategoryEP7QObjectPb
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext23initLoadContextIdLookupEj
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext23initLoadSingletonLookupEjj
 libQt6Qml.so.6:_ZNK11QQmlPrivate18AOTCompiledContext23setReturnValueUndefinedEv
@@ -1559,6 +1541,7 @@ libc.so.6:inotify_init1
 libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:kill
+libc.so.6:killpg
 libc.so.6:lchown
 libc.so.6:linkat
 libc.so.6:listen
@@ -1720,14 +1703,6 @@ libc.so.6:waitpid
 libc.so.6:wcslen
 libc.so.6:write
 libc.so.6:writev
-libcap.so.2:cap_clear
-libcap.so.2:cap_free
-libcap.so.2:cap_get_flag
-libcap.so.2:cap_get_pid
-libcap.so.2:cap_get_proc
-libcap.so.2:cap_init
-libcap.so.2:cap_set_flag
-libcap.so.2:cap_set_proc
 libgcc_s.so.1:_Unwind_Backtrace
 libgcc_s.so.1:_Unwind_DeleteException
 libgcc_s.so.1:_Unwind_FindEnclosingFunction
@@ -1749,7 +1724,6 @@ libm.so.6:cos
 libm.so.6:exp
 libm.so.6:log
 libm.so.6:log2
-libm.so.6:pow
 libm.so.6:sincos
 libpolkit-gobject-1.so.0:polkit_authority_check_authorization_sync
 libpolkit-gobject-1.so.0:polkit_authority_get_sync
@@ -1762,6 +1736,7 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignER
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base9_M_unhookEv
+libstdc++.so.6:_ZNSt9exceptionD2Ev
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
@@ -1770,6 +1745,7 @@ libstdc++.so.6:_ZSt25__throw_bad_function_callv
 libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZSt7nothrow
+libstdc++.so.6:_ZTISt9exception
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv119__pointer_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__function_type_infoE
@@ -1783,6 +1759,7 @@ libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmRKSt9nothrow_t
+libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
 libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_end_catch
@@ -1790,6 +1767,7 @@ libstdc++.so.6:__cxa_guard_abort
 libstdc++.so.6:__cxa_guard_acquire
 libstdc++.so.6:__cxa_guard_release
 libstdc++.so.6:__cxa_rethrow
+libstdc++.so.6:__cxa_throw
 libstdc++.so.6:__cxa_throw_bad_array_new_length
 libstdc++.so.6:__dynamic_cast
 libstdc++.so.6:__gxx_personality_v0

--- a/packages/m/mozilla-vpn-client/package.yml
+++ b/packages/m/mozilla-vpn-client/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : mozilla-vpn-client
-version    : 2.36.0
-release    : 5
+version    : 2.38.0
+release    : 6
 source     :
-    - git|https://github.com/mozilla-mobile/mozilla-vpn-client.git : v2.36.0
+    - git|https://github.com/mozilla-mobile/mozilla-vpn-client.git : v2.38.0
 networking : true
 homepage   : https://vpn.mozilla.org/
 license    : MPL-2.0
@@ -27,10 +27,10 @@ builddeps  :
     - qt6-base-private-devel
     - rust
 setup      : |
-    python3 ./qtglean/glean_parser_ext/run_glean_parser.py
     %cmake_ninja
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE.md
     rm -r $installdir/etc

--- a/packages/m/mozilla-vpn-client/pspec_x86_64.xml
+++ b/packages/m/mozilla-vpn-client/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mozilla-vpn-client</Name>
         <Homepage>https://vpn.mozilla.org/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>network.util</PartOf>
@@ -34,18 +34,19 @@
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/org.mozilla.vpn.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/org.mozilla.vpn.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.mozilla.vpn.svg</Path>
+            <Path fileType="data">/usr/share/licenses/mozilla-vpn-client/LICENSE.md</Path>
             <Path fileType="data">/usr/share/metainfo/org.mozilla.vpn.metainfo.xml</Path>
             <Path fileType="data">/usr/share/metainfo/org.mozilla.vpn.releases.xml</Path>
             <Path fileType="data">/usr/share/polkit-1/actions/org.mozilla.vpn.policy</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-05-16</Date>
-            <Version>2.36.0</Version>
+        <Update release="6">
+            <Date>2026-07-20</Date>
+            <Version>2.38.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add License
- Removed run_glean_parser.py as it is removed and handled via the install
- [2.38.0 Change Log](https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.38.0)
- [2.37.0 Change Log](https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.37.0)

**Test Plan**
- connect and browse

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
