### PR TITLE
os-prober: Update to v1.85

### DIFF
--- a/packages/o/os-prober/package.yml
+++ b/packages/o/os-prober/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : os-prober
-version    : '1.84'
-release    : 8
+version    : '1.85'
+release    : 9
 source     :
-    - https://ftp.debian.org/debian/pool/main/o/os-prober/os-prober_1.84.tar.xz : 42e48245986d8ec9491a07a74522c7b78e685ddc9b4f801045c62cd03dd7b067
+    - https://ftp.debian.org/debian/pool/main/o/os-prober/os-prober_1.85.tar.xz : f06094db841a214f975e79d66e2a79ea8c2b39b0f762e9d384b2feffd4ae7447
 license    : GPL-2.0-or-later
 component  : system.boot
 homepage   : https://joeyh.name/code/os-prober

--- a/packages/o/os-prober/pspec_x86_64.xml
+++ b/packages/o/os-prober/pspec_x86_64.xml
@@ -50,9 +50,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2026-05-29</Date>
-            <Version>1.84</Version>
+        <Update release="9">
+            <Date>2026-08-03</Date>
+            <Version>1.85</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Make sure, that the grep call for finding /boot/efi/EFI is locale-independent (add "LC_ALL=C")

**Test Plan**

- ?

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
