### PR TITLE
Add katifetch package with installation instructions

### DIFF
--- a/packages/k/katifetch/package.yml
+++ b/packages/k/katifetch/package.yml
@@ -1,0 +1,14 @@
+name        : katifetch
+version     : 13.1
+release     : 1
+source      :
+    - https://github.com/ximimoments/katifetch/archive/refs/tags/13.1.tar.gz : 93ef6bf75ef2eb0e5edc8b4931a5ebfbe8caaf9bc9a685cb48dc10ca1c22cbce
+license     : GPL-3.0-or-later
+component   : system.utils
+summary     : Custom system information tool
+description : |
+    Katifetch is a lightweight system information fetch utility.
+rundeps     :
+    - bash
+install     : |
+    install -Dm755 katifetch $installDir/usr/bin/katifetch


### PR DESCRIPTION
Katifetch is a lightweight system information fetch utility that requires bash. It is installed to the user's bin directory.

**Summary**

This PR adds `katifetch` version 13.1, a lightweight system information fetch utility. It installs the script directly to `/usr/bin/katifetch` and sets `bash` as a runtime dependency.

**Test Plan**

- Verified `package.yml` syntax.
- Checked source URL and SHA256 checksum validity for the 13.1 release tarball.
- Verified file permissions and installation path (`/usr/bin/katifetch`).

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.