### PR TITLE
tetro-tui: Update to v3.6.2

### DIFF
--- a/packages/t/tetro-tui/package.yml
+++ b/packages/t/tetro-tui/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : tetro-tui
-version    : 3.6.1
-release    : 4
+version    : 3.6.2
+release    : 5
 source     :
-    - https://github.com/Strophox/tetro-tui/archive/refs/tags/v3.6.1.tar.gz : 3b08e3087ef24fb79bad373408b67e6391093e3aea368698d9b994aeb7c491ff
+    - https://github.com/Strophox/tetro-tui/archive/refs/tags/v3.6.2.tar.gz : 2485eee4978b5a92d22c0fa03ccc9214a4f5b742d404bed3d544ca236a87da40
 homepage   : https://github.com/Strophox/tetro-tui
 license    : MIT
 component  : games.puzzle

--- a/packages/t/tetro-tui/pspec_x86_64.xml
+++ b/packages/t/tetro-tui/pspec_x86_64.xml
@@ -32,9 +32,9 @@ keybinds, scoreboards, replays, and statistics.
         </Replaces>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2026-05-31</Date>
-            <Version>3.6.1</Version>
+        <Update release="5">
+            <Date>2026-07-30</Date>
+            <Version>3.6.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Strophox/tetro-tui/blob/main/CHANGELOG.md).

**Test Plan**

Played a game

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
