### PR TITLE
python-coverage: Update to v7.15.3

### DIFF
--- a/packages/py/python-coverage/abi_used_symbols
+++ b/packages/py/python-coverage/abi_used_symbols
@@ -21,8 +21,8 @@ UNKNOWN:PyLong_FromUnsignedLongLong
 UNKNOWN:PyLong_Type
 UNKNOWN:PyMem_Free
 UNKNOWN:PyMem_Realloc
+UNKNOWN:PyModuleDef_Init
 UNKNOWN:PyModule_AddObject
-UNKNOWN:PyModule_Create2
 UNKNOWN:PyObject_CallFunctionObjArgs
 UNKNOWN:PyObject_CallMethod
 UNKNOWN:PyObject_CallMethodObjArgs

--- a/packages/py/python-coverage/package.yml
+++ b/packages/py/python-coverage/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-coverage
-version    : 7.6.12
-release    : 18
+version    : 7.15.3
+release    : 19
 source     :
-    - https://github.com/nedbat/coveragepy/archive/refs/tags/7.6.12.tar.gz : 2e7dc85d3b9b834c09f50f4ad222ab185a9e4fa1b94bc9056c3378df7a845d8b
+    - https://github.com/nedbat/coveragepy/archive/refs/tags/7.15.3.tar.gz : e4ccac1d297ad01b9f278b08bb30137a566d0d95a39098efe2039ee24d58c5a7
 homepage   : https://github.com/nedbat/coveragepy
 license    : Apache-2.0
 component  : programming.python
@@ -17,7 +17,19 @@ builddeps  :
     - python-packaging
     - python-setuptools
     - python-wheel
+# checkdeps  :
+#     - python-flaky
+#     - python-gevent
+#     - python-greenlet
+#     - python-hypothesis
+#     - python-pytest
+#     - python-pytest-xdist
+#     - virtualenv
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
+# A bunch of tests fail due to the environment
+# check      : |
+#     export PATH="${installdir}/usr/bin:${PATH}"
+#     %pytest -vv

--- a/packages/py/python-coverage/pspec_x86_64.xml
+++ b/packages/py/python-coverage/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-coverage</Name>
         <Homepage>https://github.com/nedbat/coveragepy</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -23,12 +23,14 @@
             <Path fileType="executable">/usr/bin/coverage</Path>
             <Path fileType="executable">/usr/bin/coverage-3.14</Path>
             <Path fileType="executable">/usr/bin/coverage3</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.6.12.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.6.12.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.6.12.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.6.12.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.6.12.dist-info/licenses/LICENSE.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.6.12.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/a1_coverage.pth</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.15.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.15.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.15.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.15.3.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.15.3.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.15.3.dist-info/licenses/NOTICE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage-7.15.3.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -81,12 +83,16 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/numbits.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/parser.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/parser.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/patch.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/patch.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/phystokens.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/phystokens.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/plugin.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/plugin.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/plugin_support.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/plugin_support.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/pth_file.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/pth_file.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/python.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/python.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/__pycache__/pytracer.cpython-314.opt-1.pyc</Path>
@@ -145,9 +151,11 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/multiproc.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/numbits.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/parser.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/patch.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/phystokens.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/plugin.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/plugin_support.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/pth_file.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/py.typed</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/python.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/coverage/pytracer.py</Path>
@@ -168,12 +176,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2026-06-05</Date>
-            <Version>7.6.12</Version>
+        <Update release="19">
+            <Date>2026-08-03</Date>
+            <Version>7.15.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/coveragepy/coveragepy/blob/7.15.3/CHANGES.rst).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that 1400+ of the tests pass. Only around 50 fail, but not due to this module, as far as I can tell.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
