### PR TITLE
nmon: Update to v16s

### DIFF
--- a/packages/n/nmon/abi_used_symbols
+++ b/packages/n/nmon/abi_used_symbols
@@ -1,11 +1,14 @@
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__read_chk
 libc.so.6:__snprintf_chk
+libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:chdir
 libc.so.6:close
@@ -64,8 +67,6 @@ libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strtod
-libc.so.6:strtol
-libc.so.6:strtoll
 libc.so.6:sysconf
 libc.so.6:system
 libc.so.6:time

--- a/packages/n/nmon/package.yml
+++ b/packages/n/nmon/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nmon
-version    : 16q
-release    : 5
+version    : 16s
+release    : 6
 source     :
-    - https://sourceforge.net/projects/nmon/files/lmon16q.c : 1b78a81672c19291b3d11a6e319dd9b23a022a262dba1efcea008d6df51aca51
+    - https://sourceforge.net/projects/nmon/files/lmon16s.c : 0736ce0f729e48c124a7ba566c069c5a234511cc9c6ac9277da92f8bb44f2b11
 homepage   : https://nmon.sourceforge.io/
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/n/nmon/pspec_x86_64.xml
+++ b/packages/n/nmon/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nmon</Name>
         <Homepage>https://nmon.sourceforge.io/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-05-18</Date>
-            <Version>16q</Version>
+        <Update release="6">
+            <Date>2026-07-25</Date>
+            <Version>16s</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Added -w option for larger TimeStamp numbers
- NFS4 fix
- Larger numbers of CPUs. Improved help text

**Test Plan**

- Run nmon, see some cpu numbers

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
