### PR TITLE
glibc: Rebuild to fix getconf breakage

### DIFF
--- a/packages/g/glibc/package.yml
+++ b/packages/g/glibc/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : glibc
 version    : '2.43'
-release    : 142
+release    : 143
 source     :
     # release/2.43/master
     - git|https://sourceware.org/git/glibc.git : 1c9988e52540c844928c6d93ff45305adc2c24a0

--- a/packages/g/glibc/pspec_x86_64.xml
+++ b/packages/g/glibc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>glibc</Name>
         <Homepage>https://www.gnu.org/software/libc/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -7020,7 +7020,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="142">glibc</Dependency>
+            <Dependency release="143">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib32/ld-linux.so.2</Path>
@@ -7321,8 +7321,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="142">glibc-32bit</Dependency>
-            <Dependency release="142">glibc-devel</Dependency>
+            <Dependency release="143">glibc-devel</Dependency>
+            <Dependency release="143">glibc-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/Mcrt1.o</Path>
@@ -7856,7 +7856,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="142">glibc</Dependency>
+            <Dependency release="143">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mtrace</Path>
@@ -8377,12 +8377,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="142">
-            <Date>2026-07-20</Date>
+        <Update release="143">
+            <Date>2026-07-27</Date>
             <Version>2.43</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

User [reported](https://discuss.getsol.us/d/12893-week-30-2026/21)
```
# getconf
-bash: /usr/bin/getconf: Permission denied

# ls -la /usr/bin/getconf
-rwxr-xr-x 4 root root 31192 Jul 21 06:01 /usr/bin/getconf

# file /usr/bin/getconf
/usr/bin/getconf: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter *empty*, for GNU/Linux 6.1.0, stripped

# ldd /usr/bin/getconf
/usr/bin/getconf: error while loading shared libraries: /usr/bin/getconf: unsupported version 0 of Verneed record
```

After rebuilding:
```
❯ getconf PAGE_SIZE
4096

❯ file /usr/bin/getconf
/usr/bin/getconf: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /usr/lib64/ld-linux-x86-64.so.2, BuildID[sha1]=4ba3ae262246fa96bd648f035545f7861b88f97e, for GNU/Linux 6.1.0, stripped

❯ ldd /usr/bin/getconf
        linux-vdso.so.1 (0x00007f6d38e24000)
        libc.so.6 => /usr/lib/glibc-hwcaps/x86-64-v3/libc.so.6 (0x00007f6d38a00000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x00007f6d38e26000)
```

**Test Plan**

- Test getconf works

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
