### PR TITLE
python-pathspec: Update to v1.1.1

### DIFF
--- a/packages/py/python-pathspec/package.yml
+++ b/packages/py/python-pathspec/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-pathspec
-version    : 1.0.4
-release    : 13
+version    : 1.1.1
+release    : 14
 source     :
-    - https://github.com/cpburnz/python-pathspec/archive/refs/tags/v1.0.4.tar.gz : 7612ec6e67f4ea83b9987367a3bbd76bf3e7466bf33769a8810509774b26862d
+    - https://github.com/cpburnz/python-pathspec/archive/refs/tags/v1.1.1.tar.gz : 7befd398baeb84cd3872bcb84926e688361012d21c8c157dcc2f9f64684b9147
 homepage   : https://github.com/cpburnz/python-path-specification
 license    : MPL-2.0
 component  : programming.python
@@ -16,9 +16,11 @@ builddeps  :
     - python-installer
     - python-packaging
     - python-wheel
+checkdeps  :
+    - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test
+    %pytest

--- a/packages/py/python-pathspec/pspec_x86_64.xml
+++ b/packages/py/python-pathspec/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-pathspec</Name>
         <Homepage>https://github.com/cpburnz/python-path-specification</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/pathspec-1.0.4.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/pathspec-1.0.4.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/pathspec-1.0.4.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/pathspec-1.0.4.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pathspec-1.1.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pathspec-1.1.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pathspec-1.1.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pathspec-1.1.1.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/pathspec/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/pathspec/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/pathspec/__pycache__/__init__.cpython-314.pyc</Path>
@@ -121,12 +121,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-06-05</Date>
-            <Version>1.0.4</Version>
+        <Update release="14">
+            <Date>2026-08-01</Date>
+            <Version>1.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/cpburnz/python-pathspec/blob/v1.1.1/CHANGES.rst).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passes. Build `python-croniter` successfully.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
