### PR TITLE
docker-buildx: Update to v0.36.1

### DIFF
--- a/packages/d/docker-buildx/package.yml
+++ b/packages/d/docker-buildx/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker-buildx
-version    : 0.36.0
-release    : 30
+version    : 0.36.1
+release    : 31
 source     :
-    - https://github.com/docker/buildx/archive/refs/tags/v0.36.0.tar.gz : c3e7c577dc4b3e0656d69e2cb3651a9bb49776732cb55583652465d25a9675f4
+    - https://github.com/docker/buildx/archive/refs/tags/v0.36.1.tar.gz : 8959987919445ab61564f50decde4dae810137063d84e2d3c969c9a4a68ecdeb
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt

--- a/packages/d/docker-buildx/pspec_x86_64.xml
+++ b/packages/d/docker-buildx/pspec_x86_64.xml
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2026-07-30</Date>
-            <Version>0.36.0</Version>
+        <Update release="31">
+            <Date>2026-08-05</Date>
+            <Version>0.36.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/docker/buildx/releases/tag/v0.36.1).

**Test Plan**

docker works. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
