### PR TITLE
svtplay-dl: Update to v4.193

### DIFF
--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : svtplay-dl
-version    : '4.191'
-release    : 41
+version    : '4.193'
+release    : 42
 source     :
-    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.191.tar.gz : 3173ed5d4e1da90e2aa42a43563e7e1c5bd9a475474af1323cbbefefa3521e27
+    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.193.tar.gz : ba79be27373761c81bac11c18bb652ab4a170dadf11a810395662d9337a82b5c
 homepage   : https://svtplay-dl.se/
 license    : MIT
 component  : network.download

--- a/packages/s/svtplay-dl/pspec_x86_64.xml
+++ b/packages/s/svtplay-dl/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>svtplay-dl</Name>
         <Homepage>https://svtplay-dl.se/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>network.download</PartOf>
@@ -21,12 +21,12 @@
         <PartOf>network.download</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/svtplay-dl</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.191.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.191.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.191.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.191.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.191.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.191.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.193.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.193.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.193.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.193.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.193.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl-4.193.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/svtplay_dl/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -243,12 +243,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2026-06-08</Date>
-            <Version>4.191</Version>
+        <Update release="42">
+            <Date>2026-08-05</Date>
+            <Version>4.193</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- pluto.tv: fix so it works again
- pluto.tv: fix getting metadata for a video. like name, season and episode info.
- new argument --abort-on-error using this it will abort the following videos instead of continuing with -A.
- new argument --tydligare-tal this will only download videos with ‘tydligare tal’ independent on language. for example there are videos with english and swedish with this. --audio-language only worked with one.
- tv4play: support for .nfo files.

**Test Plan**
- Downloaded a video.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
