### PR TITLE
python-async-lru: Update to v2.3.0

### DIFF
--- a/packages/py/python-async-lru/package.yml
+++ b/packages/py/python-async-lru/package.yml
@@ -1,9 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-async-lru
-version    : 2.0.4
-release    : 4
+version    : 2.3.0
+release    : 5
 source     :
-    - https://files.pythonhosted.org/packages/source/a/async-lru/async-lru-2.0.4.tar.gz : b8a59a5df60805ff63220b2a0c5b5393da5521b113cd5465a44eb037d81a5627
+    - https://github.com/aio-libs/async-lru/releases/download/v2.3.0/async_lru-2.3.0.tar.gz :
+        89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6
 homepage   : https://github.com/aio-libs/async-lru
 license    : MIT
 component  : programming.python
@@ -14,9 +15,16 @@ builddeps  :
     - python-build
     - python-installer
     - python-setuptools
+checkdeps  :
+    - python-pytest
+    - python-pytest-asyncio
+    - python-pytest-cov
+    - python-pytest-timeout
 rundeps    :
     - python-typing-extensions
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
+check      : |
+    %pytest -v

--- a/packages/py/python-async-lru/pspec_x86_64.xml
+++ b/packages/py/python-async-lru/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-async-lru</Name>
         <Homepage>https://github.com/aio-libs/async-lru</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru-2.0.4.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru-2.0.4.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru-2.0.4.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru-2.0.4.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru-2.0.4.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru-2.3.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru-2.3.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru-2.3.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru-2.3.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru-2.3.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/async_lru/__pycache__/__init__.cpython-314.pyc</Path>
@@ -32,12 +32,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2026-06-05</Date>
-            <Version>2.0.4</Version>
+        <Update release="5">
+            <Date>2026-07-30</Date>
+            <Version>2.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/aio-libs/async-lru/blob/v2.3.0/CHANGES.rst).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the testsuite passes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
