### PR TITLE
audit: Stop shipping two audit.conf files

### DIFF
--- a/packages/a/audit/files/audit.tmpfiles
+++ b/packages/a/audit/files/audit.tmpfiles
@@ -1,2 +1,3 @@
 d /var/log/audit 0755 root root -
 d /etc/audit/rules.d 0755 root root -
+d /run/audit 0700 root root - -

--- a/packages/a/audit/package.yml
+++ b/packages/a/audit/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : audit
 version    : 4.2.1
-release    : 21
+release    : 22
 source     :
     - https://github.com/linux-audit/audit-userspace/archive/refs/tags/v4.2.1.tar.gz : 42876d195ee2ded19e5f72d7664096eee314928aa36ad346719ba5b25818fc84
 homepage   : https://people.redhat.com/sgrubb/audit/
@@ -22,8 +22,11 @@ build      : |
     %make
 install    : |
     %make_install
-    install -D -m 00644 $pkgfiles/audit.tmpfiles $installdir/%libdir%/tmpfiles.d/audit.conf
+    %install_file ${pkgfiles}/audit.tmpfiles ${installdir}/%libdir%/tmpfiles.d/audit.conf
     %install_license COPYING*
+
+    # Remove upstream audit.conf which overwrites our own.
+    rm -rf ${installdir}/usr/lib/tmpfiles.d/
 
     # Stateless
     rm -v $installdir/etc/audit/audisp-filter.conf \

--- a/packages/a/audit/pspec_x86_64.xml
+++ b/packages/a/audit/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>audit</Name>
         <Homepage>https://people.redhat.com/sgrubb/audit/</Homepage>
         <Packager>
-            <Name>Clint Eschberger</Name>
-            <Email>clint@eschberger.info</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -26,7 +26,6 @@
             <Path fileType="executable">/usr/bin/ausyscall</Path>
             <Path fileType="library">/usr/lib/systemd/system/audit-rules.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/auditd.service</Path>
-            <Path fileType="library">/usr/lib/tmpfiles.d/audit.conf</Path>
             <Path fileType="library">/usr/lib64/audit/initscripts/legacy-actions/auditd/condrestart</Path>
             <Path fileType="library">/usr/lib64/audit/initscripts/legacy-actions/auditd/reload</Path>
             <Path fileType="library">/usr/lib64/audit/initscripts/legacy-actions/auditd/restart</Path>
@@ -121,7 +120,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">audit</Dependency>
+            <Dependency release="22">audit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/audit-records.h</Path>
@@ -241,12 +240,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2026-07-30</Date>
+        <Update release="22">
+            <Date>2026-08-03</Date>
             <Version>4.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Clint Eschberger</Name>
-            <Email>clint@eschberger.info</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
`sudo eopkg check audit` is reporting /usr/lib/tmpfiles.d/audit.conf as corrupt due to a recent update to the package.

We were already installing our own audit.conf
install -D -m 00644 $pkgfiles/audit.tmpfiles $installdir/%libdir%/tmpfiles.d/audit.conf

%libdir% is /usr/lib64/

Newer version of `audit` appears to ship their own audit.conf to:
/usr/lib/tmpfiles.d/audit.conf

In the .eopkg these are two unique locations but once installed /usr/lib/ is a symlink to /usr/lib64/ so the conf is overwritten.

Ours: 
─────┬────────────────
     │ File: /usr/lib/tmpfiles.d/audit.conf
─────┬────────────────
   1 │ d /var/log/audit 0755 root root -
   2 │ d /etc/audit/rules.d 0755 root root -
─────┬────────────────

Upstreams:
─────┬────────────────
     │ File: install/usr/lib/tmpfiles.d/audit.conf
─────┬────────────────
   1 │ d /run/audit 0700 root root - -
   2 │ d /var/log/audit 0700 root root - -
─────┬────────────────


I assume we want to keep our own?

Part of getsolus/packages#9868

**Test Plan**

```
❯ sudo eopkg check audit
[sudo] password for harvey:
Checking integrity of audit    OK
```

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
