### PR TITLE
python-xmltodict: Update to 1.0.4

### DIFF
--- a/packages/py/python-xmltodict/package.yml
+++ b/packages/py/python-xmltodict/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-xmltodict
-version    : 0.14.2
-release    : 9
+version    : 1.0.4
+release    : 10
 source     :
-    - https://pypi.python.org/packages/source/x/xmltodict/xmltodict-0.14.2.tar.gz : 201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553
+    - https://pypi.python.org/packages/source/x/xmltodict/xmltodict-1.0.4.tar.gz : 6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61
 homepage   : https://github.com/martinblech/xmltodict
 license    : MIT
 component  : programming.python

--- a/packages/py/python-xmltodict/pspec_x86_64.xml
+++ b/packages/py/python-xmltodict/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-xmltodict</Name>
         <Homepage>https://github.com/martinblech/xmltodict</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -22,21 +22,21 @@
         <Files>
             <Path fileType="library">/usr/lib/python3.14/site-packages/__pycache__/xmltodict.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/__pycache__/xmltodict.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/xmltodict-0.14.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/xmltodict-0.14.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/xmltodict-0.14.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/xmltodict-0.14.2.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/xmltodict-0.14.2.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/xmltodict-1.0.4.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/xmltodict-1.0.4.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/xmltodict-1.0.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/xmltodict-1.0.4.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/xmltodict-1.0.4.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/xmltodict.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2026-06-07</Date>
-            <Version>0.14.2</Version>
+        <Update release="10">
+            <Date>2026-07-30</Date>
+            <Version>1.0.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security
- [Change Log](https://github.com/martinblech/xmltodict/blob/master/CHANGELOG.md)

**Security**
- CVE-2025-9375

**Test Plan**
- Test import
- Test xml parse / extraction


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
