### PR TITLE
docker-compose: Update to v5.4.0

### DIFF
--- a/packages/d/docker-compose/README.md
+++ b/packages/d/docker-compose/README.md
@@ -1,0 +1,22 @@
+# Docker stack update order
+
+- `runc`
+- `containerd`
+- `buildkit`
+- `moby`
+- `docker`
+- `docker-buildx`
+- `docker-compose`
+
+## Notes
+
+- `moby` and `docker` should be bumped together (same version)
+- `buildkit` is separate from the engine but should be updated before `docker-buildx`
+- `conmon`, `buildah`, and other podman packages are a separate stack
+
+## Tips
+
+- To get the git commit for a tag: `git ls-remote <upstream .git> refs/tags/v<version> | awk '{print $1}'`
+- Use `refs/tags/v<version>^{}` for annotated tags
+- `moby` uses `refs/tags/docker-v<version>`
+- The recipes already resolve and embed the commit at build time

--- a/packages/d/docker-compose/package.yml
+++ b/packages/d/docker-compose/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker-compose
-version    : 5.3.1
-release    : 65
+version    : 5.4.0
+release    : 66
 source     :
-    - https://github.com/docker/compose/archive/refs/tags/v5.3.1.tar.gz : 1823e1b09c4082779fdf5cc9f3d8453b95dba3d939105b39366175ce12fdb6c7
+    - https://github.com/docker/compose/archive/refs/tags/v5.4.0.tar.gz : 142f895ba74715ea0018a20b7f93fa96e36fb6c91ea66f856a61c6e3716c4ef8
 homepage   : https://docs.docker.com/compose/
 license    : Apache-2.0
 component  : virt
@@ -36,10 +36,9 @@ build      : |
 
     go build -tags "e2e,kube" -o docker-compose ./cmd
 install    : |
-    install -Ddm00755 ${installdir}/%libdir%/docker/cli-plugins
-    install -m00755 ${workdir}/docker-compose ${installdir}/%libdir%/docker/cli-plugins/docker-compose
+    %install_exe docker-compose ${installdir}/%libdir%/docker/cli-plugins/docker-compose
 
-    install -dm00755 ${installdir}/usr/bin
+    %install_dir ${installdir}/usr/bin
     ln -srv ${installdir}/%libdir%/docker/cli-plugins/docker-compose ${installdir}/usr/bin/docker-compose
 
     %install_license LICENSE

--- a/packages/d/docker-compose/pspec_x86_64.xml
+++ b/packages/d/docker-compose/pspec_x86_64.xml
@@ -28,9 +28,9 @@ With Compose, you use a Compose file to configure your application&#x2019;s serv
         </Files>
     </Package>
     <History>
-        <Update release="65">
-            <Date>2026-07-10</Date>
-            <Version>5.3.1</Version>
+        <Update release="66">
+            <Date>2026-08-04</Date>
+            <Version>5.4.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/docker/compose/releases/tag/v5.4.0).

**Test Plan**

Use compose to run `portainer`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
