### PR TITLE
pip: Backport security patch

### DIFF
--- a/packages/p/pip/files/CVE-2026-13346.patch
+++ b/packages/p/pip/files/CVE-2026-13346.patch
@@ -1,0 +1,734 @@
+From 65a933ef8d0a7b07ffd6399b12174288b8982ee6 Mon Sep 17 00:00:00 2001
+From: Damian Shaw <damian.peter.shaw@gmail.com>
+Date: Fri, 26 Jun 2026 13:55:21 -0400
+Subject: [PATCH 1/4] Fix Link.filename decoding URL path twice
+
+---
+ src/pip/_internal/models/link.py        |  2 +-
+ src/pip/_internal/network/download.py   |  5 ++-
+ src/pip/_internal/operations/prepare.py |  6 ++--
+ src/pip/_internal/utils/unpacking.py    | 13 +++++++
+ tests/unit/test_link.py                 | 24 +++++++++++++
+ tests/unit/test_utils_unpacking.py      | 46 +++++++++++++++++++++++++
+ 6 files changed, 91 insertions(+), 5 deletions(-)
+
+diff --git a/src/pip/_internal/models/link.py b/src/pip/_internal/models/link.py
+index 0a09c66222..896ea5b09d 100644
+--- a/src/pip/_internal/models/link.py
++++ b/src/pip/_internal/models/link.py
+@@ -425,6 +425,7 @@ def redacted_url(self) -> str:
+ 
+     @property
+     def filename(self) -> str:
++        # ``self.path`` is already unquoted in ``__init__``; don't unquote again.
+         path = self.path.rstrip("/")
+         name = posixpath.basename(path)
+         if not name:
+@@ -433,7 +434,6 @@ def filename(self) -> str:
+             netloc, user_pass = split_auth_from_netloc(self.netloc)
+             return netloc
+ 
+-        name = urllib.parse.unquote(name)
+         assert name, f"URL {self._url!r} produced no filename"
+         return name
+ 
+diff --git a/src/pip/_internal/network/download.py b/src/pip/_internal/network/download.py
+index b8ac36cd27..cd74b855f9 100644
+--- a/src/pip/_internal/network/download.py
++++ b/src/pip/_internal/network/download.py
+@@ -24,6 +24,7 @@
+ from pip._internal.network.session import CacheControlAdapter, PipSession
+ from pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
+ from pip._internal.utils.misc import format_size, redact_auth_from_url, splitext
++from pip._internal.utils.unpacking import join_within_directory
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -187,7 +188,9 @@ def __call__(self, link: Link, location: str) -> tuple[str, str]:
+         resp = self._http_get(link)
+         download_size = _get_http_response_size(resp)
+ 
+-        filepath = os.path.join(location, _get_http_response_filename(resp, link))
++        filepath = join_within_directory(
++            location, _get_http_response_filename(resp, link)
++        )
+         with open(filepath, "wb") as content_file:
+             download = _FileDownload(link, content_file, download_size)
+             self._process_response(download, resp)
+diff --git a/src/pip/_internal/operations/prepare.py b/src/pip/_internal/operations/prepare.py
+index afcc0376da..c71104f127 100644
+--- a/src/pip/_internal/operations/prepare.py
++++ b/src/pip/_internal/operations/prepare.py
+@@ -53,7 +53,7 @@
+     redact_auth_from_requirement,
+ )
+ from pip._internal.utils.temp_dir import TempDirectory
+-from pip._internal.utils.unpacking import unpack_file
++from pip._internal.utils.unpacking import join_within_directory, unpack_file
+ from pip._internal.vcs import vcs
+ 
+ if TYPE_CHECKING:
+@@ -201,7 +201,7 @@ def _check_download_dir(
+     """Check download_dir for previously downloaded file with correct hash
+     If a correct file is found return its path else None
+     """
+-    download_path = os.path.join(download_dir, link.filename)
++    download_path = join_within_directory(download_dir, link.filename)
+ 
+     if not os.path.exists(download_path):
+         return None
+@@ -687,7 +687,7 @@ def save_linked_requirement(self, req: InstallRequirement) -> None:
+             # No distribution was downloaded for this requirement.
+             return
+ 
+-        download_location = os.path.join(self.download_dir, link.filename)
++        download_location = join_within_directory(self.download_dir, link.filename)
+         if not os.path.exists(download_location):
+             shutil.copy(req.local_file_path, download_location)
+             download_path = display_path(download_location)
+diff --git a/src/pip/_internal/utils/unpacking.py b/src/pip/_internal/utils/unpacking.py
+index 8a9b2059ca..1a7c3ba236 100644
+--- a/src/pip/_internal/utils/unpacking.py
++++ b/src/pip/_internal/utils/unpacking.py
+@@ -87,6 +87,19 @@ def is_within_directory(directory: str, target: str) -> bool:
+     return abs_target == abs_directory or abs_target.startswith(abs_directory + os.sep)
+ 
+ 
++def join_within_directory(directory: str, name: str) -> str:
++    """Join ``name`` onto ``directory`` as a single path component.
++
++    ``name`` is reduced to its basename; ``ValueError`` is raised if that is
++    empty, ``.``, or ``..``.
++    """
++    name = os.path.basename(name)
++    target = os.path.join(directory, name)
++    if name in ("", os.curdir, os.pardir) or not is_within_directory(directory, target):
++        raise ValueError(f"Unexpected file name derived from URL: {name!r}")
++    return target
++
++
+ def _get_default_mode_plus_executable() -> int:
+     return 0o777 & ~current_umask() | 0o111
+ 
+diff --git a/tests/unit/test_link.py b/tests/unit/test_link.py
+index c49f8547ac..2cd1c20a83 100644
+--- a/tests/unit/test_link.py
++++ b/tests/unit/test_link.py
+@@ -1,5 +1,7 @@
+ from __future__ import annotations
+ 
++import posixpath
++
+ import pytest
+ 
+ from pip._internal.exceptions import InvalidEggFragment, PipError
+@@ -29,6 +31,13 @@ def test_repr(self, url: str, expected: str) -> None:
+             ("https://example.com/path/page.html", "page.html"),
+             # Test a quoted character.
+             ("https://example.com/path/page%231.html", "page#1.html"),
++            # A doubly-encoded separator must stay encoded: the path is decoded
++            # exactly once, so the file name keeps its literal "%2F" instead of
++            # collapsing into a "/".
++            (
++                "https://example.com/a%252Fb.whl",
++                "a%2Fb.whl",
++            ),
+             (
+                 "http://yo/myproject-1.0%2Bfoobar.0-py2.py3-none-any.whl",
+                 "myproject-1.0+foobar.0-py2.py3-none-any.whl",
+@@ -49,6 +58,21 @@ def test_filename(self, url: str, expected: str) -> None:
+         link = Link(url)
+         assert link.filename == expected
+ 
++    @pytest.mark.parametrize(
++        "url",
++        [
++            "https://example.com/a%252Fb.whl",
++            "https://example.com/%252e%252e%252fb.whl",
++        ],
++    )
++    def test_filename_decoded_once_stays_single_component(self, url: str) -> None:
++        # The path is decoded exactly once, so an encoded separator stays
++        # encoded and the file name remains a single path component rather
++        # than collapsing into a "/"-separated path.
++        filename = Link(url).filename
++        assert not posixpath.isabs(filename)
++        assert posixpath.basename(filename) == filename
++
+     def test_splitext(self) -> None:
+         assert ("wheel", ".whl") == Link("http://yo/wheel.whl").splitext()
+ 
+diff --git a/tests/unit/test_utils_unpacking.py b/tests/unit/test_utils_unpacking.py
+index 3d4c317da3..b82360f632 100644
+--- a/tests/unit/test_utils_unpacking.py
++++ b/tests/unit/test_utils_unpacking.py
+@@ -19,6 +19,7 @@
+ from pip._internal.utils.unpacking import (
+     _get_default_mode_plus_executable,
+     is_within_directory,
++    join_within_directory,
+     unpack_file,
+     untar_file,
+     unzip_file,
+@@ -473,6 +474,51 @@ def test_is_within_directory(args: tuple[str, str], expected: bool) -> None:
+     assert result == expected
+ 
+ 
++@pytest.mark.parametrize(
++    "name",
++    [
++        "wheel.whl",
++        "myproject-1.0+foobar.0-py2.py3-none-any.whl",
++        # A literal "%2F" is a normal file name, not a separator.
++        "a%2Fb.whl",
++    ],
++)
++def test_join_within_directory_keeps_plain_name(name: str) -> None:
++    directory = os.path.join("base", "downloads")
++    assert join_within_directory(directory, name) == os.path.join(directory, name)
++
++
++@pytest.mark.parametrize(
++    "name",
++    [
++        os.path.join(os.sep, "abs", "pkg.whl"),
++        os.path.join("..", "pkg.whl"),
++        os.path.join("nested", "pkg.whl"),
++    ],
++)
++def test_join_within_directory_collapses_path_to_basename(name: str) -> None:
++    # A name carrying directory components is reduced to its basename, so the
++    # result always lands directly inside the directory.
++    directory = os.path.join("base", "downloads")
++    expected = os.path.join(directory, os.path.basename(name))
++    assert join_within_directory(directory, name) == expected
++
++
++@pytest.mark.parametrize(
++    "name",
++    [
++        "",
++        ".",
++        "..",
++        "/",
++        os.path.join("sub", ".."),
++    ],
++)
++def test_join_within_directory_rejects_empty_or_dot_name(name: str) -> None:
++    with pytest.raises(ValueError):
++        join_within_directory("downloads", name)
++
++
+ @pytest.mark.parametrize(
+     "is_zip, is_tar, unzip, untar, exception",
+     [
+
+From c2168149c834aeb965ff4853e89d182991dedfd9 Mon Sep 17 00:00:00 2001
+From: Damian Shaw <damian.peter.shaw@gmail.com>
+Date: Fri, 26 Jun 2026 13:56:32 -0400
+Subject: [PATCH 2/4] Add news entry
+
+---
+ news/14110.bugfix.rst | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 news/14110.bugfix.rst
+
+diff --git a/news/14110.bugfix.rst b/news/14110.bugfix.rst
+new file mode 100644
+index 0000000000..f7d4f78882
+--- /dev/null
++++ b/news/14110.bugfix.rst
+@@ -0,0 +1 @@
++Fix ``Link.filename`` decoding the URL path twice.
+
+From 50ceb7e936c313c8737941e4f98e6291190752f4 Mon Sep 17 00:00:00 2001
+From: Damian Shaw <damian.peter.shaw@gmail.com>
+Date: Mon, 29 Jun 2026 23:06:38 -0400
+Subject: [PATCH 3/4] Refactor Link.filename to return PathComponent and
+ enhance path validation
+
+---
+ src/pip/_internal/models/link.py        | 52 +++++++++++++-----
+ src/pip/_internal/network/download.py   | 16 +++---
+ src/pip/_internal/operations/prepare.py |  6 +--
+ src/pip/_internal/utils/unpacking.py    | 13 -----
+ tests/unit/test_link.py                 | 71 ++++++++++++++++++++++++-
+ tests/unit/test_utils_unpacking.py      | 46 ----------------
+ 6 files changed, 121 insertions(+), 83 deletions(-)
+
+diff --git a/src/pip/_internal/models/link.py b/src/pip/_internal/models/link.py
+index 896ea5b09d..0471843a5a 100644
+--- a/src/pip/_internal/models/link.py
++++ b/src/pip/_internal/models/link.py
+@@ -13,6 +13,7 @@
+ from typing import (
+     Any,
+     NamedTuple,
++    NewType,
+ )
+ 
+ from pip._internal.exceptions import InvalidEggFragment
+@@ -30,6 +31,38 @@
+ logger = logging.getLogger(__name__)
+ 
+ 
++# A single path component: percent-decoded once and reduced to a basename, so it
++# contains no path separator and is not a ``.`` or ``..`` reference. The empty
++# string means "no component".
++PathComponent = NewType("PathComponent", str)
++
++
++def _to_path_component(name: str) -> PathComponent:
++    """Reduce ``name`` to a single path component, or ``""`` if it has none.
++
++    ``os.path.basename`` drops any directory part, drive letter, or separator;
++    a ``.``, ``..``, or empty result is not a component and becomes ``""``.
++    """
++    name = os.path.basename(name)
++    if name in ("", os.curdir, os.pardir):
++        return PathComponent("")
++
++    return PathComponent(name)
++
++
++def as_path_component(name: str) -> PathComponent:
++    """Like ``_to_path_component`` but reject the empty result.
++
++    Use where a file is about to be written, so a missing name is an error
++    rather than a silent fallback to the directory itself.
++    """
++    component = _to_path_component(name)
++    if not component:
++        raise ValueError(f"Unexpected file name derived from URL: {name!r}")
++
++    return component
++
++
+ # Order matters, earlier hashes have a precedence over later hashes for what
+ # we will pick to use.
+ _SUPPORTED_HASHES = ("sha512", "sha384", "sha256", "sha224", "sha1", "md5")
+@@ -424,18 +457,13 @@ def redacted_url(self) -> str:
+         return redact_auth_from_url(self.url)
+ 
+     @property
+-    def filename(self) -> str:
+-        # ``self.path`` is already unquoted in ``__init__``; don't unquote again.
+-        path = self.path.rstrip("/")
+-        name = posixpath.basename(path)
+-        if not name:
+-            # Make sure we don't leak auth information if the netloc
+-            # includes a username and password.
+-            netloc, user_pass = split_auth_from_netloc(self.netloc)
+-            return netloc
+-
+-        assert name, f"URL {self._url!r} produced no filename"
+-        return name
++    def filename(self) -> PathComponent:
++        name = _to_path_component(posixpath.basename(self.path.rstrip("/")))
++        if name:
++            return name
++
++        # No component in the path; fall back to the netloc, dropping any auth.
++        return _to_path_component(split_auth_from_netloc(self.netloc)[0])
+ 
+     @property
+     def file_path(self) -> str:
+diff --git a/src/pip/_internal/network/download.py b/src/pip/_internal/network/download.py
+index cd74b855f9..f549381a3c 100644
+--- a/src/pip/_internal/network/download.py
++++ b/src/pip/_internal/network/download.py
+@@ -19,12 +19,11 @@
+ 
+ from pip._internal.cli.progress_bars import BarType, get_download_progress_renderer
+ from pip._internal.exceptions import IncompleteDownloadError, NetworkConnectionError
+-from pip._internal.models.link import Link
++from pip._internal.models.link import Link, PathComponent, as_path_component
+ from pip._internal.network.cache import SafeFileCache, is_from_cache
+ from pip._internal.network.session import CacheControlAdapter, PipSession
+ from pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
+ from pip._internal.utils.misc import format_size, redact_auth_from_url, splitext
+-from pip._internal.utils.unpacking import join_within_directory
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -117,11 +116,14 @@ def parse_content_disposition(content_disposition: str, default_filename: str) -
+     return filename or default_filename
+ 
+ 
+-def _get_http_response_filename(resp: Response, link: Link) -> str:
++def _get_http_response_filename(resp: Response, link: Link) -> PathComponent:
+     """Get an ideal filename from the given HTTP response, falling back to
+     the link filename if not provided.
++
++    The result is validated as a single path component, so it can be joined onto
++    a download directory without escaping it.
+     """
+-    filename = link.filename  # fallback
++    filename: str = link.filename  # fallback
+     # Have a look at the Content-Disposition header for a better guess
+     content_disposition = resp.headers.get("content-disposition")
+     if content_disposition:
+@@ -135,7 +137,7 @@ def _get_http_response_filename(resp: Response, link: Link) -> str:
+         ext = os.path.splitext(resp.url)[1]
+         if ext:
+             filename += ext
+-    return filename
++    return as_path_component(filename)
+ 
+ 
+ @dataclass
+@@ -188,9 +190,7 @@ def __call__(self, link: Link, location: str) -> tuple[str, str]:
+         resp = self._http_get(link)
+         download_size = _get_http_response_size(resp)
+ 
+-        filepath = join_within_directory(
+-            location, _get_http_response_filename(resp, link)
+-        )
++        filepath = os.path.join(location, _get_http_response_filename(resp, link))
+         with open(filepath, "wb") as content_file:
+             download = _FileDownload(link, content_file, download_size)
+             self._process_response(download, resp)
+diff --git a/src/pip/_internal/operations/prepare.py b/src/pip/_internal/operations/prepare.py
+index c71104f127..afcc0376da 100644
+--- a/src/pip/_internal/operations/prepare.py
++++ b/src/pip/_internal/operations/prepare.py
+@@ -53,7 +53,7 @@
+     redact_auth_from_requirement,
+ )
+ from pip._internal.utils.temp_dir import TempDirectory
+-from pip._internal.utils.unpacking import join_within_directory, unpack_file
++from pip._internal.utils.unpacking import unpack_file
+ from pip._internal.vcs import vcs
+ 
+ if TYPE_CHECKING:
+@@ -201,7 +201,7 @@ def _check_download_dir(
+     """Check download_dir for previously downloaded file with correct hash
+     If a correct file is found return its path else None
+     """
+-    download_path = join_within_directory(download_dir, link.filename)
++    download_path = os.path.join(download_dir, link.filename)
+ 
+     if not os.path.exists(download_path):
+         return None
+@@ -687,7 +687,7 @@ def save_linked_requirement(self, req: InstallRequirement) -> None:
+             # No distribution was downloaded for this requirement.
+             return
+ 
+-        download_location = join_within_directory(self.download_dir, link.filename)
++        download_location = os.path.join(self.download_dir, link.filename)
+         if not os.path.exists(download_location):
+             shutil.copy(req.local_file_path, download_location)
+             download_path = display_path(download_location)
+diff --git a/src/pip/_internal/utils/unpacking.py b/src/pip/_internal/utils/unpacking.py
+index 1a7c3ba236..8a9b2059ca 100644
+--- a/src/pip/_internal/utils/unpacking.py
++++ b/src/pip/_internal/utils/unpacking.py
+@@ -87,19 +87,6 @@ def is_within_directory(directory: str, target: str) -> bool:
+     return abs_target == abs_directory or abs_target.startswith(abs_directory + os.sep)
+ 
+ 
+-def join_within_directory(directory: str, name: str) -> str:
+-    """Join ``name`` onto ``directory`` as a single path component.
+-
+-    ``name`` is reduced to its basename; ``ValueError`` is raised if that is
+-    empty, ``.``, or ``..``.
+-    """
+-    name = os.path.basename(name)
+-    target = os.path.join(directory, name)
+-    if name in ("", os.curdir, os.pardir) or not is_within_directory(directory, target):
+-        raise ValueError(f"Unexpected file name derived from URL: {name!r}")
+-    return target
+-
+-
+ def _get_default_mode_plus_executable() -> int:
+     return 0o777 & ~current_umask() | 0o111
+ 
+diff --git a/tests/unit/test_link.py b/tests/unit/test_link.py
+index 2cd1c20a83..3b00da7891 100644
+--- a/tests/unit/test_link.py
++++ b/tests/unit/test_link.py
+@@ -1,11 +1,16 @@
+ from __future__ import annotations
+ 
++import os
+ import posixpath
+ 
+ import pytest
+ 
+ from pip._internal.exceptions import InvalidEggFragment, PipError
+-from pip._internal.models.link import Link, links_equivalent
++from pip._internal.models.link import (
++    Link,
++    as_path_component,
++    links_equivalent,
++)
+ from pip._internal.utils.hashes import Hashes
+ 
+ 
+@@ -73,6 +78,37 @@ def test_filename_decoded_once_stays_single_component(self, url: str) -> None:
+         assert not posixpath.isabs(filename)
+         assert posixpath.basename(filename) == filename
+ 
++    @pytest.mark.parametrize(
++        "url",
++        [
++            "https://example.com/..",
++            "https://example.com/.",
++            "https://example.com/foo/%2e%2e",
++        ],
++    )
++    def test_filename_parent_reference_falls_back_to_netloc(self, url: str) -> None:
++        # A path that is only a "." or ".." reference has no usable file name,
++        # so filename falls back to the netloc rather than handing back a
++        # traversal component that could escape a download directory.
++        assert Link(url).filename == "example.com"
++
++    @pytest.mark.parametrize(
++        "url",
++        [
++            # A path-less URL whose authority looks like a traversal: the netloc
++            # fallback must still reduce to a single path component.
++            "http://..\\..\\..\\evil.whl",
++            "http://../",
++            "http://..",
++        ],
++    )
++    def test_filename_is_always_a_path_component(self, url: str) -> None:
++        # filename must never carry a separator or parent reference, so joining
++        # it onto a directory can never escape that directory.
++        name = Link(url).filename
++        assert os.path.basename(name) == name
++        assert name not in (os.curdir, os.pardir)
++
+     def test_splitext(self) -> None:
+         assert ("wheel", ".whl") == Link("http://yo/wheel.whl").splitext()
+ 
+@@ -268,3 +304,36 @@ def test_links_equivalent(url1: str, url2: str) -> None:
+ )
+ def test_links_equivalent_false(url1: str, url2: str) -> None:
+     assert not links_equivalent(Link(url1), Link(url2))
++
++
++@pytest.mark.parametrize(
++    "name",
++    [
++        "wheel.whl",
++        "myproject-1.0+foobar.0-py2.py3-none-any.whl",
++        # A literal "%2F" is a normal file name, not a separator.
++        "a%2Fb.whl",
++    ],
++)
++def test_as_path_component_keeps_plain_name(name: str) -> None:
++    assert as_path_component(name) == name
++
++
++@pytest.mark.parametrize(
++    "name",
++    [
++        os.path.join(os.sep, "abs", "pkg.whl"),
++        os.path.join("..", "pkg.whl"),
++        os.path.join("nested", "pkg.whl"),
++    ],
++)
++def test_as_path_component_reduces_to_basename(name: str) -> None:
++    # A name carrying directory components is reduced to its basename, so the
++    # result always stays inside the directory it is later joined onto.
++    assert as_path_component(name) == os.path.basename(name)
++
++
++@pytest.mark.parametrize("name", ["", ".", "..", "/", os.path.join("sub", "..")])
++def test_as_path_component_rejects_empty_or_parent_reference(name: str) -> None:
++    with pytest.raises(ValueError):
++        as_path_component(name)
+diff --git a/tests/unit/test_utils_unpacking.py b/tests/unit/test_utils_unpacking.py
+index b82360f632..3d4c317da3 100644
+--- a/tests/unit/test_utils_unpacking.py
++++ b/tests/unit/test_utils_unpacking.py
+@@ -19,7 +19,6 @@
+ from pip._internal.utils.unpacking import (
+     _get_default_mode_plus_executable,
+     is_within_directory,
+-    join_within_directory,
+     unpack_file,
+     untar_file,
+     unzip_file,
+@@ -474,51 +473,6 @@ def test_is_within_directory(args: tuple[str, str], expected: bool) -> None:
+     assert result == expected
+ 
+ 
+-@pytest.mark.parametrize(
+-    "name",
+-    [
+-        "wheel.whl",
+-        "myproject-1.0+foobar.0-py2.py3-none-any.whl",
+-        # A literal "%2F" is a normal file name, not a separator.
+-        "a%2Fb.whl",
+-    ],
+-)
+-def test_join_within_directory_keeps_plain_name(name: str) -> None:
+-    directory = os.path.join("base", "downloads")
+-    assert join_within_directory(directory, name) == os.path.join(directory, name)
+-
+-
+-@pytest.mark.parametrize(
+-    "name",
+-    [
+-        os.path.join(os.sep, "abs", "pkg.whl"),
+-        os.path.join("..", "pkg.whl"),
+-        os.path.join("nested", "pkg.whl"),
+-    ],
+-)
+-def test_join_within_directory_collapses_path_to_basename(name: str) -> None:
+-    # A name carrying directory components is reduced to its basename, so the
+-    # result always lands directly inside the directory.
+-    directory = os.path.join("base", "downloads")
+-    expected = os.path.join(directory, os.path.basename(name))
+-    assert join_within_directory(directory, name) == expected
+-
+-
+-@pytest.mark.parametrize(
+-    "name",
+-    [
+-        "",
+-        ".",
+-        "..",
+-        "/",
+-        os.path.join("sub", ".."),
+-    ],
+-)
+-def test_join_within_directory_rejects_empty_or_dot_name(name: str) -> None:
+-    with pytest.raises(ValueError):
+-        join_within_directory("downloads", name)
+-
+-
+ @pytest.mark.parametrize(
+     "is_zip, is_tar, unzip, untar, exception",
+     [
+
+From 83e899eaec84885d769cc268d2774a6eb1c9b67a Mon Sep 17 00:00:00 2001
+From: Damian Shaw <damian.peter.shaw@gmail.com>
+Date: Tue, 30 Jun 2026 19:08:56 -0400
+Subject: [PATCH 4/4] Enforce PathComponent at directory-join call sites
+
+---
+ src/pip/_internal/models/link.py        | 11 +++++++++++
+ src/pip/_internal/network/download.py   | 11 +++++++++--
+ src/pip/_internal/operations/prepare.py |  6 +++---
+ tests/unit/test_link.py                 | 18 ++++++++++++++++++
+ 4 files changed, 41 insertions(+), 5 deletions(-)
+
+diff --git a/src/pip/_internal/models/link.py b/src/pip/_internal/models/link.py
+index 0471843a5a..cbbe945c17 100644
+--- a/src/pip/_internal/models/link.py
++++ b/src/pip/_internal/models/link.py
+@@ -63,6 +63,17 @@ def as_path_component(name: str) -> PathComponent:
+     return component
+ 
+ 
++def join_within_directory(directory: str, component: PathComponent) -> str:
++    """Join a single path ``component`` onto ``directory``.
++
++    ``component`` is a :data:`PathComponent`, so by type it has no separator and
++    is not a ``.`` or ``..`` reference; the result can never escape ``directory``.
++    Requiring ``PathComponent`` rather than ``str`` lets the type checker enforce
++    at the call site that the name was reduced to a safe component beforehand.
++    """
++    return os.path.join(directory, component)
++
++
+ # Order matters, earlier hashes have a precedence over later hashes for what
+ # we will pick to use.
+ _SUPPORTED_HASHES = ("sha512", "sha384", "sha256", "sha224", "sha1", "md5")
+diff --git a/src/pip/_internal/network/download.py b/src/pip/_internal/network/download.py
+index f549381a3c..d5e3e85251 100644
+--- a/src/pip/_internal/network/download.py
++++ b/src/pip/_internal/network/download.py
+@@ -19,7 +19,12 @@
+ 
+ from pip._internal.cli.progress_bars import BarType, get_download_progress_renderer
+ from pip._internal.exceptions import IncompleteDownloadError, NetworkConnectionError
+-from pip._internal.models.link import Link, PathComponent, as_path_component
++from pip._internal.models.link import (
++    Link,
++    PathComponent,
++    as_path_component,
++    join_within_directory,
++)
+ from pip._internal.network.cache import SafeFileCache, is_from_cache
+ from pip._internal.network.session import CacheControlAdapter, PipSession
+ from pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
+@@ -190,7 +195,9 @@ def __call__(self, link: Link, location: str) -> tuple[str, str]:
+         resp = self._http_get(link)
+         download_size = _get_http_response_size(resp)
+ 
+-        filepath = os.path.join(location, _get_http_response_filename(resp, link))
++        filepath = join_within_directory(
++            location, _get_http_response_filename(resp, link)
++        )
+         with open(filepath, "wb") as content_file:
+             download = _FileDownload(link, content_file, download_size)
+             self._process_response(download, resp)
+diff --git a/src/pip/_internal/operations/prepare.py b/src/pip/_internal/operations/prepare.py
+index afcc0376da..3b44403e0d 100644
+--- a/src/pip/_internal/operations/prepare.py
++++ b/src/pip/_internal/operations/prepare.py
+@@ -29,7 +29,7 @@
+ from pip._internal.index.package_finder import PackageFinder
+ from pip._internal.metadata import BaseDistribution, get_metadata_distribution
+ from pip._internal.models.direct_url import ArchiveInfo, DirectUrl
+-from pip._internal.models.link import Link
++from pip._internal.models.link import Link, join_within_directory
+ from pip._internal.models.wheel import Wheel
+ from pip._internal.network.download import Downloader
+ from pip._internal.network.lazy_wheel import (
+@@ -201,7 +201,7 @@ def _check_download_dir(
+     """Check download_dir for previously downloaded file with correct hash
+     If a correct file is found return its path else None
+     """
+-    download_path = os.path.join(download_dir, link.filename)
++    download_path = join_within_directory(download_dir, link.filename)
+ 
+     if not os.path.exists(download_path):
+         return None
+@@ -687,7 +687,7 @@ def save_linked_requirement(self, req: InstallRequirement) -> None:
+             # No distribution was downloaded for this requirement.
+             return
+ 
+-        download_location = os.path.join(self.download_dir, link.filename)
++        download_location = join_within_directory(self.download_dir, link.filename)
+         if not os.path.exists(download_location):
+             shutil.copy(req.local_file_path, download_location)
+             download_path = display_path(download_location)
+diff --git a/tests/unit/test_link.py b/tests/unit/test_link.py
+index 3b00da7891..bc8cb8ab9b 100644
+--- a/tests/unit/test_link.py
++++ b/tests/unit/test_link.py
+@@ -9,6 +9,7 @@
+ from pip._internal.models.link import (
+     Link,
+     as_path_component,
++    join_within_directory,
+     links_equivalent,
+ )
+ from pip._internal.utils.hashes import Hashes
+@@ -337,3 +338,20 @@ def test_as_path_component_reduces_to_basename(name: str) -> None:
+ def test_as_path_component_rejects_empty_or_parent_reference(name: str) -> None:
+     with pytest.raises(ValueError):
+         as_path_component(name)
++
++
++@pytest.mark.parametrize(
++    "name",
++    [
++        "pkg.whl",
++        # A literal "%2F" is a normal file name, not a separator.
++        "a%2Fb.whl",
++    ],
++)
++def test_join_within_directory_stays_inside(name: str) -> None:
++    # The component is joined onto the directory as its final element, so the
++    # result stays inside the directory.
++    directory = os.path.join("base", "downloads")
++    joined = join_within_directory(directory, as_path_component(name))
++    assert joined == os.path.join(directory, name)
++    assert os.path.basename(joined) == name

--- a/packages/p/pip/package.yml
+++ b/packages/p/pip/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : pip
 version    : 26.1.2
-release    : 19
+release    : 20
 source     :
     - https://github.com/pypa/pip/archive/refs/tags/26.1.2.tar.gz : 193a7030ac78282beba6a95a3512241a71c2025fe5a05308d0e827a679f99847
 homepage   : https://pip.pypa.io/en/stable/
@@ -24,24 +24,24 @@ rundeps    :
     - python-cryptography
     - python-filelock
     - python-wheel
-checkdeps  :
-    - python-pytest
+# checkdeps  :
+#     - python-pytest
+setup      : |
+    %patch -p1 -i ${pkgfiles}/CVE-2026-13346.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     # Generate shell completions
-    # TODO: Replace with python sitepackages macro
-    _site_packages=$(python -c "import site; print(site.getsitepackages()[0])")
-    PYTHONPATH=${installdir}/${_site_packages} ${installdir}/usr/bin/pip completion --bash | install -Dm 00644 /dev/stdin ${installdir}/usr/share/bash-completion/completions/pip
-    PYTHONPATH=${installdir}/${_site_packages} ${installdir}/usr/bin/pip completion --zsh | tail -n+3 | install -Dm 00644 /dev/stdin ${installdir}/usr/share/zsh/site-functions/_pip
-    PYTHONPATH=${installdir}/${_site_packages} ${installdir}/usr/bin/pip completion --fish | install -Dm 00644 /dev/stdin ${installdir}/usr/share/fish/vendor_completions.d/pip.fish
+    PYTHONPATH=${installdir}/%python3_sitepackages% ${installdir}/usr/bin/pip completion --bash | %install_file /dev/stdin ${installdir}/usr/share/bash-completion/completions/pip
+    PYTHONPATH=${installdir}/%python3_sitepackages% ${installdir}/usr/bin/pip completion --zsh | tail -n+3 | %install_file /dev/stdin ${installdir}/usr/share/zsh/site-functions/_pip
+    PYTHONPATH=${installdir}/%python3_sitepackages% ${installdir}/usr/bin/pip completion --fish | %install_file /dev/stdin ${installdir}/usr/share/fish/vendor_completions.d/pip.fish
 
     # Install wheel for virtualenv
-    install -Dm 00644 dist/*.whl -t ${installdir}/usr/share/python-wheels
-#check      : |
-  #    %python3_test pytest
+    %install_file dist/*.whl -t ${installdir}/usr/share/python-wheels
+# check      : |
+#     %pytest -v
 patterns   :
     - wheel :
         - /usr/share/python-wheels

--- a/packages/p/pip/pspec_x86_64.xml
+++ b/packages/p/pip/pspec_x86_64.xml
@@ -1298,8 +1298,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-07-16</Date>
+        <Update release="20">
+            <Date>2026-07-29</Date>
             <Version>26.1.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
Backport security patch.

**Security**
- CVE-2026-13346

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `pip list` and see all installed Python packages.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
