### PR TITLE
weechat: Update to v4.9.5

### DIFF
--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : weechat
-version    : 4.9.4
-release    : 108
+version    : 4.9.5
+release    : 109
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.9.4.tar.gz : 13e4f4873c25748df34a56d6580f779885f6ae83d4980d0cb5da953ce3dd46f5
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.9.5.tar.gz : 045bb0f4c9bc0298ce8d595b15dbc675406c0b538feb09cb475a3a292a076577
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -92,7 +92,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="108">weechat</Dependency>
+            <Dependency release="109">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -100,9 +100,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="108">
-            <Date>2026-07-23</Date>
-            <Version>4.9.4</Version>
+        <Update release="109">
+            <Date>2026-07-26</Date>
+            <Version>4.9.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/weechat/weechat/releases/tag/v4.9.5).

**Security**
- GHSA-rfmh-3r7f-jpx5
- GHSA-q2xg-9ggx-77mr
- GHSA-hx59-4hq9-6vmw

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
