### PR TITLE
syncthing: Update to v2.1.2

### DIFF
--- a/packages/s/syncthing/package.yml
+++ b/packages/s/syncthing/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : syncthing
-version    : 2.0.16
-release    : 108
+version    : 2.1.2
+release    : 109
 homepage   : https://syncthing.net
 source     :
-    - https://github.com/syncthing/syncthing/archive/refs/tags/v2.0.16.tar.gz : 30ab1917025de0d057ae53b3568e721bbea652b4b3d7bd96b04a6ef9bfb28bab
+    - https://github.com/syncthing/syncthing/archive/refs/tags/v2.1.2.tar.gz : cddcd03945de492f5c995f6fcda910fc49c1174a74899a26704aae63aa558c4a
 license    : MPL-2.0
 component  : network.util
 networking : true

--- a/packages/s/syncthing/pspec_x86_64.xml
+++ b/packages/s/syncthing/pspec_x86_64.xml
@@ -50,9 +50,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="108">
-            <Date>2026-05-10</Date>
-            <Version>2.0.16</Version>
+        <Update release="109">
+            <Date>2026-07-22</Date>
+            <Version>2.1.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

Major changes in 2.1
- Devices and folders can now be grouped in the GUI by setting the new `group` attribute.

- HTTP and HTTPS proxies with support for CONNECT can now be used, in addition to the existing support for SOCKS proxies (the environment variable `all_proxy=https://...`).

- Block indexing can be turned off for folders where it's more desirable to optimise for reduced database size and overhead than minimal transfer size (the `blockIndexing` attribute on folder configuration).

- GUI login session duration can be configured to be longer or shorter than the default one week, or set to infinitely long. The cookie path can also be adjusted. (The `sessionCookieDurationS` and `sessionCookiePath` attributes in the GUI configuration.)

Bug fixes and chores

Full changelog available [here](https://github.com/syncthing/syncthing/releases/)

**Test Plan**

- Restart the syncthing daemon, load the syncthing web GUI, verify all folders sync

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
