### PR TITLE
dav1d: Update to v1.5.4

### DIFF
--- a/packages/d/dav1d/abi_used_symbols
+++ b/packages/d/dav1d/abi_used_symbols
@@ -5,7 +5,6 @@ libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__sched_cpucount
 libc.so.6:__snprintf_chk
-libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strcat_chk
 libc.so.6:__sysconf
@@ -31,6 +30,7 @@ libc.so.6:isatty
 libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
+libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:nanosleep
 libc.so.6:optarg

--- a/packages/d/dav1d/package.yml
+++ b/packages/d/dav1d/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dav1d
-version    : 1.5.0
-release    : 31
+version    : 1.5.4
+release    : 32
 source     :
-    - https://code.videolan.org/videolan/dav1d/-/archive/1.5.0/dav1d-1.5.0.tar.bz2 : a6ca64e34cec56ae1c2d359e1da5c5386ecd7a3a62f931d026ac4f2ff72ade64
-    - https://code.videolan.org/videolan/dav1d-test-data/-/archive/1.5.0/dav1d-test-data-1.5.0.tar.gz#dav1d-test-data.tar.gz : acdbbdac30ea4e9df61530f8d8cab3245a34c89ab0c0b18bc8e8122cde79ca09
+    - https://code.videolan.org/videolan/dav1d/-/archive/1.5.4/dav1d-1.5.4.tar.bz2 : 2abfb0c89212e6e4733a54e0ae509ec00a5b845a6360946f918806e14aedb011
+    - https://code.videolan.org/videolan/dav1d-test-data/-/archive/1.5.4/dav1d-test-data-1.5.4.tar.gz#dav1d-test-data.tar.gz : b19926f25347a32633ffb40f6189eb750b50f1b8b02b2eb63954845a744de343
 homepage   : https://code.videolan.org/videolan/dav1d
 license    : BSD-2-Clause
 component  : multimedia.codecs
@@ -24,5 +24,6 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 check      : |
     %ninja_check

--- a/packages/d/dav1d/pspec_x86_64.xml
+++ b/packages/d/dav1d/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>dav1d</Name>
         <Homepage>https://code.videolan.org/videolan/dav1d</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>multimedia.codecs</PartOf>
@@ -25,6 +25,7 @@
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libdav1d.so.7.0.0</Path>
             <Path fileType="library">/usr/lib64/libdav1d.so.7</Path>
             <Path fileType="library">/usr/lib64/libdav1d.so.7.0.0</Path>
+            <Path fileType="data">/usr/share/licenses/dav1d/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -34,7 +35,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="31">dav1d</Dependency>
+            <Dependency release="32">dav1d</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/dav1d/common.h</Path>
@@ -48,12 +49,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2024-10-21</Date>
-            <Version>1.5.0</Version>
+        <Update release="32">
+            <Date>2026-07-28</Date>
+            <Version>1.5.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [1.5.4](https://code.videolan.org/videolan/dav1d/-/releases/1.5.4)
- [1.5.3](https://code.videolan.org/videolan/dav1d/-/releases/1.5.3)
- [1.5.2](https://code.videolan.org/videolan/dav1d/-/releases/1.5.2)

**Test Plan**

- Play an AV1 test file with VLC

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
