### PR TITLE
python-deprecated: Update to v1.3.1

### DIFF
--- a/packages/py/python-deprecated/files/deprecated-1.3.1-no-pkg-resources.patch
+++ b/packages/py/python-deprecated/files/deprecated-1.3.1-no-pkg-resources.patch
@@ -1,0 +1,77 @@
+From d9934fb49721cf23967f87b03a5cb93204a2dbeb Mon Sep 17 00:00:00 2001
+From: Miro <200482516+Mirochill@users.noreply.github.com>
+Date: Sat, 23 May 2026 15:43:53 +0200
+Subject: [PATCH] Replace pkg_resources version parsing in tests
+
+---
+ .github/workflows/python-package.yml | 2 +-
+ setup.py                             | 1 +
+ tests/test.py                        | 4 ++--
+ tox.ini                              | 2 ++
+ 4 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/.github/workflows/python-package.yml b/.github/workflows/python-package.yml
+index 2290338..210a802 100644
+--- a/.github/workflows/python-package.yml
++++ b/.github/workflows/python-package.yml
+@@ -26,7 +26,7 @@ jobs:
+       - name: Install dependencies
+         run: |
+           python -m pip install --upgrade pip
+-          python -m pip install pytest setuptools
++          python -m pip install packaging pytest setuptools
+           python -m pip install -e .
+       - name: Test with pytest
+         run: |
+diff --git a/setup.py b/setup.py
+index 4dabb04..2683d39 100755
+--- a/setup.py
++++ b/setup.py
+@@ -191,6 +191,7 @@ def function_three():
+             "tox",
+             "PyTest",
+             "PyTest-Cov",
++            "packaging",
+             "bump2version < 1",
+             "setuptools; python_version>='3.12'",
+         ]
+diff --git a/tests/test.py b/tests/test.py
+index 3d5aa21..ca77cf6 100644
+--- a/tests/test.py
++++ b/tests/test.py
+@@ -1,5 +1,5 @@
+ # coding: utf-8
+-import pkg_resources
++import packaging.version
+ 
+ import deprecated
+ 
+@@ -13,7 +13,7 @@ def test_deprecated_has_docstring():
+ def test_deprecated_has_version():
+     # The deprecated package must have a valid version number
+     assert deprecated.__version__ is not None
+-    version = pkg_resources.parse_version(deprecated.__version__)
++    version = packaging.version.parse(deprecated.__version__)
+ 
+     # .. note::
+     #
+diff --git a/tox.ini b/tox.ini
+index a566a6a..26bdc84 100644
+--- a/tox.ini
++++ b/tox.ini
+@@ -22,6 +22,7 @@ envlist =
+ [testenv]
+ commands = pytest tests/
+ deps =
++    packaging
+     py{37,38,39,310,311,312,313,314,py3}: PyTest
+     wrapt1.10: wrapt ~= 1.10.0
+     wrapt1.11: wrapt ~= 1.11.0
+@@ -40,6 +41,7 @@ commands =
+     pytest --cov-report=term-missing --cov=deprecated --cov-report=html tests/
+ deps =
+     coverage
++    packaging
+     pytest
+     pytest-cov
+     setuptools; python_version>="3.12"

--- a/packages/py/python-deprecated/package.yml
+++ b/packages/py/python-deprecated/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-deprecated
-version    : 1.2.18
-release    : 12
+version    : 1.3.1
+release    : 13
 source     :
-    - https://github.com/tantale/deprecated/archive/refs/tags/v1.2.18.tar.gz : 8e5ad74b6a3a47b079b37425f46c54674668f3d4c9de7afd576574bb332dd5bd
+    - https://github.com/tantale/deprecated/archive/refs/tags/v1.3.1.tar.gz : 5bfaa49b1edadd5599b2117baf2bf037f493eeda686d6b2c004d55e8ace6f988
 homepage   : https://github.com/tantale/deprecated
 license    : MIT
 component  : programming.python
@@ -14,9 +14,18 @@ builddeps  :
     - python-build
     - python-installer
     - python-setuptools
+    - python-wheel
+checkdeps  :
+    - python-pytest
+    - python-pytest-cov
+    - python-wrapt
 rundeps    :
     - python-wrapt
+setup      : |
+    %patch -p1 -i ${pkgfiles}/deprecated-1.3.1-no-pkg-resources.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
+check      : |
+    %pytest -v

--- a/packages/py/python-deprecated/pspec_x86_64.xml
+++ b/packages/py/python-deprecated/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-deprecated</Name>
         <Homepage>https://github.com/tantale/deprecated</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,29 +20,32 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated-1.2.18.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated-1.2.18.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated-1.2.18.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated-1.2.18.dist-info/licenses/LICENSE.rst</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated-1.2.18.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated-1.3.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated-1.3.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated-1.3.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated-1.3.1.dist-info/licenses/LICENSE.rst</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated-1.3.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/__pycache__/__init__.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/__pycache__/classic.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/__pycache__/classic.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/__pycache__/params.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/__pycache__/params.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/__pycache__/sphinx.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/__pycache__/sphinx.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/classic.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/params.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/deprecated/sphinx.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2026-06-06</Date>
-            <Version>1.2.18</Version>
+        <Update release="13">
+            <Date>2026-08-05</Date>
+            <Version>1.3.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/laurent-laporte-pro/deprecated/blob/v1.3.1/CHANGELOG.rst).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
