### PR TITLE
python-argparse-manpage: Update to v4.7

### DIFF
--- a/packages/py/python-argparse-manpage/package.yml
+++ b/packages/py/python-argparse-manpage/package.yml
@@ -1,12 +1,13 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-argparse-manpage
-version    : '4.6'
-release    : 4
+version    : '4.7'
+release    : 5
 source     :
-    - https://pypi.debian.net/argparse-manpage/argparse-manpage-4.6.tar.gz : 0b659d70fd142876da41c2918bd6de4d027875720b0e4672d6443b51198dbb62
+    - https://github.com/praiskup/argparse-manpage/releases/download/v4.7/argparse_manpage-4.7.tar.gz :
+        1deab76b212ac8753cbb67b9d2d2bc0949bbc338bb1cc3547f0890cb34108b32
+homepage   : https://github.com/praiskup/argparse-manpage
 license    : Apache-2.0
 component  : programming.python
-homepage   : https://github.com/praiskup/argparse-manpage
 summary    : Automatically build man-pages for your Python project
 description: |
     Automatically build man-pages for your Python project
@@ -18,8 +19,11 @@ builddeps  :
     - python-setuptools
     - python-wheel
 checkdeps  :
+    - pip
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
+check      : |
+    python -m unittest discover -vs tests

--- a/packages/py/python-argparse-manpage/pspec_x86_64.xml
+++ b/packages/py/python-argparse-manpage/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-argparse-manpage</Name>
         <Homepage>https://github.com/praiskup/argparse-manpage</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -21,13 +21,13 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/argparse-manpage</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.6.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.6.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.6.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.6.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.6.dist-info/licenses/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.6.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.6.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.7.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.7.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.7.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.7.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.7.dist-info/licenses/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.7.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage-4.7.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/argparse_manpage/__pycache__/__init__.cpython-314.pyc</Path>
@@ -62,12 +62,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2026-06-05</Date>
-            <Version>4.6</Version>
+        <Update release="5">
+            <Date>2026-07-30</Date>
+            <Version>4.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/praiskup/argparse-manpage/releases/tag/v4.7).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the testsuite passes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
