### PR TITLE
python-dirty-equals: Re-enable test with pydantic

### DIFF
--- a/packages/py/python-dirty-equals/package.yml
+++ b/packages/py/python-dirty-equals/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-dirty-equals
 version    : 0.11.0
-release    : 1
+release    : 2
 source     :
     - https://github.com/samuelcolvin/dirty-equals/archive/refs/tags/v0.11.0.tar.gz : 60e0be7d05669c780258804739c6882fd3d1069e72fe2b7909656bd8f2d48e2c
 homepage   : https://dirty-equals.helpmanual.io/
@@ -30,5 +30,4 @@ check      : |
     # tests require UTC timezone: https://github.com/samuelcolvin/dirty-equals/issues/33
     export TZ=UTC
 
-    # TODO(Evan): Revisit the ignore after pydantic update
-    %pytest -v -W=ignore::DeprecationWarning --ignore=tests/test_other.py
+    %pytest -v -W=ignore::DeprecationWarning

--- a/packages/py/python-dirty-equals/pspec_x86_64.xml
+++ b/packages/py/python-dirty-equals/pspec_x86_64.xml
@@ -64,8 +64,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2026-08-03</Date>
+        <Update release="2">
+            <Date>2026-08-04</Date>
             <Version>0.11.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**

Re-enable test with pydantic.

**Test Plan**

See that the test suite passes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
