### PR TITLE
editorconfig-core-c: Update to v0.12.11

### DIFF
--- a/packages/e/editorconfig-core-c/abi_used_symbols
+++ b/packages/e/editorconfig-core-c/abi_used_symbols
@@ -5,7 +5,6 @@ libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__stack_chk_fail
-libc.so.6:__strcpy_chk
 libc.so.6:calloc
 libc.so.6:exit
 libc.so.6:fclose

--- a/packages/e/editorconfig-core-c/package.yml
+++ b/packages/e/editorconfig-core-c/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : editorconfig-core-c
-version    : 0.12.7
-release    : 4
+version    : 0.12.11
+release    : 5
 source     :
-    - https://github.com/editorconfig/editorconfig-core-c/archive/refs/tags/v0.12.7.tar.gz : f89d2e144fd67bdf0d7acfb2ac7618c6f087e1b3f2c3a707656b4180df422195
+    - https://github.com/editorconfig/editorconfig-core-c/archive/refs/tags/v0.12.11.tar.gz : 9d8b420b56a969ea3cf784861c72d26fa0e158fa1494d732df2c8a1480d36a5c
 homepage   : https://editorconfig.org/
 license    : BSD-2-Clause
 component  : programming.library
@@ -20,3 +20,4 @@ build      : |
 install    : |
     %ninja_install
     rm $installdir/%libdir%/*.a
+    %install_license LICENSE

--- a/packages/e/editorconfig-core-c/pspec_x86_64.xml
+++ b/packages/e/editorconfig-core-c/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>editorconfig-core-c</Name>
         <Homepage>https://editorconfig.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>programming.library</PartOf>
@@ -21,11 +21,12 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/editorconfig</Path>
-            <Path fileType="executable">/usr/bin/editorconfig-0.12.7</Path>
+            <Path fileType="executable">/usr/bin/editorconfig-0.12.11</Path>
             <Path fileType="library">/usr/lib64/libeditorconfig.so.0</Path>
-            <Path fileType="library">/usr/lib64/libeditorconfig.so.0.12.7</Path>
-            <Path fileType="man">/usr/share/man/man1/editorconfig.1</Path>
-            <Path fileType="man">/usr/share/man/man5/editorconfig-format.5</Path>
+            <Path fileType="library">/usr/lib64/libeditorconfig.so.0.12.11</Path>
+            <Path fileType="data">/usr/share/licenses/editorconfig-core-c/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/editorconfig.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/editorconfig-format.5.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -35,7 +36,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">editorconfig-core-c</Dependency>
+            <Dependency release="5">editorconfig-core-c</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/editorconfig/editorconfig.h</Path>
@@ -46,17 +47,17 @@
             <Path fileType="library">/usr/lib64/cmake/EditorConfig/EditorConfigTargets.cmake</Path>
             <Path fileType="library">/usr/lib64/libeditorconfig.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/editorconfig.pc</Path>
-            <Path fileType="man">/usr/share/man/man3/editorconfig.h.3</Path>
-            <Path fileType="man">/usr/share/man/man3/editorconfig_handle.h.3</Path>
+            <Path fileType="man">/usr/share/man/man3/editorconfig.h.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/editorconfig_handle.h.3.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-04-05</Date>
-            <Version>0.12.7</Version>
+        <Update release="5">
+            <Date>2026-07-30</Date>
+            <Version>0.12.11</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [0.12.11](https://github.com/editorconfig/editorconfig-core-c/releases/tag/v0.12.11)
- [0.12.10](https://github.com/editorconfig/editorconfig-core-c/releases/tag/v0.12.10)
- [0.12.9](https://github.com/editorconfig/editorconfig-core-c/releases/tag/v0.12.9)
- [0.12.8](https://github.com/editorconfig/editorconfig-core-c/releases/tag/v0.12.8)

**Security**

-  CVE-2026-40489

**Summary**

- Built revdeps with no apparent change: gnome-text-editor, ktexteditor

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
