### PR TITLE
eopkg: Patch eopkg check to ignore modules.softdep

### DIFF
--- a/packages/e/eopkg/files/0001-Add-modules.softdep-to-ignore.patch
+++ b/packages/e/eopkg/files/0001-Add-modules.softdep-to-ignore.patch
@@ -1,0 +1,22 @@
+From 59e423ea39088cd46f1903b1094127d8fda28d73 Mon Sep 17 00:00:00 2001
+From: Troy Harvey <harvey@getsol.us>
+Date: Sun, 2 Aug 2026 12:30:45 +1000
+Subject: [PATCH] operations: Add modules.softdep to ignore list
+
+Signed-off-by: Troy Harvey <harvey@getsol.us>
+---
+ pisi/operations/check.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pisi/operations/check.py b/pisi/operations/check.py
+index 51162d47..c7a728a8 100644
+--- a/pisi/operations/check.py
++++ b/pisi/operations/check.py
+@@ -33,6 +33,7 @@ def file_corrupted(pfile):
+     "modules.dep.bin",
+     "modules.symbols",
+     "modules.symbols.bin",
++    "modules.softdep",
+ ]
+ 
+ _top_level_dirs = [

--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : eopkg
 version    : 5.0.0
-release    : 52
+release    : 53
 source     :
     - git|https://github.com/getsolus/eopkg.git : 35c497e20c439926b8a82323971ee86d64a15d36 # v5.0.0
     - git|https://github.com/PackageKit/PackageKit.git : 61e115bae31a4aea8a7c6874b8e46ad59058ae72
@@ -53,6 +53,9 @@ environment: |
     # to be added in the future to guard against either x86_64-v2, x86_64-v3 or x86_64-v4 hwcaps being used.
     export GLIBC_TUNABLES=glibc.cpu.hwcaps=-AVX
 setup      : |
+    # Stop eopkg check of non static file
+    %patch -p1 -i ${pkgfiles}/0001-Add-modules.softdep-to-ignore.patch
+
     pushd $sources/PackageKit.git
     %patch -p1 -i $pkgfiles/packagekit/0002-backends-eopkg-Mark-security-updates-with-critical-s.patch
     popd

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eopkg</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -466,12 +466,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2026-07-20</Date>
+        <Update release="53">
+            <Date>2026-08-03</Date>
             <Version>5.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Resolves getsolus/packages#9868

Stop `sudo eopkg check` reporting modules.softdep as corrupt as it is not a static file.

Fix has already been merged in [eopkg repo](https://github.com/getsolus/eopkg/pull/354).

**Test Plan**
Modify  /usr/lib64/modules/7.1.5-349.current/modules.softdep so it will fail the hash check.

Before:
```
❯ sudo eopkg check linux-current
Checking integrity of linux-current    Broken
Corrupted file: /usr/lib64/modules/7.1.5-349.current/modules.softdep

The following packages are broken:
linux-current
Reinstall the broken packages? (yes/no)
```

After patch:
```
❯ sudo eopkg check linux-current
Checking integrity of linux-current    OK
```

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
