### PR TITLE
python-cssselect2: Update to v0.9.0

### DIFF
--- a/packages/py/python-cssselect2/package.yml
+++ b/packages/py/python-cssselect2/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-cssselect2
-version    : 0.8.0
-release    : 6
+version    : 0.9.0
+release    : 7
 source     :
-    - https://files.pythonhosted.org/packages/source/c/cssselect2/cssselect2-0.8.0.tar.gz : 7674ffb954a3b46162392aee2a3a0aedb2e14ecf99fcc28644900f4e6e3e9d3a
-license    : BSD-3-Clause
+    - https://files.pythonhosted.org/packages/source/c/cssselect2/cssselect2-0.9.0.tar.gz : 759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb
 homepage   : https://doc.courtbouillon.org/cssselect2/stable/
+license    : BSD-3-Clause
 component  : programming.python
 summary    : CSS selectors for Python ElementTree
 description: |
@@ -24,8 +24,8 @@ rundeps    :
     - python-tinycss2
     - python-webencodings
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    python3 -m pytest
+    %pytest -v

--- a/packages/py/python-cssselect2/pspec_x86_64.xml
+++ b/packages/py/python-cssselect2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-cssselect2</Name>
         <Homepage>https://doc.courtbouillon.org/cssselect2/stable/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.8.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.8.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.8.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.8.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.9.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.9.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.9.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.9.0.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2/__pycache__/__init__.cpython-314.pyc</Path>
@@ -39,12 +39,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-06-06</Date>
-            <Version>0.8.0</Version>
+        <Update release="7">
+            <Date>2026-08-01</Date>
+            <Version>0.9.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/Kozea/cssselect2/releases/tag/0.9.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
