### PR TITLE
wlr-randr: Update to v0.5.0

### DIFF
--- a/packages/w/wlr-randr/abi_used_symbols
+++ b/packages/w/wlr-randr/abi_used_symbols
@@ -3,10 +3,12 @@ libc.so.6:__fprintf_chk
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__stack_chk_fail
+libc.so.6:abort
 libc.so.6:calloc
 libc.so.6:free
 libc.so.6:getopt_long
 libc.so.6:optarg
+libc.so.6:optind
 libc.so.6:stderr
 libc.so.6:strcmp
 libc.so.6:strdup

--- a/packages/w/wlr-randr/package.yml
+++ b/packages/w/wlr-randr/package.yml
@@ -1,10 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : wlr-randr
-version    : 0.4.1
-release    : 1
+version    : 0.5.0
+release    : 2
 source     :
-    - https://git.sr.ht/~emersion/wlr-randr/refs/download/v0.4.1/wlr-randr-0.4.1.tar.gz : fd5783002c13d37267898e571f03b618363d13952a264cf3d61a35383869d631
-homepage   : https://git.sr.ht/~emersion/wlr-randr
+    - https://gitlab.freedesktop.org/emersion/wlr-randr/-/archive/v0.5.0/wlr-randr-v0.5.0.tar.bz2 : 
+        eae7dd785b2a19c82fd33ca281706616b12b1e5e62042156ab39407c39074b8c
+homepage   : https://gitlab.freedesktop.org/emersion/wlr-randr
 license    : MIT
 component  : desktop
 summary    : An xrandr clone for wlroots compositors
@@ -12,9 +13,11 @@ description: |
     Utility to manage outputs of a Wayland compositor.
 builddeps  :
     - pkgconfig(wayland-client)
+    - scdoc
 setup      : |
     %meson_configure
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE

--- a/packages/w/wlr-randr/pspec_x86_64.xml
+++ b/packages/w/wlr-randr/pspec_x86_64.xml
@@ -1,7 +1,7 @@
 <PISI>
     <Source>
         <Name>wlr-randr</Name>
-        <Homepage>https://git.sr.ht/~emersion/wlr-randr</Homepage>
+        <Homepage>https://gitlab.freedesktop.org/emersion/wlr-randr</Homepage>
         <Packager>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>
@@ -21,12 +21,14 @@
         <PartOf>desktop</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/wlr-randr</Path>
+            <Path fileType="data">/usr/share/licenses/wlr-randr/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/wlr-randr.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-12-31</Date>
-            <Version>0.4.1</Version>
+        <Update release="2">
+            <Date>2026-07-24</Date>
+            <Version>0.5.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://gitlab.freedesktop.org/emersion/wlr-randr/-/releases/v0.5.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Toggle a display off an on.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
