### PR TITLE
msgpack update

### DIFF
--- a/packages/m/msgpack-cxx/package.yml
+++ b/packages/m/msgpack-cxx/package.yml
@@ -1,22 +1,29 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : msgpack-cxx
-version    : 6.1.0
-release    : 2
+version    : 8.0.0
+release    : 3
 source     :
-    - https://github.com/msgpack/msgpack-c/releases/download/cpp-6.1.0/msgpack-cxx-6.1.0.tar.gz : 23ede7e93c8efee343ad8c6514c28f3708207e5106af3b3e4969b3a9ed7039e7
+    - https://github.com/msgpack/msgpack-c/releases/download/cpp-8.0.0/msgpack-cxx-8.0.0.tar.gz : 4a3c0c0ac55ef4456c2d0b93c21b5d105aa3a8f21ef8fa9758550feaf989b92f
 homepage   : https://github.com/msgpack/msgpack-c/tree/cpp_master
 license    : BSL-1.0
 component  : programming.library
 summary    : msgpack for C++
 description: |
     MessagePack is an efficient binary serialization format, which lets you exchange data among multiple languages like JSON, except that it's faster and smaller. Small integers are encoded into a single byte and short strings require only one extra byte in addition to the strings themselves.
-patterns   : /*
 builddeps  :
+    - doxygen
     - libboost-devel
 setup      : |
     %cmake_ninja \
-        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        -D MSGPACK_CXX17=ON \
+        -D MSGPACK_BUILD_TESTS=ON
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
+check      : |
+    ctest --test-dir solusBuildDir
+patterns   :
+    - main :
+        - /*

--- a/packages/m/msgpack-cxx/pspec_x86_64.xml
+++ b/packages/m/msgpack-cxx/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>msgpack-cxx</Name>
         <Homepage>https://github.com/msgpack/msgpack-c/tree/cpp_master</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSL-1.0</License>
         <PartOf>programming.library</PartOf>
@@ -103,6 +103,7 @@
             <Path fileType="header">/usr/include/msgpack/iterator_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/meta.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/meta_decl.hpp</Path>
+            <Path fileType="header">/usr/include/msgpack/nan_util.hpp~</Path>
             <Path fileType="header">/usr/include/msgpack/null_visitor.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/null_visitor_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/object.hpp</Path>
@@ -615,6 +616,7 @@
             <Path fileType="header">/usr/include/msgpack/v1/adaptor/wstring.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v1/cpp_config.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v1/cpp_config_decl.hpp</Path>
+            <Path fileType="header">/usr/include/msgpack/v1/detail/#cpp11_zone.hpp#</Path>
             <Path fileType="header">/usr/include/msgpack/v1/detail/cpp03_zone.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v1/detail/cpp03_zone_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v1/detail/cpp11_zone.hpp</Path>
@@ -625,6 +627,7 @@
             <Path fileType="header">/usr/include/msgpack/v1/iterator_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v1/meta.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v1/meta_decl.hpp</Path>
+            <Path fileType="header">/usr/include/msgpack/v1/nan_util.hpp~</Path>
             <Path fileType="header">/usr/include/msgpack/v1/object.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v1/object_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v1/object_fwd.hpp</Path>
@@ -674,6 +677,7 @@
             <Path fileType="header">/usr/include/msgpack/v2/fbuffer_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v2/iterator_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v2/meta_decl.hpp</Path>
+            <Path fileType="header">/usr/include/msgpack/v2/nan_util.hpp~</Path>
             <Path fileType="header">/usr/include/msgpack/v2/null_visitor.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v2/null_visitor_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v2/object.hpp</Path>
@@ -722,6 +726,7 @@
             <Path fileType="header">/usr/include/msgpack/v3/fbuffer_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v3/iterator_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v3/meta_decl.hpp</Path>
+            <Path fileType="header">/usr/include/msgpack/v3/nan_util.hpp~</Path>
             <Path fileType="header">/usr/include/msgpack/v3/null_visitor_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v3/object_decl.hpp</Path>
             <Path fileType="header">/usr/include/msgpack/v3/object_fwd.hpp</Path>
@@ -755,15 +760,16 @@
             <Path fileType="library">/usr/lib64/cmake/msgpack-cxx/msgpack-cxx-config-version.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/msgpack-cxx/msgpack-cxx-config.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/msgpack-cxx/msgpack-cxx-targets.cmake</Path>
+            <Path fileType="data">/usr/share/licenses/msgpack-cxx/COPYING</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2026-06-28</Date>
-            <Version>6.1.0</Version>
+        <Update release="3">
+            <Date>2026-07-30</Date>
+            <Version>8.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/msgpack/package.yml
+++ b/packages/m/msgpack/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : msgpack
-version    : 6.1.0
-release    : 8
+version    : 7.0.1
+release    : 9
 source     :
-    - https://github.com/msgpack/msgpack-c/releases/download/c-6.1.0/msgpack-c-6.1.0.tar.gz : 674119f1a85b5f2ecc4c7d5c2859edf50c0b05e0c10aa0df85eefa2c8c14b796
+    - https://github.com/msgpack/msgpack-c/releases/download/c-7.0.1/msgpack-c-7.0.1.tar.gz : 2d80f190ab89b73b513025d8aef09b144e5c07b3734dfe99dd0137725d355504
 homepage   : https://msgpack.org/
 license    : BSL-1.0
 component  : programming
@@ -13,13 +13,14 @@ description: |
 builddeps  :
     - pkgconfig(gtest)
 setup      : |
-    %cmake . \
+    %cmake_ninja \
         -DCMAKE_INSTALL_LIBDIR=%libdir% \
         -DMSGPACK_BUILD_TESTS=ON \
         -DBUILD_SHARED_LIBS=ON
 build      : |
-    %make
+    %ninja_build
 install    : |
-    %make_install
+    %ninja_install
+    %install_license COPYING
 check      : |
-    %make test
+    %ninja_check

--- a/packages/m/msgpack/pspec_x86_64.xml
+++ b/packages/m/msgpack/pspec_x86_64.xml
@@ -22,6 +22,7 @@
         <Files>
             <Path fileType="library">/usr/lib64/libmsgpack-c.so.2</Path>
             <Path fileType="library">/usr/lib64/libmsgpack-c.so.2.0.0</Path>
+            <Path fileType="data">/usr/share/licenses/msgpack/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -31,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">msgpack</Dependency>
+            <Dependency release="9">msgpack</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/msgpack.h</Path>
@@ -62,9 +63,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-10-03</Date>
-            <Version>6.1.0</Version>
+        <Update release="9">
+            <Date>2026-07-30</Date>
+            <Version>7.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>

--- a/packages/py/python-msgpack/abi_symbols
+++ b/packages/py/python-msgpack/abi_symbols
@@ -1,3 +1,2 @@
 _cmsgpack.cpython-314-x86_64-linux-gnu.so:PyInit__cmsgpack
-_cmsgpack.cpython-314-x86_64-linux-gnu.so:__pyx_CommonTypesMetaclass_get_module
 _cmsgpack.cpython-314-x86_64-linux-gnu.so:__pyx_module_is_main_msgpack___cmsgpack

--- a/packages/py/python-msgpack/abi_used_symbols
+++ b/packages/py/python-msgpack/abi_used_symbols
@@ -16,7 +16,6 @@ UNKNOWN:PyCapsule_GetPointer
 UNKNOWN:PyCapsule_Import
 UNKNOWN:PyCapsule_New
 UNKNOWN:PyCode_NewEmpty
-UNKNOWN:PyDescr_IsData
 UNKNOWN:PyDict_Contains
 UNKNOWN:PyDict_DelItem
 UNKNOWN:PyDict_GetItemRef
@@ -50,7 +49,9 @@ UNKNOWN:PyExc_AttributeError
 UNKNOWN:PyExc_BufferError
 UNKNOWN:PyExc_DeprecationWarning
 UNKNOWN:PyExc_ImportError
+UNKNOWN:PyExc_MemoryError
 UNKNOWN:PyExc_NameError
+UNKNOWN:PyExc_NotImplementedError
 UNKNOWN:PyExc_OverflowError
 UNKNOWN:PyExc_RuntimeError
 UNKNOWN:PyExc_RuntimeWarning
@@ -92,6 +93,7 @@ UNKNOWN:PyLong_Type
 UNKNOWN:PyMem_Free
 UNKNOWN:PyMem_Malloc
 UNKNOWN:PyMem_Realloc
+UNKNOWN:PyMemoryView_FromMemory
 UNKNOWN:PyMemoryView_FromObject
 UNKNOWN:PyMemoryView_GetContiguous
 UNKNOWN:PyMemoryView_Type
@@ -115,12 +117,14 @@ UNKNOWN:PyObject_CallFunction
 UNKNOWN:PyObject_CallFunctionObjArgs
 UNKNOWN:PyObject_CallMethodObjArgs
 UNKNOWN:PyObject_CallObject
+UNKNOWN:PyObject_ClearManagedDict
 UNKNOWN:PyObject_ClearWeakRefs
 UNKNOWN:PyObject_GC_Del
 UNKNOWN:PyObject_GC_IsFinalized
 UNKNOWN:PyObject_GC_Track
 UNKNOWN:PyObject_GC_UnTrack
-UNKNOWN:PyObject_GenericGetAttr
+UNKNOWN:PyObject_GenericGetDict
+UNKNOWN:PyObject_GenericSetDict
 UNKNOWN:PyObject_GetAttr
 UNKNOWN:PyObject_GetAttrString
 UNKNOWN:PyObject_GetBuffer
@@ -128,6 +132,7 @@ UNKNOWN:PyObject_GetItem
 UNKNOWN:PyObject_GetIter
 UNKNOWN:PyObject_GetOptionalAttr
 UNKNOWN:PyObject_HasAttr
+UNKNOWN:PyObject_HasAttrWithError
 UNKNOWN:PyObject_Hash
 UNKNOWN:PyObject_IsInstance
 UNKNOWN:PyObject_IsSubclass
@@ -139,6 +144,7 @@ UNKNOWN:PyObject_SetAttrString
 UNKNOWN:PyObject_Size
 UNKNOWN:PyObject_VectorcallDict
 UNKNOWN:PyObject_VectorcallMethod
+UNKNOWN:PyObject_VisitManagedDict
 UNKNOWN:PyThreadState_Get
 UNKNOWN:PyThreadState_GetUnchecked
 UNKNOWN:PyTraceBack_Here
@@ -157,8 +163,8 @@ UNKNOWN:PyUnicode_AsEncodedString
 UNKNOWN:PyUnicode_AsUTF8
 UNKNOWN:PyUnicode_AsUTF8AndSize
 UNKNOWN:PyUnicode_Concat
-UNKNOWN:PyUnicode_Decode
 UNKNOWN:PyUnicode_DecodeUTF8
+UNKNOWN:PyUnicode_FindChar
 UNKNOWN:PyUnicode_Format
 UNKNOWN:PyUnicode_FromFormat
 UNKNOWN:PyUnicode_FromOrdinal
@@ -167,8 +173,10 @@ UNKNOWN:PyUnicode_FromStringAndSize
 UNKNOWN:PyUnicode_InternFromString
 UNKNOWN:PyUnicode_InternInPlace
 UNKNOWN:PyUnicode_New
+UNKNOWN:PyUnicode_Substring
 UNKNOWN:PyUnicode_Type
 UNKNOWN:PyUnstable_Code_NewWithPosOnlyArgs
+UNKNOWN:PyUnstable_Object_EnableDeferredRefcount
 UNKNOWN:Py_EnterRecursiveCall
 UNKNOWN:Py_LeaveRecursiveCall
 UNKNOWN:Py_Version
@@ -176,7 +184,6 @@ UNKNOWN:_PyByteArray_empty_string
 UNKNOWN:_PyDict_GetItem_KnownHash
 UNKNOWN:_PyDict_NewPresized
 UNKNOWN:_PyObject_GC_New
-UNKNOWN:_PyObject_GetDictPtr
 UNKNOWN:_PyType_Lookup
 UNKNOWN:_Py_Dealloc
 UNKNOWN:_Py_FalseStruct

--- a/packages/py/python-msgpack/package.yml
+++ b/packages/py/python-msgpack/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-msgpack
-version    : 1.1.1
-release    : 19
+version    : 1.2.1
+release    : 20
 source     :
-    - https://files.pythonhosted.org/packages/source/m/msgpack/msgpack-1.1.1.tar.gz : 77b79ce34a2bdab2594f490c8e80dd62a02d650b91a75159a63ec413b8d104cd
+    - https://files.pythonhosted.org/packages/source/m/msgpack/msgpack-1.2.1.tar.gz : 04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647
 homepage   : https://msgpack.org/
 license    : Apache-2.0
 component  : programming.python
@@ -15,11 +15,12 @@ builddeps  :
     - python-build
     - python-installer
     - python-setuptools
+    - python-wheel
 checkdeps  :
     - python-pytest
-setup      : |
-    %python3_setup
+build      : |
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    %pytest -v

--- a/packages/py/python-msgpack/pspec_x86_64.xml
+++ b/packages/py/python-msgpack/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-msgpack</Name>
         <Homepage>https://msgpack.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack-1.1.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack-1.1.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack-1.1.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack-1.1.1.dist-info/licenses/COPYING</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack-1.1.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack-1.2.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack-1.2.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack-1.2.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack-1.2.1.dist-info/licenses/COPYING</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack-1.2.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/msgpack/__pycache__/__init__.cpython-314.pyc</Path>
@@ -41,12 +41,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-06-06</Date>
-            <Version>1.1.1</Version>
+        <Update release="20">
+            <Date>2026-07-30</Date>
+            <Version>1.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- **msgpack: Update to v7.0.1**
- **msgpack-cxx: Update to v8.0.0**
- **python-msgpack: Update to v1.2.1**

Some of the file names in `msgpack-cxx` are wierd. I don't know where they're coming from. I don't see a reference to them anywheres, and the Arch package doesn't seem to have them. I tried building without ninja, and same result.

**Test Plan**

Rebuild a reverse dependency.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
