### PR TITLE
mako-notify: Update to v1.11.0

### DIFF
--- a/packages/m/mako-notify/package.yml
+++ b/packages/m/mako-notify/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : mako-notify
-version    : 1.10.0
-release    : 1
+version    : 1.11.0
+release    : 2
 source     :
-    - https://github.com/emersion/mako/releases/download/v1.10.0/mako-1.10.0.tar.gz : a72543f7b92568a0c3c45a5c0e3487ced65c18003eecd9b7d017a6464e7cef82
-homepage   : https://wayland.emersion.fr/mako
+    - https://github.com/emersion/mako/releases/download/v1.11.0/mako-1.11.0.tar.gz : e97eb5bd0dc6a9159019949f48b3db4e8781b56bd6377bd65827e1cb440a7def
+homepage   : https://github.com/emersion/mako
 license    : MIT
 component  : desktop
 summary    : A lightweight Wayland notification daemon
@@ -18,10 +18,12 @@ builddeps  :
     - pkgconfig(wayland-protocols)
     - scdoc
 setup      : |
-    %meson_configure -Dsd-bus-provider='libsystemd'
+    %meson_configure \
+        -Dsd-bus-provider='libsystemd'
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE
 
-    install -Dm00644 -t $installdir/usr/lib/systemd/user contrib/systemd/mako.service
+    install -Dm00644 -t ${installdir}/usr/lib/systemd/user contrib/systemd/mako.service

--- a/packages/m/mako-notify/pspec_x86_64.xml
+++ b/packages/m/mako-notify/pspec_x86_64.xml
@@ -1,7 +1,7 @@
 <PISI>
     <Source>
         <Name>mako-notify</Name>
-        <Homepage>https://wayland.emersion.fr/mako</Homepage>
+        <Homepage>https://github.com/emersion/mako</Homepage>
         <Packager>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>
@@ -24,15 +24,16 @@
             <Path fileType="executable">/usr/bin/makoctl</Path>
             <Path fileType="library">/usr/lib/systemd/user/mako.service</Path>
             <Path fileType="data">/usr/share/dbus-1/services/fr.emersion.mako.service</Path>
-            <Path fileType="man">/usr/share/man/man1/mako.1</Path>
-            <Path fileType="man">/usr/share/man/man1/makoctl.1</Path>
-            <Path fileType="man">/usr/share/man/man5/mako.5</Path>
+            <Path fileType="data">/usr/share/licenses/mako-notify/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/mako.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/makoctl.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/mako.5.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2025-06-18</Date>
-            <Version>1.10.0</Version>
+        <Update release="2">
+            <Date>2026-07-24</Date>
+            <Version>1.11.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/emersion/mako/releases/tag/v1.11.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `notify-send test` while `mako` is running.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
