### PR TITLE
python-astroid: Update to v4.1.2

### DIFF
--- a/packages/py/python-astroid/package.yml
+++ b/packages/py/python-astroid/package.yml
@@ -1,9 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-astroid
-version    : 3.3.11
-release    : 41
+version    : 4.1.2
+release    : 42
 source     :
-    - https://github.com/pylint-dev/astroid/archive/v3.3.11/astroid-3.3.11.tar.gz : 5bb714e739c650e7e31186e1765f7edd33171b2f423ddbddb43b1c37cb6cfbb5
+    - https://github.com/pylint-dev/astroid/releases/download/v4.1.2/astroid-4.1.2.tar.gz :
+        d6c4a52bfcda4bbeb7359dead642b0248b90f7d9a07e690230bd86fefd6d37f1
 homepage   : https://github.com/PyCQA/astroid
 license    : LGPL-2.1-or-later
 component  : programming.python
@@ -27,9 +28,9 @@ checkdeps  :
 rundeps    :
     - python-typing-extensions
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     numpy_test_prefix=tests/brain/numpy
     pytest_args=(
@@ -47,4 +48,4 @@ check      : |
         --deselect tests/test_manager.py::AstroidManagerTest::test_identify_old_namespace_package_protocol
     )
 
-    %python3_test pytest -v "${pytest_args[@]}"
+    %pytest -v "${pytest_args[@]}"

--- a/packages/py/python-astroid/pspec_x86_64.xml
+++ b/packages/py/python-astroid/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-astroid</Name>
         <Homepage>https://github.com/PyCQA/astroid</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.python</PartOf>
@@ -20,22 +20,23 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-3.3.11.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-3.3.11.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-3.3.11.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-3.3.11.dist-info/licenses/CONTRIBUTORS.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-3.3.11.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-3.3.11.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-4.1.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-4.1.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-4.1.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-4.1.2.dist-info/licenses/CONTRIBUTORS.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-4.1.2.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid-4.1.2.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pkginfo__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/__main__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/__main__.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/__pkginfo__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/__pkginfo__.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/_ast.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/_ast.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/_backport_stdlib_names.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/_backport_stdlib_names.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/arguments.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/arguments.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/astroid_manager.cpython-314.opt-1.pyc</Path>
@@ -81,7 +82,6 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/util.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/__pycache__/util.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/_ast.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/_backport_stdlib_names.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/arguments.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/astroid_manager.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/bases.py</Path>
@@ -128,8 +128,6 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_multiprocessing.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_namedtuple_enum.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_namedtuple_enum.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_nose.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_nose.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_numpy_core_einsumfunc.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_numpy_core_einsumfunc.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_numpy_core_fromnumeric.cpython-314.opt-1.pyc</Path>
@@ -178,6 +176,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_sqlalchemy.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_ssl.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_ssl.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_statistics.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_statistics.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_subprocess.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_subprocess.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/__pycache__/brain_threading.cpython-314.opt-1.pyc</Path>
@@ -212,7 +212,6 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_mechanize.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_multiprocessing.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_namedtuple_enum.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_nose.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_numpy_core_einsumfunc.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_numpy_core_fromnumeric.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_numpy_core_function_base.py</Path>
@@ -237,6 +236,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_six.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_sqlalchemy.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_ssl.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_statistics.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_subprocess.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_threading.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/astroid/brain/brain_type.py</Path>
@@ -317,12 +317,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2026-06-05</Date>
-            <Version>3.3.11</Version>
+        <Update release="42">
+            <Date>2026-07-30</Date>
+            <Version>4.1.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/pylint-dev/astroid/blob/v4.1.2/ChangeLog).

Note that the "latest" version according to release-monitoring is 4.2.0. And there is a 4.2.0 tag. But there are more 4.2.0 beta tags *after* that tag, and there isn't an actual release on GitHub. So, I decided to only go to version 4.1.2.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the testsuite passes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
