### PR TITLE
libreswan: Update to 5.3.2

### DIFF
--- a/packages/l/libreswan/package.yml
+++ b/packages/l/libreswan/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libreswan
-version    : 5.3.1
-release    : 15
+version    : 5.3.2
+release    : 16
 source     :
-    - https://download.libreswan.org/libreswan-5.3.1.tar.gz : e3f0e51d8b642bf693a6a8cc6f1e62a764cff4180a023bf3c7e42d43a62dfe9e
+    - https://download.libreswan.org/libreswan-5.3.2.tar.gz : fb918afa0bb92bd0430c1da861ef8068864d25d72130df0c6307a1f9da761088
 homepage   : https://libreswan.org/
 license    : GPL-2.0-or-later
 component  : network.util

--- a/packages/l/libreswan/pspec_x86_64.xml
+++ b/packages/l/libreswan/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libreswan</Name>
         <Homepage>https://libreswan.org/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.util</PartOf>
@@ -141,12 +141,12 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2026-07-09</Date>
-            <Version>5.3.1</Version>
+        <Update release="16">
+            <Date>2026-07-23</Date>
+            <Version>5.3.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security
- [Change Log](https://github.com/libreswan/libreswan/releases/tag/v5.3.2)

**Security**
- CVE-2026-14957

**Test Plan**
- sudo ipsec trafficstatus, sudo ipsec briefstatus

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
