### PR TITLE
libreoffice: Add liberation-fonts-ttf as rundep

### DIFF
--- a/packages/l/libreoffice/package.yml
+++ b/packages/l/libreoffice/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libreoffice
 version    : 26.2.5.2
-release    : 212
+release    : 213
 source     :
     - https://download.documentfoundation.org/libreoffice/src/26.2.5/libreoffice-26.2.5.2.tar.xz : 8ec785ee1fd1a1d9b9d8eba1c8ff7556695ca8f02e1f7a26bef8cd540f669fea
     - https://download.documentfoundation.org/libreoffice/src/26.2.5/libreoffice-dictionaries-26.2.5.2.tar.xz : 81f70748287ae25e4b142b3aa5b595daec3d61dad03eb1453cdb35ff837909e3
@@ -177,7 +177,9 @@ rundeps    :
     - base-help : libreoffice-common-help
     - calc : libreoffice-writer
     - calc-help : libreoffice-common-help
-    - common : libreoffice-common-dictionaries
+    - common : 
+        - liberation-fonts-ttf
+        - libreoffice-common-dictionaries
     - common-kde-integration : libreoffice-common
     - draw : libreoffice-writer
     - draw-help : libreoffice-common-help

--- a/packages/l/libreoffice/pspec_x86_64.xml
+++ b/packages/l/libreoffice/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libreoffice</Name>
         <Homepage>https://www.libreoffice.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>BSD-2-Clause</License>
@@ -25,13 +25,13 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-base</Dependency>
-            <Dependency releaseFrom="212">libreoffice-calc</Dependency>
-            <Dependency releaseFrom="212">libreoffice-common</Dependency>
-            <Dependency releaseFrom="212">libreoffice-common-dictionaries</Dependency>
-            <Dependency releaseFrom="212">libreoffice-draw</Dependency>
-            <Dependency releaseFrom="212">libreoffice-impress</Dependency>
-            <Dependency releaseFrom="212">libreoffice-math</Dependency>
+            <Dependency releaseFrom="213">libreoffice-base</Dependency>
+            <Dependency releaseFrom="213">libreoffice-calc</Dependency>
+            <Dependency releaseFrom="213">libreoffice-common</Dependency>
+            <Dependency releaseFrom="213">libreoffice-common-dictionaries</Dependency>
+            <Dependency releaseFrom="213">libreoffice-draw</Dependency>
+            <Dependency releaseFrom="213">libreoffice-impress</Dependency>
+            <Dependency releaseFrom="213">libreoffice-math</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="doc">/usr/share/doc/libreoffice-all</Path>
@@ -43,8 +43,8 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency release="212">libreoffice-common</Dependency>
-            <Dependency releaseFrom="212">libreoffice-writer</Dependency>
+            <Dependency release="213">libreoffice-common</Dependency>
+            <Dependency releaseFrom="213">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/lobase</Path>
@@ -73,7 +73,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="213">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/sdatabase.cfg</Path>
@@ -696,7 +696,7 @@
         <Description xml:lang="en">Calc is the spreadsheet program you&apos;ve always needed.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="213">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/localc</Path>
@@ -977,7 +977,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="213">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/scalc.cfg</Path>
@@ -1600,7 +1600,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-common-dictionaries</Dependency>
+            <Dependency releaseFrom="213">libreoffice-common-dictionaries</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/libreoffice</Path>
@@ -14945,7 +14945,7 @@
         <Description xml:lang="en">KDE integration for LibreOffice.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency release="212">libreoffice-common</Dependency>
+            <Dependency release="213">libreoffice-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/program/libvclplug_kf6lo.so</Path>
@@ -14959,7 +14959,7 @@
         <Description xml:lang="en">Draw lets you produce anything from a quick sketch to a complex plan and gives you the means to communicate with graphics and diagrams.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="213">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/lodraw</Path>
@@ -15089,7 +15089,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="213">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/sdraw.cfg</Path>
@@ -15712,8 +15712,8 @@
         <Description xml:lang="en">Impress is a truly outstanding tool for creating effective multimedia presentations.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-draw</Dependency>
-            <Dependency releaseFrom="212">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="213">libreoffice-draw</Dependency>
+            <Dependency releaseFrom="213">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/loimpress</Path>
@@ -15898,7 +15898,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="213">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/simpress.cfg</Path>
@@ -16521,7 +16521,7 @@
         <Description xml:lang="en">Math is LibreOffice&apos;s formula editor.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="213">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/lomath</Path>
@@ -16569,7 +16569,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="213">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/smath.cfg</Path>
@@ -17192,7 +17192,7 @@
         <Description xml:lang="en">Writer has all the features you need from a modern, full-featured word processing and desktop publishing tool.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-common</Dependency>
+            <Dependency releaseFrom="213">libreoffice-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/loweb</Path>
@@ -17535,7 +17535,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="212">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="213">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/swriter.cfg</Path>
@@ -18153,12 +18153,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="212">
-            <Date>2026-07-24</Date>
+        <Update release="213">
+            <Date>2026-07-30</Date>
             <Version>26.2.5.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add liberation-fonts-ttf as rundep. Resolves getsolus/packages#9796


**Test Plan**
- Open Impress
- Verify Liberation Sans fonts


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
