### PR TITLE
gammastep: Update to v2.0.11

### DIFF
--- a/packages/g/gammastep/abi_used_symbols
+++ b/packages/g/gammastep/abi_used_symbols
@@ -18,12 +18,14 @@ libc.so.6:bindtextdomain
 libc.so.6:calloc
 libc.so.6:clock_gettime
 libc.so.6:close
+libc.so.6:closedir
 libc.so.6:dcgettext
 libc.so.6:execl
 libc.so.6:exit
 libc.so.6:fclose
 libc.so.6:fcntl
 libc.so.6:fgets
+libc.so.6:fnmatch
 libc.so.6:fopen
 libc.so.6:fork
 libc.so.6:fputc
@@ -137,6 +139,10 @@ libwayland-client.so.0:wl_display_dispatch_queue
 libwayland-client.so.0:wl_display_flush
 libwayland-client.so.0:wl_display_roundtrip
 libwayland-client.so.0:wl_event_queue_destroy
+libwayland-client.so.0:wl_list_empty
+libwayland-client.so.0:wl_list_init
+libwayland-client.so.0:wl_list_insert
+libwayland-client.so.0:wl_list_remove
 libwayland-client.so.0:wl_output_interface
 libwayland-client.so.0:wl_proxy_add_listener
 libwayland-client.so.0:wl_proxy_destroy

--- a/packages/g/gammastep/package.yml
+++ b/packages/g/gammastep/package.yml
@@ -1,15 +1,17 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gammastep
-version    : 2.0.9
-release    : 3
+version    : 2.0.11
+release    : 4
 source     :
-    - https://gitlab.com/chinstrap/gammastep/-/archive/v2.0.9/gammastep-v2.0.9.tar.bz2 : 371c66ff8eac9c8795afe014493dc347d0242493bbb2fe13bfaee14b42a29328
+    - https://gitlab.com/chinstrap/gammastep/-/archive/v2.0.11/gammastep-v2.0.11.tar.bz2 : b5ca6413205a2bbee4b4ffd10b0bec31f141b792e91b56bad1917facb2176c07
 homepage   : https://gitlab.com/chinstrap/gammastep
 # src/gamma-control.xml is licensed under MIT
 license    :
     - GPL-3.0-or-later
     - MIT
-component  : desktop
+component  :
+    - indicator : desktop
+    - desktop
 summary    :
     - indicator : Status icon for gammastep that allows the user to control color temperature
     - Adjust the color temperature of your screen according to your surroundings
@@ -34,6 +36,7 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
 patterns   :
     - indicator :
         - /usr/bin/gammastep-indicator

--- a/packages/g/gammastep/pspec_x86_64.xml
+++ b/packages/g/gammastep/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gammastep</Name>
         <Homepage>https://gitlab.com/chinstrap/gammastep</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <License>MIT</License>
@@ -25,6 +25,7 @@
             <Path fileType="library">/usr/lib/systemd/user/gammastep.service</Path>
             <Path fileType="data">/usr/share/applications/gammastep.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/gammastep.svg</Path>
+            <Path fileType="data">/usr/share/licenses/gammastep/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/gammastep.mo</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/gammastep.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/gammastep.mo</Path>
@@ -69,8 +70,9 @@
         <Summary xml:lang="en">Status icon for gammastep that allows the user to control color temperature</Summary>
         <Description xml:lang="en">Adjust the color temperature of your screen according to your surroundings. This may help your eyes hurt less if you are working in front of the screen at night.
 </Description>
+        <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="3">gammastep</Dependency>
+            <Dependency releaseFrom="4">gammastep</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gammastep-indicator</Path>
@@ -102,12 +104,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-06-07</Date>
-            <Version>2.0.9</Version>
+        <Update release="4">
+            <Date>2026-07-24</Date>
+            <Version>2.0.11</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://gitlab.com/chinstrap/gammastep/-/blob/v2.0.11/NEWS.md).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Update and change the screen brightness on Budgie.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
