### PR TITLE
python-annotated-types: Update to v0.8.0

### DIFF
--- a/packages/py/python-annotated-types/package.yml
+++ b/packages/py/python-annotated-types/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-annotated-types
-version    : 0.7.0
-release    : 4
+version    : 0.8.0
+release    : 5
 source     :
-    - https://github.com/annotated-types/annotated-types/archive/refs/tags/v0.7.0.tar.gz : 791241e2b1e83031543246d9b3b304430233ff964a32a2cfac47896b4eed2513
+    - https://github.com/annotated-types/annotated-types/archive/refs/tags/v0.8.0.tar.gz : 4d038ad7abecc913fdf426d1b28ce60c4fb129c65ed33863515dfd1975e97dce
 homepage   : https://github.com/annotated-types/annotated-types
 license    : MIT
 component  : programming.python
@@ -14,7 +14,11 @@ builddeps  :
     - python-build
     - python-hatchling
     - python-installer
+checkdeps:
+    - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
+check      : |
+    %pytest -v

--- a/packages/py/python-annotated-types/pspec_x86_64.xml
+++ b/packages/py/python-annotated-types/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-annotated-types</Name>
         <Homepage>https://github.com/annotated-types/annotated-types</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_types-0.7.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_types-0.7.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_types-0.7.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_types-0.7.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_types-0.8.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_types-0.8.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_types-0.8.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_types-0.8.0.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_types/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_types/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/annotated_types/__pycache__/__init__.cpython-314.pyc</Path>
@@ -34,12 +34,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2026-06-05</Date>
-            <Version>0.7.0</Version>
+        <Update release="5">
+            <Date>2026-07-30</Date>
+            <Version>0.8.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/annotated-types/annotated-types/releases/tag/v0.8.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the testsuite passes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
