### PR TITLE
libssh: Update to v0.12.1

### DIFF
--- a/packages/l/libssh/package.yml
+++ b/packages/l/libssh/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libssh
-version    : 0.12.0
-release    : 20
+version    : 0.12.1
+release    : 21
 source     :
-    - https://www.libssh.org/files/0.12/libssh-0.12.0.tar.xz : 1a6af424d8327e5eedef4e5fe7f5b924226dd617ac9f3de80f217d82a36a7121
+    - https://www.libssh.org/files/0.12/libssh-0.12.1.tar.xz : d3941af0a2d78d5d82ed7a36988e9133994312f035b9659a6e43f8db3968784c
 homepage   : https://www.libssh.org/
 license    : LGPL-2.1-or-later
 component  : programming.library

--- a/packages/l/libssh/pspec_x86_64.xml
+++ b/packages/l/libssh/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libssh</Name>
         <Homepage>https://www.libssh.org/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libssh.so.4</Path>
-            <Path fileType="library">/usr/lib64/libssh.so.4.11.0</Path>
+            <Path fileType="library">/usr/lib64/libssh.so.4.11.1</Path>
             <Path fileType="data">/usr/share/licenses/libssh/COPYING</Path>
         </Files>
     </Package>
@@ -32,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">libssh</Dependency>
+            <Dependency release="21">libssh</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libssh/callbacks.h</Path>
@@ -52,12 +52,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-05-08</Date>
-            <Version>0.12.0</Version>
+        <Update release="21">
+            <Date>2026-07-21</Date>
+            <Version>0.12.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://www.libssh.org/).

**Security**
- CVE-2026-15370
- CVE-2026-59842
- CVE-2026-59843
- CVE-2026-59844
- CVE-2026-59845
- CVE-2026-59846
- CVE-2026-59847
- CVE-2026-59848
- CVE-2026-59849
- CVE-2026-59850
- CVE-2026-59851

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild a reverse dependency.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
