### PR TITLE
docker-buildx: Update to v0.36.0

### DIFF
--- a/packages/d/docker-buildx/package.yml
+++ b/packages/d/docker-buildx/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker-buildx
-version    : 0.35.0
-release    : 29
+version    : 0.36.0
+release    : 30
 source     :
-    - https://github.com/docker/buildx/archive/refs/tags/v0.35.0.tar.gz : 790e4eb0c98da49c60d2c94cebcd3f1658cd7aca3be82093fcb19b9c1d0ac06b
+    - https://github.com/docker/buildx/archive/refs/tags/v0.36.0.tar.gz : c3e7c577dc4b3e0656d69e2cb3651a9bb49776732cb55583652465d25a9675f4
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt
@@ -39,6 +39,5 @@ build      : |
         -X ${_buildx_r}/version.Package=${_buildx_r}" \
         ./cmd/buildx
 install    : |
-    install -Ddm00755 ${installdir}/%libdir%/docker/cli-plugins
-    install -m00755 ${workdir}/docker-buildx ${installdir}/%libdir%/docker/cli-plugins/docker-buildx
+    %install_exe docker-buildx ${installdir}/%libdir%/docker/cli-plugins/docker-buildx
     %install_license LICENSE

--- a/packages/d/docker-buildx/pspec_x86_64.xml
+++ b/packages/d/docker-buildx/pspec_x86_64.xml
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2026-06-19</Date>
-            <Version>0.35.0</Version>
+        <Update release="30">
+            <Date>2026-07-30</Date>
+            <Version>0.36.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/docker/buildx/releases/tag/v0.36.0).

**Test Plan**

docker works. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
