### PR TITLE
python-asttokens: Update to v3.0.2

### DIFF
--- a/packages/py/python-asttokens/package.yml
+++ b/packages/py/python-asttokens/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-asttokens
-version    : 3.0.1
-release    : 20
+version    : 3.0.2
+release    : 21
 source     :
-    - https://files.pythonhosted.org/packages/source/a/asttokens/asttokens-3.0.1.tar.gz : 71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7
+    - https://files.pythonhosted.org/packages/source/a/asttokens/asttokens-3.0.2.tar.gz : 3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2
 homepage   : https://github.com/gristlabs/asttokens
 license    : Apache-2.0
 component  : programming.python
@@ -20,8 +20,8 @@ checkdeps  :
     - python-astroid
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    %pytest -v

--- a/packages/py/python-asttokens/pspec_x86_64.xml
+++ b/packages/py/python-asttokens/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-asttokens</Name>
         <Homepage>https://github.com/gristlabs/asttokens</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,13 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.1.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.2.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.2.dist-info/scm_file_list.json</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.2.dist-info/scm_version.json</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens-3.0.2.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/asttokens/__pycache__/__init__.cpython-314.pyc</Path>
@@ -50,12 +52,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-06-05</Date>
-            <Version>3.0.1</Version>
+        <Update release="21">
+            <Date>2026-07-27</Date>
+            <Version>3.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/gristlabs/asttokens/releases/tag/v3.0.2).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Update and make sure Thonny still works.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
