### PR TITLE
python-colorlog: Update to v6.12.0

### DIFF
--- a/packages/py/python-colorlog/package.yml
+++ b/packages/py/python-colorlog/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-colorlog
-version    : 6.9.0
-release    : 16
+version    : 6.12.0
+release    : 17
 source     :
-    - https://github.com/borntyping/python-colorlog/archive/refs/tags/v6.9.0.tar.gz : 92a779e4f89c4bbdf9af60ea157d998a0a9b59cce5168107e1a90da417596060
+    - https://github.com/borntyping/python-colorlog/archive/refs/tags/v6.12.0.tar.gz : e2af839288367ac5785e819fc288a7fcf9b63a48883dcd5c677e4c627cd3f4f7
 homepage   : https://github.com/borntyping/python-colorlog
 license    : MIT
 component  : programming.python
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest
+    %pytest -v

--- a/packages/py/python-colorlog/pspec_x86_64.xml
+++ b/packages/py/python-colorlog/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-colorlog</Name>
         <Homepage>https://github.com/borntyping/python-colorlog</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog-6.9.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog-6.9.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog-6.9.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog-6.9.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog-6.9.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog-6.12.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog-6.12.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog-6.12.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog-6.12.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog-6.12.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/colorlog/__pycache__/__init__.cpython-314.pyc</Path>
@@ -41,12 +41,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2026-06-05</Date>
-            <Version>6.9.0</Version>
+        <Update release="17">
+            <Date>2026-07-27</Date>
+            <Version>6.12.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- When logging exceptions, enable colorized traceback
- Fix LevelFormatter KeyError on unlisted or custom log levels

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

TBD

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
