### PR TITLE
python-cookiecutter: Update to v2.7.1

### DIFF
--- a/packages/py/python-cookiecutter/package.yml
+++ b/packages/py/python-cookiecutter/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-cookiecutter
-version    : 2.6.0
-release    : 13
+version    : 2.7.1
+release    : 14
 source     :
-    - https://github.com/cookiecutter/cookiecutter/archive/refs/tags/2.6.0.tar.gz : da014a94d85c1b1be14be214662982c8c90d860834cbf9ddb2391a37ad7d08be
+    - https://github.com/cookiecutter/cookiecutter/archive/refs/tags/v2.7.1.tar.gz : ad22b0a6355e208a614ae0285268a6b612938935f1d29ec9edab85c6053c7224
 homepage   : https://github.com/cookiecutter/cookiecutter
 license    : BSD-3-Clause
 component  : programming.python
@@ -36,8 +36,8 @@ rundeps    :
     - python-slugify
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    %pytest -v

--- a/packages/py/python-cookiecutter/pspec_x86_64.xml
+++ b/packages/py/python-cookiecutter/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-cookiecutter</Name>
         <Homepage>https://github.com/cookiecutter/cookiecutter</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -21,14 +21,13 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/cookiecutter</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.6.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.6.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.6.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.6.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.6.0.dist-info/licenses/AUTHORS.md</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.6.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.6.0.dist-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter/VERSION.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.7.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.7.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.7.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.7.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.7.1.dist-info/licenses/AUTHORS.md</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.7.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter-2.7.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/cookiecutter/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -86,12 +85,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-06-05</Date>
-            <Version>2.6.0</Version>
+        <Update release="14">
+            <Date>2026-07-30</Date>
+            <Version>2.7.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Full changelog [here](https://github.com/cookiecutter/cookiecutter/compare/2.6.0...v2.7.1)

**Test Plan**

- check version with importlib.metadata and cookiecutter -V
- use cookieicutter to create a project based on templates "gh:osprey-oss/cookiecutter-poetry" and "gh:cookiecutter/cookiecutter-django"

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
