### PR TITLE
dankcalendar: Update to v0.3.0

### DIFF
--- a/packages/d/dankcalendar/package.yml
+++ b/packages/d/dankcalendar/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dankcalendar
-version    : 0.2.7
-release    : 5
+version    : 0.3.0
+release    : 6
 source     :
-    - https://github.com/AvengeMedia/dankcalendar/releases/download/v0.2.7/dankcalendar-0.2.7.tar.gz : b52a2d5f5c876d4c737c2e785890ac935ebb81657375c2a50d766de55bdb7a1e
+    - https://github.com/AvengeMedia/dankcalendar/releases/download/v0.3.0/dankcalendar-0.3.0.tar.gz : b9d52ae1b908bfe0ae6a94d30d850a4fbfe22e09b74f641ecc06978f90a49d3e
 homepage   : https://danklinux.com
 license    : MIT
 component  : desktop
@@ -38,6 +38,6 @@ install    : |
     sed -i "s|${installdir}||g" ${installdir}/usr/lib/systemd/user/dcal.service
 
     # Install completions
-    install -Dm 00644 -t ${installdir}/usr/share/bash-completion/completions completions/dcal
-    install -Dm 00644 -t ${installdir}/usr/share/fish/vendor_completions.d completions/dcal.fish
-    install -Dm 00644 -t ${installdir}/usr/share/zsh/site-functions completions/_dcal
+    %install_file -t ${installdir}/usr/share/bash-completion/completions completions/dcal
+    %install_file -t ${installdir}/usr/share/fish/vendor_completions.d completions/dcal.fish
+    %install_file -t ${installdir}/usr/share/zsh/site-functions completions/_dcal

--- a/packages/d/dankcalendar/pspec_x86_64.xml
+++ b/packages/d/dankcalendar/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-07-24</Date>
-            <Version>0.2.7</Version>
+        <Update release="6">
+            <Date>2026-07-31</Date>
+            <Version>0.3.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/AvengeMedia/dankcalendar/releases/tag/v0.3.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Launch Dank Calendar.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
