### PR TITLE
budgie-control-center: Stop building against libcheese

### DIFF
--- a/packages/b/budgie-control-center/abi_libs
+++ b/packages/b/budgie-control-center/abi_libs
@@ -1,2 +1,1 @@
 budgie-control-center
-budgie-control-center-print-renderer

--- a/packages/b/budgie-control-center/abi_symbols
+++ b/packages/b/budgie-control-center/abi_symbols
@@ -1782,4 +1782,3 @@ budgie-control-center:ws_wpa_psk_get_type
 budgie-control-center:ws_wpa_psk_new
 budgie-control-center:xcb_modifier_transform_binding_to_label
 budgie-control-center:xdevice_get_device_node
-budgie-control-center-print-renderer:_IO_stdin_used

--- a/packages/b/budgie-control-center/abi_used_libs
+++ b/packages/b/budgie-control-center/abi_used_libs
@@ -4,8 +4,6 @@ libaccountsservice.so.0
 libatk-1.0.so.0
 libc.so.6
 libcairo.so.2
-libcheese-gtk.so.25
-libcheese.so.8
 libcolord-gtk.so.1
 libcolord.so.2
 libcups.so.2

--- a/packages/b/budgie-control-center/abi_used_symbols
+++ b/packages/b/budgie-control-center/abi_used_symbols
@@ -143,10 +143,6 @@ libcairo.so.2:cairo_stroke
 libcairo.so.2:cairo_surface_destroy
 libcairo.so.2:cairo_surface_set_device_scale
 libcairo.so.2:cairo_translate
-libcheese-gtk.so.25:cheese_avatar_chooser_new
-libcheese-gtk.so.25:cheese_gtk_init
-libcheese.so.8:cheese_camera_device_monitor_coldplug
-libcheese.so.8:cheese_camera_device_monitor_get_type
 libcolord-gtk.so.1:cd_sample_widget_new
 libcolord-gtk.so.1:cd_sample_widget_set_color
 libcolord.so.2:cd_client_connect

--- a/packages/b/budgie-control-center/package.yml
+++ b/packages/b/budgie-control-center/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : budgie-control-center
 version    : 1.4.1
-release    : 36
+release    : 37
 source     :
     - https://github.com/BuddiesOfBudgie/budgie-control-center/releases/download/v1.4.1/budgie-control-center-1.4.1.tar.xz : 6184b30ccf939686a22101dd82d943fcfd8b7585261b656e633278b66227510e
     - git|https://gitlab.gnome.org/GNOME/libgnome-volume-control.git : d2442f455844e5292cb4a74ffc66ecc8d7595a9f
@@ -14,7 +14,6 @@ description: |
 builddeps  :
     - pkgconfig(ModemManager)
     - pkgconfig(accountsservice)
-    - pkgconfig(cheese)
     - pkgconfig(clutter-1.0)
     - pkgconfig(clutter-gtk-1.0)
     - pkgconfig(colord-gtk)
@@ -59,7 +58,10 @@ setup      : |
     rm -vrf subprojects/gvc
     cp -r ${sources}/libgnome-volume-control.git subprojects/gvc
 
-    %meson_configure -Ddocumentation=true -Dprivileged_group=wheel
+    %meson_configure \
+      -Ddocumentation=true \
+      -Dprivileged_group=wheel \
+      -Dcheese=false
 build      : |
     %ninja_build
 install    : |

--- a/packages/b/budgie-control-center/pspec_x86_64.xml
+++ b/packages/b/budgie-control-center/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>budgie-control-center</Name>
         <Homepage>https://buddiesofbudgie.org</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.budgie</PartOf>
@@ -316,12 +316,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2026-05-28</Date>
+        <Update release="37">
+            <Date>2026-08-03</Date>
             <Version>1.4.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
libcheese is dead upstream, and may cause crashes.

Fixes https://github.com/getsolus/packages/issues/9767

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

User reported the issue was resolved by this change.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
