### PR TITLE
python-croniter: Update to v6.2.4

### DIFF
--- a/packages/py/python-croniter/package.yml
+++ b/packages/py/python-croniter/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-croniter
-version    : 6.2.2
-release    : 16
+version    : 6.2.4
+release    : 17
 source     :
-    - https://files.pythonhosted.org/packages/source/c/croniter/croniter-6.2.2.tar.gz : ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab
+    - https://files.pythonhosted.org/packages/source/c/croniter/croniter-6.2.4.tar.gz : fc124f751b1b04805c2a04b061898b436b45ab2320b045e1e052ea895de65189
 homepage   : https://github.com/kiorky/croniter
 license    : MIT
 component  : programming.python
@@ -15,6 +15,7 @@ builddeps  :
     - python-hatchling
     - python-installer
     - python-packaging
+    - python-pathspec
     - python-pluggy
     - python-setuptools
     - python-trove-classifiers
@@ -25,12 +26,13 @@ checkdeps  :
 rundeps    :
     - python-dateutil
     - python-pytz
-build      : |
+setup      : |
     # don't hardcode fucking version constraints
     sed -i 's/==/>=/g' pyproject.toml
-    %python3_setup
+build      : |
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # pytz/DST/timezone tests fail on Python 3.14 (zoneinfo vs pytz tzinfo behavior)
-    %python3_test pytest -v -k 'not pytz and not test_dst_daily and not test_dst_hourly and not test_timezone_dateutil'
+    %pytest -v -k 'not pytz and not test_dst_daily and not test_dst_hourly and not test_timezone_dateutil'

--- a/packages/py/python-croniter/pspec_x86_64.xml
+++ b/packages/py/python-croniter/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-croniter</Name>
         <Homepage>https://github.com/kiorky/croniter</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/croniter-6.2.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/croniter-6.2.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/croniter-6.2.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/croniter-6.2.2.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/croniter-6.2.4.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/croniter-6.2.4.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/croniter-6.2.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/croniter-6.2.4.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/croniter/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/croniter/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/croniter/__pycache__/__init__.cpython-314.pyc</Path>
@@ -57,12 +57,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2026-06-12</Date>
-            <Version>6.2.2</Version>
+        <Update release="17">
+            <Date>2026-08-01</Date>
+            <Version>6.2.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/pallets-eco/croniter/blob/6.2.4/CHANGELOG.rst).

Depends on https://github.com/getsolus/packages/pull/9871

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
