### PR TITLE
libxfce4windowing: Update to v4.20.6

### DIFF
--- a/packages/l/libxfce4windowing/abi_symbols
+++ b/packages/l/libxfce4windowing/abi_symbols
@@ -38,6 +38,7 @@ libxfce4windowing-0.so.0:xfw_monitor_subpixel_get_type
 libxfce4windowing-0.so.0:xfw_monitor_transform_get_type
 libxfce4windowing-0.so.0:xfw_screen_get_active_window
 libxfce4windowing-0.so.0:xfw_screen_get_default
+libxfce4windowing-0.so.0:xfw_screen_get_monitor_from_gdk_monitor
 libxfce4windowing-0.so.0:xfw_screen_get_monitors
 libxfce4windowing-0.so.0:xfw_screen_get_primary_monitor
 libxfce4windowing-0.so.0:xfw_screen_get_seats

--- a/packages/l/libxfce4windowing/abi_used_symbols
+++ b/packages/l/libxfce4windowing/abi_used_symbols
@@ -59,6 +59,7 @@ libgdk-3.so.0:gdk_monitor_get_type
 libgdk-3.so.0:gdk_rectangle_equal
 libgdk-3.so.0:gdk_rectangle_get_type
 libgdk-3.so.0:gdk_rectangle_intersect
+libgdk-3.so.0:gdk_rectangle_union
 libgdk-3.so.0:gdk_screen_get_default
 libgdk-3.so.0:gdk_screen_get_display
 libgdk-3.so.0:gdk_screen_get_root_window
@@ -200,6 +201,7 @@ libglib-2.0.so.0:g_string_replace
 libglib-2.0.so.0:g_strndup
 libglib-2.0.so.0:g_strv_contains
 libglib-2.0.so.0:g_timeout_add
+libglib-2.0.so.0:g_timeout_add_seconds
 libglib-2.0.so.0:g_unichar_totitle
 libglib-2.0.so.0:g_utf8_validate
 libglib-2.0.so.0:g_warn_message
@@ -272,6 +274,7 @@ libgobject-2.0.so.0:g_value_set_object
 libgobject-2.0.so.0:g_value_set_pointer
 libgobject-2.0.so.0:g_value_set_string
 libgobject-2.0.so.0:g_value_set_uint
+libgobject-2.0.so.0:g_value_take_boxed
 libgtk-3.so.0:gtk_bin_get_child
 libgtk-3.so.0:gtk_check_menu_item_new_with_mnemonic
 libgtk-3.so.0:gtk_check_menu_item_set_active
@@ -400,6 +403,7 @@ libwnck-3.so.0:wnck_window_unpin
 libwnck-3.so.0:wnck_window_unshade
 libwnck-3.so.0:wnck_workspace_activate
 libwnck-3.so.0:wnck_workspace_change_name
+libwnck-3.so.0:wnck_workspace_get_height
 libwnck-3.so.0:wnck_workspace_get_layout_column
 libwnck-3.so.0:wnck_workspace_get_layout_row
 libwnck-3.so.0:wnck_workspace_get_name

--- a/packages/l/libxfce4windowing/package.yml
+++ b/packages/l/libxfce4windowing/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libxfce4windowing
-version    : 4.20.5
-release    : 9
+version    : 4.20.6
+release    : 10
 source     :
-    - https://archive.xfce.org/src/xfce/libxfce4windowing/4.20/libxfce4windowing-4.20.5.tar.bz2 : 6b4e19a66db650c9c8a88f00bbf266e9ced0070b7dbc0aaeea05be0fc6a2eb4d
+    - https://archive.xfce.org/src/xfce/libxfce4windowing/4.20/libxfce4windowing-4.20.6.tar.bz2 : 2d06b6a567c965afbca1a51419fc728fd83bd0460e30ab62c34564d5e0aac9e3
 homepage   : https://gitlab.xfce.org/xfce/libxfce4windowing
 license    : LGPL-2.1-or-later
 component  : desktop.library

--- a/packages/l/libxfce4windowing/pspec_x86_64.xml
+++ b/packages/l/libxfce4windowing/pspec_x86_64.xml
@@ -58,6 +58,7 @@ Currently, X11 is fully supported, via libwnck.  Wayland is partially supported,
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/libxfce4windowing.mo</Path>
             <Path fileType="localedata">/usr/share/locale/kk/LC_MESSAGES/libxfce4windowing.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/libxfce4windowing.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/lo/LC_MESSAGES/libxfce4windowing.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/libxfce4windowing.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nb/LC_MESSAGES/libxfce4windowing.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/libxfce4windowing.mo</Path>
@@ -90,7 +91,7 @@ Currently, X11 is fully supported, via libwnck.  Wayland is partially supported,
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">libxfce4windowing</Dependency>
+            <Dependency release="10">libxfce4windowing</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xfce4/libxfce4windowing-0/libxfce4windowing/libxfce4windowing-config.h</Path>
@@ -123,9 +124,9 @@ Currently, X11 is fully supported, via libwnck.  Wayland is partially supported,
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2026-01-23</Date>
-            <Version>4.20.5</Version>
+        <Update release="10">
+            <Date>2026-07-25</Date>
+            <Version>4.20.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://gitlab.xfce.org/xfce/libxfce4windowing/-/blob/libxfce4windowing-4.20.6/NEWS).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild a reverse dependency.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
