### PR TITLE
python-typing-extensions: Update to 4.16.0

### DIFF
--- a/packages/py/python-typing-extensions/package.yml
+++ b/packages/py/python-typing-extensions/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-typing-extensions
-version    : 4.15.0
-release    : 14
+version    : 4.16.0
+release    : 15
 source     :
-    - https://files.pythonhosted.org/packages/source/t/typing-extensions/typing_extensions-4.15.0.tar.gz : 0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466
+    - https://files.pythonhosted.org/packages/source/t/typing-extensions/typing_extensions-4.16.0.tar.gz : dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5
 homepage   : https://github.com/python/typing_extensions
 license    : Python-2.0
 component  : programming.python
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-packaging
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-typing-extensions/pspec_x86_64.xml
+++ b/packages/py/python-typing-extensions/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-typing-extensions</Name>
         <Homepage>https://github.com/python/typing_extensions</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>Python-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -22,20 +22,20 @@
         <Files>
             <Path fileType="library">/usr/lib/python3.14/site-packages/__pycache__/typing_extensions.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/__pycache__/typing_extensions.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/typing_extensions-4.15.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/typing_extensions-4.15.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/typing_extensions-4.15.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/typing_extensions-4.15.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/typing_extensions-4.16.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/typing_extensions-4.16.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/typing_extensions-4.16.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/typing_extensions-4.16.0.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/typing_extensions.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2026-06-06</Date>
-            <Version>4.15.0</Version>
+        <Update release="15">
+            <Date>2026-08-03</Date>
+            <Version>4.16.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- [4.16.0 Change Log](https://github.com/python/typing_extensions/releases/tag/4.16.0)

**Test Plan**
- Load and test TypeAliasType works


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
