### PR TITLE
unbound: Update to v1.25.2

### DIFF
--- a/packages/u/unbound/abi_libs
+++ b/packages/u/unbound/abi_libs
@@ -1,6 +1,1 @@
 libunbound.so.8
-unbound
-unbound-anchor
-unbound-checkconf
-unbound-control
-unbound-host

--- a/packages/u/unbound/abi_symbols
+++ b/packages/u/unbound/abi_symbols
@@ -34,8 +34,3 @@ libunbound.so.8:ub_resolve_free
 libunbound.so.8:ub_strerror
 libunbound.so.8:ub_version
 libunbound.so.8:ub_wait
-unbound:_IO_stdin_used
-unbound-anchor:_IO_stdin_used
-unbound-checkconf:_IO_stdin_used
-unbound-control:_IO_stdin_used
-unbound-host:_IO_stdin_used

--- a/packages/u/unbound/package.yml
+++ b/packages/u/unbound/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : unbound
-version    : 1.25.1
-release    : 22
+version    : 1.25.2
+release    : 23
 source     :
-    - https://nlnetlabs.nl/downloads/unbound/unbound-1.25.1.tar.gz : 0fe8b6277b0959cfd17562debac0aa5f71e0b02dc4ffa9c60271c583edab586f
+    - https://nlnetlabs.nl/downloads/unbound/unbound-1.25.2.tar.gz : 0d92275c703d5f5f8baba3dab22117dd8c29b495588a5c229768ed6581566600
 homepage   : https://nlnetlabs.nl/projects/unbound/about/
 license    : BSD-3-Clause
 component  : network.util

--- a/packages/u/unbound/pspec_x86_64.xml
+++ b/packages/u/unbound/pspec_x86_64.xml
@@ -21,7 +21,7 @@
         <PartOf>network.util</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libunbound.so.8</Path>
-            <Path fileType="library">/usr/lib64/libunbound.so.8.1.37</Path>
+            <Path fileType="library">/usr/lib64/libunbound.so.8.1.38</Path>
             <Path fileType="library">/usr/lib64/systemd/system/unbound.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/unbound.socket</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/unbound.conf</Path>
@@ -50,7 +50,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="22">unbound</Dependency>
+            <Dependency release="23">unbound</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/unbound-event.h</Path>
@@ -91,9 +91,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2026-05-20</Date>
-            <Version>1.25.1</Version>
+        <Update release="23">
+            <Date>2026-07-23</Date>
+            <Version>1.25.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://community.nlnetlabs.nl/t/unbound-1-25-2-released/3430).

**Security**
- CVE-2026-32665
- CVE-2026-40691
- CVE-2026-44690
- CVE-2026-55973
- CVE-2026-14586
- CVE-2026-44621
- CVE-2026-50045
- CVE-2026-50046
- CVE-2026-50243
- CVE-2026-50248
- CVE-2026-50251
- CVE-2026-50252
- CVE-2026-52863
- CVE-2026-55717
- CVE-2026-55990
- CVE-2026-55991
- CVE-2026-56416
- CVE-2026-56444
- CVE-2026-41637
- CVE-2026-42955
- CVE-2026-44687
- CVE-2026-46582
- CVE-2026-54478
- CVE-2026-55708

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild a reverse dependency, reboot and see that the internet still works.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
