### PR TITLE
nghttp2: Update to v1.70.0

### DIFF
--- a/packages/n/nghttp2/package.yml
+++ b/packages/n/nghttp2/package.yml
@@ -1,27 +1,24 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nghttp2
-version    : 1.68.1
-release    : 19
+version    : 1.70.0
+release    : 20
 source     :
-    - https://github.com/nghttp2/nghttp2/releases/download/v1.68.1/nghttp2-1.68.1.tar.xz : 6abd7ab0a7f1580d5914457cb3c85eb80455657ee5119206edbd7f848c14f0b2
+    - https://github.com/nghttp2/nghttp2/releases/download/v1.70.0/nghttp2-1.70.0.tar.xz : e05cb1388eaca3830aded4ccf20044b6e1ac1a61411dcca11b0437c4285c8bc2
+homepage   : https://nghttp2.org/
 license    : MIT
 component  : system.base
-emul32     : true
-homepage   : https://nghttp2.org/
 summary    : HTTP/2 C Library
 description: |
     This is an implementation of the Hypertext Transfer Protocol version 2 in C.
+emul32     : true
 builddeps  :
     - pkgconfig32(openssl)
 setup      : |
     %cmake_ninja \
-                 -DENABLE_LIB_ONLY=ON \
-                 -DCMAKE_INSTALL_LIBDIR=%libdir%
+        -DENABLE_LIB_ONLY=ON \
+        -DCMAKE_INSTALL_LIBDIR=%libdir%
 build      : |
     %ninja_build
 install    : |
     %ninja_install
     %install_license COPYING
-
-    rm -rf $installdir/usr/share/doc \
-           $installdir/usr/share/man

--- a/packages/n/nghttp2/pspec_x86_64.xml
+++ b/packages/n/nghttp2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nghttp2</Name>
         <Homepage>https://nghttp2.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.base</PartOf>
@@ -21,8 +21,13 @@
         <PartOf>system.base</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libnghttp2.so.14</Path>
-            <Path fileType="library">/usr/lib64/libnghttp2.so.14.29.3</Path>
+            <Path fileType="library">/usr/lib64/libnghttp2.so.14.29.5</Path>
+            <Path fileType="doc">/usr/share/doc/nghttp2/README.rst</Path>
             <Path fileType="data">/usr/share/licenses/nghttp2/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/h2load.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/nghttp.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/nghttpd.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/nghttpx.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -32,11 +37,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="19">nghttp2</Dependency>
+            <Dependency release="20">nghttp2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnghttp2.so.14</Path>
-            <Path fileType="library">/usr/lib32/libnghttp2.so.14.29.3</Path>
+            <Path fileType="library">/usr/lib32/libnghttp2.so.14.29.5</Path>
         </Files>
     </Package>
     <Package>
@@ -46,10 +51,14 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="19">nghttp2-32bit</Dependency>
-            <Dependency release="19">nghttp2-devel</Dependency>
+            <Dependency release="20">nghttp2-32bit</Dependency>
+            <Dependency release="20">nghttp2-devel</Dependency>
         </RuntimeDependencies>
         <Files>
+            <Path fileType="library">/usr/lib32/cmake/nghttp2/nghttp2Config.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/nghttp2/nghttp2ConfigVersion.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/nghttp2/nghttp2Targets-relwithdebinfo.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/nghttp2/nghttp2Targets.cmake</Path>
             <Path fileType="library">/usr/lib32/libnghttp2.so</Path>
             <Path fileType="data">/usr/lib32/pkgconfig/libnghttp2.pc</Path>
         </Files>
@@ -61,26 +70,26 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="19">nghttp2</Dependency>
+            <Dependency release="20">nghttp2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/nghttp2/nghttp2.h</Path>
             <Path fileType="header">/usr/include/nghttp2/nghttp2ver.h</Path>
-            <Path fileType="library">/usr/lib/cmake/nghttp2/nghttp2Config.cmake</Path>
-            <Path fileType="library">/usr/lib/cmake/nghttp2/nghttp2ConfigVersion.cmake</Path>
-            <Path fileType="library">/usr/lib/cmake/nghttp2/nghttp2Targets-relwithdebinfo.cmake</Path>
-            <Path fileType="library">/usr/lib/cmake/nghttp2/nghttp2Targets.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/nghttp2/nghttp2Config.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/nghttp2/nghttp2ConfigVersion.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/nghttp2/nghttp2Targets-relwithdebinfo.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/nghttp2/nghttp2Targets.cmake</Path>
             <Path fileType="library">/usr/lib64/libnghttp2.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libnghttp2.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-03-18</Date>
-            <Version>1.68.1</Version>
+        <Update release="20">
+            <Date>2026-07-31</Date>
+            <Version>1.70.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://nghttp2.org/blog/2026/07/29/nghttp2-v1-70-0/).

**Security**
Includes fixes for:
- CVE-2026-58055

**Test Plan**

Smoke tests

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
