### PR TITLE
dankcalendar: Update to v0.3.1

### DIFF
--- a/packages/d/dankcalendar/package.yml
+++ b/packages/d/dankcalendar/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dankcalendar
-version    : 0.3.0
-release    : 6
+version    : 0.3.1
+release    : 7
 source     :
-    - https://github.com/AvengeMedia/dankcalendar/releases/download/v0.3.0/dankcalendar-0.3.0.tar.gz : b9d52ae1b908bfe0ae6a94d30d850a4fbfe22e09b74f641ecc06978f90a49d3e
+    - https://github.com/AvengeMedia/dankcalendar/releases/download/v0.3.1/dankcalendar-0.3.1.tar.gz : fcbac8bdd9edba67ddebd8f8d219b77fcc981ae478bfb62e752051e6e772fea0
 homepage   : https://danklinux.com
 license    : MIT
 component  : desktop

--- a/packages/d/dankcalendar/pspec_x86_64.xml
+++ b/packages/d/dankcalendar/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-07-31</Date>
-            <Version>0.3.0</Version>
+        <Update release="7">
+            <Date>2026-08-01</Date>
+            <Version>0.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/AvengeMedia/dankcalendar/releases/tag/v0.3.1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Launch Dank Calendar.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
