### PR TITLE
python-annotated-doc: Update to v0.0.5

### DIFF
--- a/packages/py/python-annotated-doc/package.yml
+++ b/packages/py/python-annotated-doc/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-annotated-doc
-version    : 0.0.4
-release    : 1
+version    : 0.0.5
+release    : 2
 source     :
-    - https://files.pythonhosted.org/packages/source/a/annotated-doc/annotated_doc-0.0.4.tar.gz : fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4
+    - https://files.pythonhosted.org/packages/source/a/annotated-doc/annotated_doc-0.0.5.tar.gz : c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb
 homepage   : https://github.com/fastapi/annotated-doc
 license    : MIT
 component  : programming.python
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    %pytest -v

--- a/packages/py/python-annotated-doc/pspec_x86_64.xml
+++ b/packages/py/python-annotated-doc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-annotated-doc</Name>
         <Homepage>https://github.com/fastapi/annotated-doc</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc-0.0.4.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc-0.0.4.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc-0.0.4.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc-0.0.4.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc-0.0.4.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc-0.0.5.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc-0.0.5.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc-0.0.5.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc-0.0.5.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc-0.0.5.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_doc/__pycache__/__init__.cpython-314.pyc</Path>
@@ -35,12 +35,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2026-06-13</Date>
-            <Version>0.0.4</Version>
+        <Update release="2">
+            <Date>2026-07-30</Date>
+            <Version>0.0.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/fastapi/annotated-doc/releases/tag/0.0.5).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the testsuite passes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
