### PR TITLE
perl: Deprecate -devel packages no longer split

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -3246,5 +3246,31 @@
 		<Package>freerdp2-devel</Package>
 		<Package>freerdp2-dbginfo</Package>
 		<Package>font-awesome-ttf</Package>
+		<Package>perl-b-hooks-endofscope-devel</Package>
+		<Package>perl-business-isbn-devel</Package>
+		<Package>perl-datetime-devel</Package>
+		<Package>perl-dbd-mariadb-devel</Package>
+		<Package>perl-docbook-devel</Package>
+		<Package>perl-glib-devel</Package>
+		<Package>perl-glib-object-introspection-devel</Package>
+		<Package>perl-image-exiftool-devel</Package>
+		<Package>perl-ipc-run3-devel</Package>
+		<Package>perl-net-ssleay-devel</Package>
+		<Package>perl-package-deprecationmanager-devel</Package>
+		<Package>perl-pdf-api2-devel</Package>
+		<Package>perl-pdf-builder-devel</Package>
+		<Package>perl-pod-parser-devel</Package>
+		<Package>perl-sdl-devel</Package>
+		<Package>perl-should-update-devel</Package>
+		<Package>perl-template-devel</Package>
+		<Package>perl-term-table-devel</Package>
+		<Package>perl-test-simple-devel</Package>
+		<Package>perl-test-trap-devel</Package>
+		<Package>perl-test2-suite-devel</Package>
+		<Package>perl-text-csv-devel</Package>
+		<Package>perl-text-csv-xs-devel</Package>
+		<Package>perl-uri-devel</Package>
+		<Package>perl-xmlparser-devel</Package>
+		<Package>perl-xsaccessor-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -4473,5 +4473,34 @@
 
 		<!-- Removed upstream -->
 		<Package>font-awesome-ttf</Package>
+
+		<!-- Perl packages no longer split -devel; content is in the main package -->
+		<Package>perl-b-hooks-endofscope-devel</Package>
+		<Package>perl-business-isbn-devel</Package>
+		<Package>perl-datetime-devel</Package>
+		<Package>perl-dbd-mariadb-devel</Package>
+		<Package>perl-docbook-devel</Package>
+		<Package>perl-glib-devel</Package>
+		<Package>perl-glib-object-introspection-devel</Package>
+		<Package>perl-image-exiftool-devel</Package>
+		<Package>perl-ipc-run3-devel</Package>
+		<Package>perl-net-ssleay-devel</Package>
+		<Package>perl-package-deprecationmanager-devel</Package>
+		<Package>perl-pdf-api2-devel</Package>
+		<Package>perl-pdf-builder-devel</Package>
+		<Package>perl-pod-parser-devel</Package>
+		<Package>perl-sdl-devel</Package>
+		<Package>perl-should-update-devel</Package>
+		<Package>perl-template-devel</Package>
+		<Package>perl-term-table-devel</Package>
+		<Package>perl-test-simple-devel</Package>
+		<Package>perl-test-trap-devel</Package>
+		<Package>perl-test2-suite-devel</Package>
+		<Package>perl-text-csv-devel</Package>
+		<Package>perl-text-csv-xs-devel</Package>
+		<Package>perl-uri-devel</Package>
+		<Package>perl-xmlparser-devel</Package>
+		<Package>perl-xsaccessor-devel</Package>
+		
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
**Summary**
- -devel packages no longer produced as they are now in the main packages. YPKG was putting man pages in -devel.

**Test Plan**

See that -devel is no longer in those packages. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
