### PR TITLE
python-click: Update to v8.4.2

### DIFF
--- a/packages/py/python-click/package.yml
+++ b/packages/py/python-click/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-click
-version    : 8.4.1
-release    : 19
+version    : 8.4.2
+release    : 20
 source     :
-    - https://github.com/pallets/click/archive/refs/tags/8.4.1.tar.gz : 433ed8c0b5806771fcc05f009a7f3b67d82eca61601d7f30d14a43849f76c432
+    - https://github.com/pallets/click/archive/refs/tags/8.4.2.tar.gz : d5635f9b7999806a02bd323fc7a9f8c4b1cb5f600b2967d4e7e5dbb106b1c216
 homepage   : https://click.palletsprojects.com
 license    : BSD-3-Clause
 component  : programming.python
@@ -16,9 +16,9 @@ builddeps  :
     - python-installer
 checkdeps  :
     - python-pytest
-setup      : |
-    %python3_setup
+build      : |
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    %pytest -v -W ignore::pytest.PytestRemovedIn10Warning

--- a/packages/py/python-click/pspec_x86_64.xml
+++ b/packages/py/python-click/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-click</Name>
         <Homepage>https://click.palletsprojects.com</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/click-8.4.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/click-8.4.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/click-8.4.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/click-8.4.1.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/click-8.4.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/click-8.4.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/click-8.4.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/click-8.4.2.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/click/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/click/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/click/__pycache__/__init__.cpython-314.pyc</Path>
@@ -79,12 +79,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-06-12</Date>
-            <Version>8.4.1</Version>
+        <Update release="20">
+            <Date>2026-07-30</Date>
+            <Version>8.4.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixes broken fish shelll completion
- Deprecated commands no longer render a stray leading space
- echo_via_pager flushes after write
- echo_via_pager and get_pager_file no longer close a borrowed stdout
Full clangelog [here](https://github.com/pallets/click/blob/main/CHANGES.md)

**Test Plan**

- Check version via importlib
- Use the example script provided at the project page https://click.palletsprojects.com/en/stable/

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
