### PR TITLE
nano: Update to v9.2

### DIFF
--- a/packages/n/nano/package.yml
+++ b/packages/n/nano/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nano
-version    : '9.1'
-release    : 214
+version    : '9.2'
+release    : 215
 source     :
-    - https://www.nano-editor.org/dist/v9/nano-9.1.tar.xz : 5f47764274cb7532349ce0aa20ec10f1e8e851a6e9fa3eb66812c43d196db042
+    - https://www.nano-editor.org/dist/v9/nano-9.2.tar.xz : 05ecb99247b782e8a5b3a25ed4101dd034b0236902f7449bc9795b717642f7e9
 homepage   : https://www.nano-editor.org
 license    : GPL-3.0-or-later
 component  : system.devel
@@ -28,20 +28,20 @@ install    : |
     %install_license COPYING
 
     # Include syntax definitions
-    for rcfile in $installdir/usr/share/nano/*.nanorc; do
-        echo include /usr/share/nano/${rcfile##*nano/} >> $pkgfiles/nanorc
+    for rcfile in ${installdir}/usr/share/nano/*.nanorc; do
+        echo include /usr/share/nano/${rcfile##*nano/} >> ${pkgfiles}/nanorc
     done
 
     # Include missing definitions from scopatz's files
     for rcfile in /usr/share/nanorc/*.nanorc; do
-        if ! grep -Fq ${rcfile#*highlighting/} $pkgfiles/nanorc
+        if ! grep -Fq ${rcfile#*highlighting/} ${pkgfiles}/nanorc
         then
-            echo include "$rcfile" >> $pkgfiles/nanorc
+            echo include "$rcfile" >> ${pkgfiles}/nanorc
         fi
     done
 
-    %install_file $pkgfiles/nanorc $installdir/usr/share/defaults/nano/nanorc
+    %install_file ${pkgfiles}/nanorc ${installdir}/usr/share/defaults/nano/nanorc
 
     # Ensure that nano is set up as default EDITOR and VISUAL
-    %install_file $pkgfiles/81-nano-is-default-EDITOR-and-VISUAL.sh $installdir/usr/share/defaults/etc/profile.d/81-nano-is-default-EDITOR-and-VISUAL.sh
-    %install_file $pkgfiles/81-nano-is-default-EDITOR-and-VISUAL.fish $installdir/usr/share/defaults/etc/profile.d/81-nano-is-default-EDITOR-and-VISUAL.fish
+    %install_file ${pkgfiles}/81-nano-is-default-EDITOR-and-VISUAL.sh ${installdir}/usr/share/defaults/etc/profile.d/81-nano-is-default-EDITOR-and-VISUAL.sh
+    %install_file ${pkgfiles}/81-nano-is-default-EDITOR-and-VISUAL.fish ${installdir}/usr/share/defaults/etc/profile.d/81-nano-is-default-EDITOR-and-VISUAL.fish

--- a/packages/n/nano/pspec_x86_64.xml
+++ b/packages/n/nano/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nano</Name>
         <Homepage>https://www.nano-editor.org</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -119,12 +119,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="214">
-            <Date>2026-07-25</Date>
-            <Version>9.1</Version>
+        <Update release="215">
+            <Date>2026-07-31</Date>
+            <Version>9.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.nano-editor.org/news.php).
- Nano refuses to start when standard output is not a terminal.
- Options --newbuffer and 'set newbuffer' were added as better synonyms of --multibuffer and 'set multibuffer'.
- Legacy keystroke pairs ^W^T and ^/^T are recognized again.

**Test Plan**

Edited commit with `nano`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
