### PR TITLE
docker: Update to v29.7.1

### DIFF
--- a/packages/d/docker/package.yml
+++ b/packages/d/docker/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker
-version    : 29.6.2
-release    : 79
+version    : 29.7.1
+release    : 80
 source     :
-    - https://github.com/docker/cli/archive/refs/tags/v29.6.2.tar.gz : 11aef3484c38d39d291a54a73a4d9dd2bb3c000d9a3fc3862bd03fe899594f2c
+    - https://github.com/docker/cli/archive/refs/tags/v29.7.1.tar.gz : 09c72c14870f9c34029942f4c5cf3169b69dc48ea78e7380b5ebaa316356ba1d
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt

--- a/packages/d/docker/pspec_x86_64.xml
+++ b/packages/d/docker/pspec_x86_64.xml
@@ -218,9 +218,9 @@ Docker containers are both hardware-agnostic and platform-agnostic. This means t
         </Files>
     </Package>
     <History>
-        <Update release="79">
-            <Date>2026-07-16</Date>
-            <Version>29.6.2</Version>
+        <Update release="80">
+            <Date>2026-08-02</Date>
+            <Version>29.7.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/m/moby/README.md
+++ b/packages/m/moby/README.md
@@ -1,0 +1,22 @@
+# Docker stack update order
+
+- `runc`
+- `containerd`
+- `buildkit`
+- `moby`
+- `docker`
+- `docker-buildx`
+- `docker-compose`
+
+## Notes
+
+- `moby` and `docker` should be bumped together (same version)
+- `buildkit` is separate from the engine but should be updated before `docker-buildx`
+- `conmon`, `buildah`, and other podman packages are a separate stack
+
+## Tips
+
+- To get the git commit for a tag: `git ls-remote <upstream .git> refs/tags/v<version> | awk '{print $1}'`
+- Use `refs/tags/v<version>^{}` for annotated tags
+- `moby` uses `refs/tags/docker-v<version>`
+- The recipes already resolve and embed the commit at build time

--- a/packages/m/moby/package.yml
+++ b/packages/m/moby/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : moby
-version    : 29.6.2
-release    : 35
+version    : 29.7.1
+release    : 36
 source     :
-    - https://github.com/moby/moby/archive/refs/tags/docker-v29.6.2.tar.gz : 8b64afb7562347d2ce9f1027e326ce9a45c8f41a486106ce2034f7eb1abe0e0f
+    - https://github.com/moby/moby/archive/refs/tags/docker-v29.7.1.tar.gz : e852479cc37cbf151126be1c077bef5e7ceea6c854dd860d46e61004bdf70b76
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt

--- a/packages/m/moby/pspec_x86_64.xml
+++ b/packages/m/moby/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2026-07-16</Date>
-            <Version>29.6.2</Version>
+        <Update release="36">
+            <Date>2026-08-02</Date>
+            <Version>29.7.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://docs.docker.com/engine/release-notes/29/).

**Security**
Includes fixes for:
- CVE-2026-17106

**Test Plan**

docker works. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
