### PR TITLE
python-starlette: Update to v1.3.1

### DIFF
--- a/packages/py/python-starlette/package.yml
+++ b/packages/py/python-starlette/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-starlette
-version    : 0.48.0
-release    : 10
+version    : 1.3.1
+release    : 11
 source     :
-    - https://files.pythonhosted.org/packages/source/s/starlette/starlette-0.48.0.tar.gz : 7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46
+    - https://files.pythonhosted.org/packages/source/s/starlette/starlette-1.3.1.tar.gz : 05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0
 homepage   : https://github.com/encode/starlette
 license    : BSD-3-Clause
 component  : programming.python
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-anyio
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-starlette/pspec_x86_64.xml
+++ b/packages/py/python-starlette/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-starlette</Name>
         <Homepage>https://github.com/encode/starlette</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/starlette-0.48.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/starlette-0.48.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/starlette-0.48.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/starlette-0.48.0.dist-info/licenses/LICENSE.md</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/starlette-1.3.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/starlette-1.3.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/starlette-1.3.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/starlette-1.3.1.dist-info/licenses/LICENSE.md</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/starlette/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/starlette/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/starlette/__pycache__/__init__.cpython-314.pyc</Path>
@@ -130,12 +130,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2026-06-07</Date>
-            <Version>0.48.0</Version>
+        <Update release="11">
+            <Date>2026-08-04</Date>
+            <Version>1.3.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security
- [1.3.1 Change Log](https://github.com/Kludex/starlette/releases/tag/1.3.1)
- [1.3.0 Change Log](https://github.com/Kludex/starlette/releases/tag/1.3.0)
- [1.2.1 Change Log](https://github.com/Kludex/starlette/releases/tag/1.2.1)
- [1.2.0 Change Log](https://github.com/Kludex/starlette/releases/tag/1.2.0)
- [1.1.0 Change Log](https://github.com/Kludex/starlette/releases/tag/1.1.0)
- [1.0.1 Change Log](https://github.com/Kludex/starlette/releases/tag/1.0.1)
- [1.0.0 Change Log](https://github.com/Kludex/starlette/releases/tag/1.0.0)
- [0.52.1 Change Log](https://github.com/Kludex/starlette/releases/tag/0.52.1)
- [0.52.0 Change Log](https://github.com/Kludex/starlette/releases/tag/0.52.0)
- [0.51.0 Change Log](https://github.com/Kludex/starlette/releases/tag/0.51.0)
- [0.50.0 Change Log](https://github.com/Kludex/starlette/releases/tag/0.50.0)
- [0.49.3 Change Log](https://github.com/Kludex/starlette/releases/tag/0.49.3)
- [0.49.2 Change Log](https://github.com/Kludex/starlette/releases/tag/0.49.2)
- [0.49.1 Change Log](https://github.com/Kludex/starlette/releases/tag/0.49.1)

**Security**
- CVE-2026-54283
- CVE-2026-54282
- CVE-2026-48817

**Test Plan**
- Check version
- Test with python-httpx

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
