### PR TITLE
python-configargparse: Update to v1.7.5

### DIFF
--- a/packages/py/python-configargparse/package.yml
+++ b/packages/py/python-configargparse/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-configargparse
-version    : 1.7.1
-release    : 15
+version    : 1.7.5
+release    : 16
 source     :
-    - https://github.com/bw2/ConfigArgParse/archive/refs/tags/1.7.1.tar.gz : b31bfcce183ef7226f00cd07a37cfd69fe654229fe462f9a1de6091f396fc0f9
+    - https://github.com/bw2/ConfigArgParse/archive/refs/tags/v1.7.5.tar.gz : bebae43c8afa35f5c16fe295c811ecb0ec13bfc606b245c7d3ebebee99fdcf2a
 homepage   : https://github.com/bw2/ConfigArgParse/
 license    : MIT
 component  : programming.python
@@ -11,12 +11,16 @@ summary    : A drop-in replacement for argparse with config file support
 description: |
     A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables
 builddeps  :
-    - python-setuptools
+    - python-build
+    - python-installer
+    - python-setuptools-scm
+    - python-wheel
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    export SETUPTOOLS_SCM_PRETEND_VERSION=${version}
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    %pytest -v

--- a/packages/py/python-configargparse/pspec_x86_64.xml
+++ b/packages/py/python-configargparse/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-configargparse</Name>
         <Homepage>https://github.com/bw2/ConfigArgParse/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,22 +20,23 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/ConfigArgParse-1.7.1-py3.14.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/ConfigArgParse-1.7.1-py3.14.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/ConfigArgParse-1.7.1-py3.14.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/ConfigArgParse-1.7.1-py3.14.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/ConfigArgParse-1.7.1-py3.14.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/__pycache__/configargparse.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/__pycache__/configargparse.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/configargparse-1.7.5.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/configargparse-1.7.5.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/configargparse-1.7.5.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/configargparse-1.7.5.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/configargparse-1.7.5.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/configargparse.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2026-06-05</Date>
-            <Version>1.7.1</Version>
+        <Update release="16">
+            <Date>2026-07-31</Date>
+            <Version>1.7.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/bw2/ConfigArgParse/releases/tag/v1.7.5).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the testsuite passes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
