### PR TITLE
python-docstring-to-markdown: Update to v0.17

### DIFF
--- a/packages/py/python-docstring-to-markdown/files/fix-importlib.patch
+++ b/packages/py/python-docstring-to-markdown/files/fix-importlib.patch
@@ -1,0 +1,39 @@
+diff '--color=auto' -pruN a/docstring_to_markdown/__init__.py b/docstring_to_markdown/__init__.py
+--- a/docstring_to_markdown/__init__.py	2025-05-02 11:07:43.000000000 -0400
++++ b/docstring_to_markdown/__init__.py	2026-08-05 19:10:54.900737386 -0400
+@@ -1,10 +1,10 @@
+-from importlib_metadata import entry_points
++from importlib.metadata import entry_points
+ from typing import List, TYPE_CHECKING
+ 
+ from .types import Converter
+ 
+ if TYPE_CHECKING:
+-    from importlib_metadata import EntryPoint
++    from importlib.metadata import EntryPoint
+ 
+ __version__ = "0.17"
+ 
+diff '--color=auto' -pruN a/setup.cfg b/setup.cfg
+--- a/setup.cfg	2025-05-02 11:07:43.000000000 -0400
++++ b/setup.cfg	2026-08-05 19:10:08.173137995 -0400
+@@ -30,7 +30,6 @@ warn_unused_configs = True
+ packages = find:
+ python_requires = >=3.7
+ install_requires =
+-    importlib-metadata>=3.6
+     typing_extensions>=4.6
+ 
+ [options.package_data]
+diff '--color=auto' -pruN a/tests/test_convert.py b/tests/test_convert.py
+--- a/tests/test_convert.py	2025-05-02 11:07:43.000000000 -0400
++++ b/tests/test_convert.py	2026-08-05 19:13:49.627007970 -0400
+@@ -2,7 +2,7 @@ from contextlib import contextmanager
+ from docstring_to_markdown import convert, UnknownFormatError
+ from docstring_to_markdown.types import Converter
+ from docstring_to_markdown.cpython import CPythonConverter
+-from importlib_metadata import EntryPoint, entry_points, distribution
++from importlib.metadata import EntryPoint, entry_points, distribution
+ from unittest.mock import patch
+ import docstring_to_markdown
+ import pytest

--- a/packages/py/python-docstring-to-markdown/package.yml
+++ b/packages/py/python-docstring-to-markdown/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-docstring-to-markdown
-version    : '0.15'
-release    : 8
+version    : '0.17'
+release    : 9
 source     :
-    - https://files.pythonhosted.org/packages/source/d/docstring-to-markdown/docstring-to-markdown-0.15.tar.gz : e146114d9c50c181b1d25505054a8d0f7a476837f0da2c19f07e06eaed52b73d
+    - https://github.com/python-lsp/docstring-to-markdown/archive/refs/tags/v0.17.tar.gz : 2e5d77db913f8bbea1fb8bb1cb269896904e9fe43c75e00e01e20839ab0fae82
 homepage   : https://github.com/python-lsp/docstring-to-markdown
 license    : LGPL-2.1-or-later
 component  : programming.python
@@ -14,7 +14,17 @@ builddeps  :
     - python-build
     - python-installer
     - python-setuptools
+    - python-wheel
+checkdeps  :
+    - python-pytest
+rundeps    :
+    - python-typing-extensions
+setup      : |
+    %patch -p1 -i ${pkgfiles}/fix-importlib.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
+check      : |
+    # Override addopts as they invoke coverage testing
+    %pytest -v --override-ini="addopts="

--- a/packages/py/python-docstring-to-markdown/pspec_x86_64.xml
+++ b/packages/py/python-docstring-to-markdown/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-docstring-to-markdown</Name>
         <Homepage>https://github.com/python-lsp/docstring-to-markdown</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,12 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown-0.15.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown-0.15.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown-0.15.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown-0.15.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown-0.15.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown-0.17.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown-0.17.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown-0.17.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown-0.17.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown-0.17.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown-0.17.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/__pycache__/__init__.cpython-314.pyc</Path>
@@ -38,21 +39,24 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/__pycache__/plain.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/__pycache__/rst.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/__pycache__/rst.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/__pycache__/types.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/__pycache__/types.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/_utils.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/cpython.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/google.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/plain.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/py.typed</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/rst.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/docstring_to_markdown/types.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2026-06-06</Date>
-            <Version>0.15</Version>
+        <Update release="9">
+            <Date>2026-08-05</Date>
+            <Version>0.17</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/python-lsp/docstring-to-markdown/releases/tag/v0.17).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
