### PR TITLE
cryptsetup: Update to 2.8.7

### DIFF
--- a/packages/c/cryptsetup/package.yml
+++ b/packages/c/cryptsetup/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : cryptsetup
-version    : 2.8.6
-release    : 27
+version    : 2.8.7
+release    : 28
 source     :
-    - https://mirrors.edge.kernel.org/pub/linux/utils/cryptsetup/v2.8/cryptsetup-2.8.6.tar.xz : 8004265fd993885d08f7b633dbe056851de1a210307613a4ebddc743fccefe5a
+    - https://mirrors.edge.kernel.org/pub/linux/utils/cryptsetup/v2.8/cryptsetup-2.8.7.tar.xz : e776f0d381e86ca61042c457069491fe8e0ac286780c7c3b1e4f9921abc961da
 homepage   : https://gitlab.com/cryptsetup/cryptsetup
 license    :
     - GPL-2.0-or-later

--- a/packages/c/cryptsetup/pspec_x86_64.xml
+++ b/packages/c/cryptsetup/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>cryptsetup</Name>
         <Homepage>https://gitlab.com/cryptsetup/cryptsetup</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-3.0-or-later</License>
@@ -39,6 +39,7 @@
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/cryptsetup.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/cryptsetup.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/cryptsetup.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/cryptsetup.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/cryptsetup.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/cryptsetup.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/cryptsetup.mo</Path>
@@ -98,7 +99,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">cryptsetup</Dependency>
+            <Dependency release="28">cryptsetup</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcryptsetup.h</Path>
@@ -107,12 +108,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2026-04-06</Date>
-            <Version>2.8.6</Version>
+        <Update release="28">
+            <Date>2026-07-29</Date>
+            <Version>2.8.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Bugfix release
- Notoable: Address Linux kernel deprecation of the AF_ALG crypto userspace interface
- [Change Log](https://gitlab.com/cryptsetup/cryptsetup/-/blob/main/docs/v2.8.7-ReleaseNotes?ref_type=heads)

**Test Plan**
- Verify library links
- Test with LUKS device, with luksDUMP and status


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
