### PR TITLE
gnome-online-accounts-gtk: Update to v3.50.10

### DIFF
--- a/packages/g/gnome-online-accounts-gtk/package.yml
+++ b/packages/g/gnome-online-accounts-gtk/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-online-accounts-gtk
-version    : 3.50.4
-release    : 3
+version    : 3.50.10
+release    : 4
 source     :
-    - https://github.com/xapp-project/gnome-online-accounts-gtk/archive/refs/tags/3.50.4.tar.gz : 661192f5092cf722fb883d364f1f3555a4f2c00194e5c27f92e2ac0db65f1e93
+    - https://github.com/xapp-project/gnome-online-accounts-gtk/archive/refs/tags/3.50.10.tar.gz : 1335240713781c7f88d3d0a179cd275d309fd010cbd9d9048518560a75d774ac
 homepage   : https://github.com/xapp-project/gnome-online-accounts-gtk
 license    : GPL-3.0-or-later
 component  : desktop.gtk
@@ -15,6 +15,7 @@ builddeps  :
     - pkgconfig(gtk4)
 rundeps    :
     - gvfs-goa
+    - xapp-symbolic-icons
 setup      : |
     %meson_configure
 build      : |

--- a/packages/g/gnome-online-accounts-gtk/pspec_x86_64.xml
+++ b/packages/g/gnome-online-accounts-gtk/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-online-accounts-gtk</Name>
         <Homepage>https://github.com/xapp-project/gnome-online-accounts-gtk</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>alfi@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.gtk</PartOf>
@@ -24,33 +24,52 @@
             <Path fileType="data">/usr/share/applications/gnome-online-accounts-gtk.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/gnome-online-accounts-gtk.svg</Path>
             <Path fileType="data">/usr/share/licenses/gnome-online-accounts-gtk/COPYING</Path>
+            <Path fileType="localedata">/usr/share/locale/am/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/br/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cy/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/el/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/en_CA/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/en_GB/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/et/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/eu/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fil/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr_CA/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/gl/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/he/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hi/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hr/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ia/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/is/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kn/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/lo/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/lv/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/mk/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ml/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/mnw/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ms/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nb/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nn/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/oc/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
@@ -59,7 +78,12 @@
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sk/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sl/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sq/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/su/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/te/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/th/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uz/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
@@ -69,12 +93,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-06-01</Date>
-            <Version>3.50.4</Version>
+        <Update release="4">
+            <Date>2026-07-24</Date>
+            <Version>3.50.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>alfi@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/xapp-project/gnome-online-accounts-gtk/blob/3.50.10/debian/changelog).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Launch the application.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
