### PR TITLE
uv: Update to v0.11.32

### DIFF
--- a/packages/u/uv/abi_used_libs
+++ b/packages/u/uv/abi_used_libs
@@ -1,4 +1,5 @@
 ld-linux-x86-64.so.2
 libc.so.6
 libgcc_s.so.1
+liblzma.so.5
 libm.so.6

--- a/packages/u/uv/abi_used_symbols
+++ b/packages/u/uv/abi_used_symbols
@@ -218,5 +218,10 @@ libgcc_s.so.1:_Unwind_RaiseException
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
+liblzma.so.5:lzma_alone_encoder
+liblzma.so.5:lzma_code
+liblzma.so.5:lzma_easy_encoder
+liblzma.so.5:lzma_end
+liblzma.so.5:lzma_lzma_preset
 libm.so.6:log2f
 libm.so.6:pow

--- a/packages/u/uv/files/downstream-bin.patch
+++ b/packages/u/uv/files/downstream-bin.patch
@@ -1,0 +1,36 @@
+From 2a9baed6b1246c566e1bed531b17363277e99c0f Mon Sep 17 00:00:00 2001
+From: "Benjamin A. Beasley" <code@musicinmybrain.net>
+Date: Sun, 23 Jun 2024 16:29:05 -0400
+Subject: [PATCH] Downstream patch: always find the system-wide uv executable
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+“Should uv.find_uv_bin() be able to find /usr/bin/uv?”
+https://github.com/astral-sh/uv/issues/4451
+---
+ python/uv/_find_uv.py | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/python/uv/_find_uv.py b/python/uv/_find_uv.py
+index 736288a4c..306451db2 100644
+--- a/python/uv/_find_uv.py
++++ b/python/uv/_find_uv.py
+@@ -35,6 +35,14 @@ def find_uv_bin() -> str:
+         sysconfig.get_path("scripts", scheme=_user_scheme()),
+     ]
+ 
++    # Downstream patch: always find the system-wide uv executable
++    #
++    # “Should uv.find_uv_bin() be able to find /usr/bin/uv?”
++    #  https://github.com/astral-sh/uv/issues/4451
++    bindir_path = sysconfig.get_config_var("BINDIR")
++    if bindir_path is not None:
++        targets.insert(0, os.path.join(bindir_path, uv_exe))
++
+     seen = []
+     for target in targets:
+         if not target:
+-- 
+2.50.1
+

--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -2,16 +2,22 @@
 #
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : uv
-version    : 0.11.28
-release    : 18
+version    : 0.11.32
+release    : 19
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.28.tar.gz : 556c6cb42a2101c690704b08d0d3c5d596ea94e69353a820664568f0fcd62fd4
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.32.tar.gz : 62799114a5914728b0de55e65ae856e599fe3103eef9997b479cfc7acdd6ae67
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0
     - MIT
-component  : programming.tools
-summary    : An extremely fast Python package and project manager, written in Rust.
+component  :
+    - ^python-uv : programming.python
+    - ^python-uv-build : programming.python
+    - programming.tools
+summary    :
+    - ^python-uv : An extremely fast Python package and project manager, written in Rust
+    - ^python-uv-build : PEP517 build backend for uv
+    - An extremely fast Python package and project manager, written in Rust
 description: |
     An extremely fast Python package and project manager, written in Rust.
 networking : true
@@ -21,6 +27,9 @@ builddeps  :
     - python-maturin
     - python-packaging
     - python-wheel
+rundeps    :
+    - ^python-uv :
+        - uv
 checkdeps  :
     - numpy
 environment: |
@@ -33,28 +42,50 @@ environment: |
     CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO="off"; export CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO;
     CARGO_PROFILE_RELEASE_LTO="off"; export CARGO_PROFILE_RELEASE_LTO;
     CARGO_PROFILE_RELEASE_STRIP="none"; export CARGO_PROFILE_RELEASE_STRIP;
+    
+    tripple="$(rustc --print host-tuple)"
+setup      : |
+    %patch -p1 -i ${pkgfiles}/downstream-bin.patch
+
+    %cargo_fetch
+
+    mkdir completions
 build      : |
-    %python3_setup
+    # Note: do not use --all-features as in enables a self-updater
+    maturin build --locked --release --target "${tripple}" --compatibility linux
+    maturin build --locked --release --target "${tripple}" --compatibility linux -m crates/uv-build/Cargo.toml
 
     # Build completions
-    mkdir completions
-    COMPGEN="target/release/uv --generate-shell-completion"
-    $COMPGEN bash > "completions/$package.bash"
-    $COMPGEN fish > "completions/$package.fish"
-    $COMPGEN zsh > "completions/_$package"
+    _uv="target/${tripple}/release/uv"
+    ${_uv} --generate-shell-completion bash > "completions/${package}.bash"
+    ${_uv} --generate-shell-completion fish > "completions/${package}.fish"
+    ${_uv} --generate-shell-completion zsh > "completions/_${package}"
 install    : |
-    %python3_install
+    python3 -m installer --destdir=%installroot% target/wheels/uv-${version}-*.whl
+    python3 -m installer --destdir=%installroot% target/wheels/uv_build-${version}-*.whl
 
     # Add readme
-    install -Dm00644 -t "$installdir/usr/share/doc/$package/" README.md
+    %install_file -t "${installdir}/usr/share/doc/${package}/" README.md
 
     # Install completions
-    install -Dm00644 "completions/$package.bash" -t "$installdir/usr/share/bash-completion/completions/"
-    install -Dm00644 "completions/$package.fish" -t "$installdir/usr/share/fish/vendor_completions.d/"
-    install -Dm00644 "completions/_$package" -t "$installdir/usr/share/zsh/site-functions/"
+    %install_file "completions/${package}.bash" -t "${installdir}/usr/share/bash-completion/completions/"
+    %install_file "completions/${package}.fish" -t "${installdir}/usr/share/fish/vendor_completions.d/"
+    %install_file "completions/_${package}" -t "${installdir}/usr/share/zsh/site-functions/"
 
     %install_license LICENSE*
+
+    # Ensure the correct binaries are installed
+    %install_bin target/${tripple}/release/uv
+    %install_bin target/${tripple}/release/uvx
 check      : |
     # Run smoke tests
     cd /tmp
-    "$installdir/usr/bin/uv" run "$workdir/scripts/smoke-test"
+    "${installdir}/usr/bin/uv" run "${workdir}/scripts/smoke-test"
+patterns   :
+    - ^python-uv :
+        - /usr/lib/python3.*/site-packages/uv-*
+        - /usr/lib/python3.*/site-packages/uv
+    - ^python-uv-build :
+        - /usr/bin/uv-build
+        - /usr/lib/python3.*/site-packages/uv_build
+        - /usr/lib/python3.*/site-packages/uv_build-*

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -3,32 +3,50 @@
         <Name>uv</Name>
         <Homepage>https://docs.astral.sh/uv</Homepage>
         <Packager>
-            <Name>Matthias Homann</Name>
-            <Email>palto@mailbox.org</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
-        <Summary xml:lang="en">An extremely fast Python package and project manager, written in Rust.</Summary>
+        <Summary xml:lang="en">An extremely fast Python package and project manager, written in Rust</Summary>
         <Description xml:lang="en">An extremely fast Python package and project manager, written in Rust.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>uv</Name>
-        <Summary xml:lang="en">An extremely fast Python package and project manager, written in Rust.</Summary>
+        <Summary xml:lang="en">An extremely fast Python package and project manager, written in Rust</Summary>
         <Description xml:lang="en">An extremely fast Python package and project manager, written in Rust.
 </Description>
         <PartOf>programming.tools</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/uv</Path>
             <Path fileType="executable">/usr/bin/uvx</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/licenses/LICENSE-MIT</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.28.dist-info/sboms/uv.cyclonedx.json</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/uv.bash</Path>
+            <Path fileType="doc">/usr/share/doc/uv/README.md</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/uv.fish</Path>
+            <Path fileType="data">/usr/share/licenses/uv/LICENSE-APACHE</Path>
+            <Path fileType="data">/usr/share/licenses/uv/LICENSE-MIT</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_uv</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>python-uv</Name>
+        <Summary xml:lang="en">An extremely fast Python package and project manager, written in Rust</Summary>
+        <Description xml:lang="en">An extremely fast Python package and project manager, written in Rust.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="19">uv</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/sboms/uv.cyclonedx.json</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -39,21 +57,38 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__pycache__/_find_uv.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/_find_uv.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/py.typed</Path>
-            <Path fileType="data">/usr/share/bash-completion/completions/uv.bash</Path>
-            <Path fileType="doc">/usr/share/doc/uv/README.md</Path>
-            <Path fileType="data">/usr/share/fish/vendor_completions.d/uv.fish</Path>
-            <Path fileType="data">/usr/share/licenses/uv/LICENSE-APACHE</Path>
-            <Path fileType="data">/usr/share/licenses/uv/LICENSE-MIT</Path>
-            <Path fileType="data">/usr/share/zsh/site-functions/_uv</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>python-uv-build</Name>
+        <Summary xml:lang="en">PEP517 build backend for uv</Summary>
+        <Description xml:lang="en">An extremely fast Python package and project manager, written in Rust.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/uv-build</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/sboms/uv-build.cyclonedx.json</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__main__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__pycache__/__main__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__pycache__/__main__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/py.typed</Path>
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2026-07-09</Date>
-            <Version>0.11.28</Version>
+        <Update release="19">
+            <Date>2026-07-27</Date>
+            <Version>0.11.32</Version>
             <Comment>Packaging update</Comment>
-            <Name>Matthias Homann</Name>
-            <Email>palto@mailbox.org</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/astral-sh/uv/releases/tag/0.11.32).

Added build backend and split out the Python module.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build Thonny v5.0.0, which requires the `uv_build` backend.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
