### PR TITLE
Add monitoring python

### DIFF
--- a/packages/py/python-sip-4/monitoring.yaml
+++ b/packages/py/python-sip-4/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 319290
+  rss: ~
+# No known CPE, checked 2026-06-19
+security:
+  cpe: ~

--- a/packages/py/python-sphinx-lv2-theme/monitoring.yaml
+++ b/packages/py/python-sphinx-lv2-theme/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 267121
+  rss: ~
+# No known CPE, checked 2026-06-19
+security:
+  cpe: ~

--- a/packages/py/python-sphinx-rtd-theme/monitoring.yaml
+++ b/packages/py/python-sphinx-rtd-theme/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 232897
+  rss: https://github.com/readthedocs/sphinx_rtd_theme/releases.atom
+# No known CPE, checked 2026-06-19
+security:
+  cpe: ~

--- a/packages/py/python2-setuptools/monitoring.yaml
+++ b/packages/py/python2-setuptools/monitoring.yaml
@@ -1,0 +1,7 @@
+releases:
+  id: 4021
+  rss: https://github.com/pypa/setuptools/releases.atom
+security:
+  cpe:
+    - vendor: python
+      product: setuptools


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->

Adds monitoring.yaml to 4 Python packages that were missing it, enabling automated release and CVE monitoring. Part of #4121.

- python-sip-4 - Anitya ID 13626
- python-sphinx-lv2-theme - Anitya ID 267121
- python-sphinx-rtd-theme - Anitya ID 232897 (GitHub release feed)
- python2-setuptools - Anitya ID 4021 (GitHub release feed, CPE python/setuptools)


**Test Plan**

<!-- Short description of how the package was tested -->

- Verified each monitoring.yaml is valid YAML
- Confirmed all four Anitya IDs resolve and return version info at https://release-monitoring.org
- Checked NVD CPE database; only setuptools has CPE entries (added), the other three have none

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
