### PR TITLE
fluidsynth: Update to 2.5.6

### DIFF
--- a/packages/f/fluidsynth/abi_used_symbols
+++ b/packages/f/fluidsynth/abi_used_symbols
@@ -120,6 +120,7 @@ libc.so.6:rand
 libc.so.6:read
 libc.so.6:realloc
 libc.so.6:setrlimit
+libc.so.6:shutdown
 libc.so.6:snprintf
 libc.so.6:socket
 libc.so.6:stat

--- a/packages/f/fluidsynth/package.yml
+++ b/packages/f/fluidsynth/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fluidsynth
-version    : 2.5.3
-release    : 34
+version    : 2.5.6
+release    : 35
 source     :
-    - https://github.com/FluidSynth/fluidsynth/archive/refs/tags/v2.5.3.tar.gz : 6f247edfb4b91b927efc68c8884cec2ec345c8007afe6b59558cc52a67ef2517
+    - https://github.com/FluidSynth/fluidsynth/archive/refs/tags/v2.5.6.tar.gz : 0825f024c9cf7a18073739b83612d46542ecbfb349ae9147a1e9f08e2d524407
 homepage   : https://www.fluidsynth.org/
 license    : LGPL-2.1-or-later
 component  : multimedia.audio

--- a/packages/f/fluidsynth/pspec_x86_64.xml
+++ b/packages/f/fluidsynth/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fluidsynth</Name>
         <Homepage>https://www.fluidsynth.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>multimedia.audio</PartOf>
@@ -22,7 +22,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/fluidsynth</Path>
             <Path fileType="library">/usr/lib64/libfluidsynth.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfluidsynth.so.3.5.2</Path>
+            <Path fileType="library">/usr/lib64/libfluidsynth.so.3.5.5</Path>
             <Path fileType="data">/usr/share/licenses/fluidsynth/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/fluidsynth.1.zst</Path>
         </Files>
@@ -34,7 +34,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">fluidsynth</Dependency>
+            <Dependency release="35">fluidsynth</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/fluidsynth.h</Path>
@@ -64,12 +64,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2026-03-14</Date>
-            <Version>2.5.3</Version>
+        <Update release="35">
+            <Date>2026-07-21</Date>
+            <Version>2.5.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security Update
- [2.5.6 Change Log](https://github.com/FluidSynth/fluidsynth/releases/tag/v2.5.6)
- [2.5.5 Change Log](https://github.com/FluidSynth/fluidsynth/releases/tag/v2.5.5)
- [2.5.4 Change Log](https://github.com/FluidSynth/fluidsynth/releases/tag/v2.5.4)

**Security**
- CVE-2026-58264
- GHSA-976m-35rw-h3m6
- GHSA-59ph-rx8r-8p4j
- GHSA-r4mc-v3p8-pv47
- GHSA-hp72-35pr-6h6r
- GHSA-rmc4-c8hw-455w

**Test Plan**
- Check version
- Test loading soundfont and playing a note with noteon

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
