### PR TITLE
python-confuse: Update to v2.2.1

### DIFF
--- a/packages/py/python-confuse/package.yml
+++ b/packages/py/python-confuse/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-confuse
-version    : 2.2.0
-release    : 13
+version    : 2.2.1
+release    : 14
 source     :
-    - https://files.pythonhosted.org/packages/source/c/confuse/confuse-2.2.0.tar.gz : 35c1b53e81be125f441bee535130559c935917b26aeaa61289010cd1f55c2b9e
+    - https://files.pythonhosted.org/packages/source/c/confuse/confuse-2.2.1.tar.gz : 8e7600c3261852122eb5f17b24b06ab8e5437b21d6224853c1420c38ac469d3c
 homepage   : https://github.com/beetbox/confuse
 license    : MIT
 component  : programming.python
@@ -19,8 +19,8 @@ checkdeps  :
 rundeps    :
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    %pytest -v

--- a/packages/py/python-confuse/pspec_x86_64.xml
+++ b/packages/py/python-confuse/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-confuse</Name>
         <Homepage>https://github.com/beetbox/confuse</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/confuse-2.2.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/confuse-2.2.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/confuse-2.2.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/confuse-2.2.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/confuse-2.2.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/confuse-2.2.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/confuse-2.2.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/confuse-2.2.1.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/confuse/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/confuse/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/confuse/__pycache__/__init__.cpython-314.pyc</Path>
@@ -49,12 +49,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-06-05</Date>
-            <Version>2.2.0</Version>
+        <Update release="14">
+            <Date>2026-07-31</Date>
+            <Version>2.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/beetbox/confuse/releases/tag/v2.2.1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the testsuite passes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
