### PR TITLE
tree-sitter: Update to 0.26.11

### DIFF
--- a/packages/t/tree-sitter/abi_used_symbols
+++ b/packages/t/tree-sitter/abi_used_symbols
@@ -22,6 +22,7 @@ libc.so.6:cfmakeraw
 libc.so.6:chdir
 libc.so.6:chroot
 libc.so.6:clock_gettime
+libc.so.6:clock_nanosleep
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:connect
@@ -79,7 +80,6 @@ libc.so.6:mkdir
 libc.so.6:mmap64
 libc.so.6:mprotect
 libc.so.6:munmap
-libc.so.6:nanosleep
 libc.so.6:open
 libc.so.6:open64
 libc.so.6:openat64

--- a/packages/t/tree-sitter/package.yml
+++ b/packages/t/tree-sitter/package.yml
@@ -1,17 +1,17 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : tree-sitter
-version    : 0.26.8
-release    : 21
+version    : 0.26.11
+release    : 22
 source     :
-    - https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.26.8.tar.gz : e6826b7533ec3a885aba598377a6d20b5a6321ff3db76968e960c2352d3a5077
+    - https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.26.11.tar.gz : 1bab01ed21464f3272665b9c60e39ee79f68da1333e80b23f2c9356569d06971
 license    : MIT
-component  : 
+component  :
     - programming.library
-    - cli: programming.tools
+    - cli : programming.tools
 homepage   : https://tree-sitter.github.io
 summary    :
     - An incremental parsing system for programming tools
-    - cli: CLI tool for developing, testing, and using Tree-sitter parsers
+    - cli : CLI tool for developing, testing, and using Tree-sitter parsers
 description: |
     Tree-sitter is a parser generator tool and an incremental parsing library.
 networking : true
@@ -32,5 +32,5 @@ install    : |
     install -Dm00755 target/release/tree-sitter -t $installdir/usr/bin
     %install_license LICENSE
 patterns   :
-    - cli:
+    - cli :
         - /usr/bin

--- a/packages/t/tree-sitter/pspec_x86_64.xml
+++ b/packages/t/tree-sitter/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>tree-sitter</Name>
         <Homepage>https://tree-sitter.github.io</Homepage>
         <Packager>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.library</PartOf>
@@ -41,7 +41,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">tree-sitter</Dependency>
+            <Dependency release="22">tree-sitter</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/tree_sitter/api.h</Path>
@@ -50,12 +50,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2026-04-25</Date>
-            <Version>0.26.8</Version>
+        <Update release="22">
+            <Date>2026-07-27</Date>
+            <Version>0.26.11</Version>
             <Comment>Packaging update</Comment>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- [0.26.11 Change Log](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.26.11)
- [0.26.10 Change Log](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.26.10)
- [0.26.9 Change Log](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.26.9)

**Test Plan**
- Use tree-sitter to parse a test file

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
