### PR TITLE
docker: Update to v29.7.2

### DIFF
--- a/packages/d/docker/package.yml
+++ b/packages/d/docker/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker
-version    : 29.7.1
-release    : 80
+version    : 29.7.2
+release    : 81
 source     :
-    - https://github.com/docker/cli/archive/refs/tags/v29.7.1.tar.gz : 09c72c14870f9c34029942f4c5cf3169b69dc48ea78e7380b5ebaa316356ba1d
+    - https://github.com/docker/cli/archive/refs/tags/v29.7.2.tar.gz : 225b7ab2a15f5230b482df8461069cd4bce38891266fb9898d4188d0a3cbf54a
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt
@@ -39,19 +39,19 @@ build      : |
     export DOCKER_GITCOMMIT=$GITCOMMIT
 
     %make dynbinary
-    make manpages
+    %make manpages
 install    : |
     # Install docker client
-    install -Dm00755 build/docker-linux-amd64 ${installdir}/usr/bin/docker
+    %install_exe build/docker-linux-amd64 ${installdir}/usr/bin/docker
     %install_license LICENSE
 
-    install -Dm00644 man/man1/*.1 -t ${installdir}/usr/share/man/man1
-    install -Dm00644 man/man5/*.5 -t ${installdir}/usr/share/man/man5
+    %install_file man/man1/*.1 -t ${installdir}/usr/share/man/man1
+    %install_file man/man5/*.5 -t ${installdir}/usr/share/man/man5
 
     # Install completions
-    install -Dm00644 contrib/completion/bash/docker ${installdir}/usr/share/bash-completion/completions/docker
-    install -Dm00644 contrib/completion/zsh/_docker ${installdir}/usr/share/zsh/site-functions/_docker
-    install -Dm00644 contrib/completion/fish/docker.fish ${installdir}/usr/share/fish/vendor_completions.d/docker.fish
+    %install_file contrib/completion/bash/docker -t ${installdir}/usr/share/bash-completion/completions
+    %install_file contrib/completion/zsh/_docker -t ${installdir}/usr/share/zsh/site-functions
+    %install_file contrib/completion/fish/docker.fish -t ${installdir}/usr/share/fish/vendor_completions.d
 
     # Install nanorc
-    install -Dm00644 ${pkgfiles}/Dockerfile.nanorc -t ${installdir}/usr/share/nano/
+    %install_file ${pkgfiles}/Dockerfile.nanorc -t ${installdir}/usr/share/nano/

--- a/packages/d/docker/pspec_x86_64.xml
+++ b/packages/d/docker/pspec_x86_64.xml
@@ -218,9 +218,9 @@ Docker containers are both hardware-agnostic and platform-agnostic. This means t
         </Files>
     </Package>
     <History>
-        <Update release="80">
-            <Date>2026-08-02</Date>
-            <Version>29.7.1</Version>
+        <Update release="81">
+            <Date>2026-08-06</Date>
+            <Version>29.7.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/m/moby/package.yml
+++ b/packages/m/moby/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : moby
-version    : 29.7.1
-release    : 36
+version    : 29.7.2
+release    : 37
 source     :
-    - https://github.com/moby/moby/archive/refs/tags/docker-v29.7.1.tar.gz : e852479cc37cbf151126be1c077bef5e7ceea6c854dd860d46e61004bdf70b76
+    - https://github.com/moby/moby/archive/refs/tags/docker-v29.7.2.tar.gz : 3a93a88bff41ffa6f4dca9f4ed9fc05e7fdb08e0f9014cf1d8177f85ecbc0683
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt
@@ -45,27 +45,27 @@ build      : |
 
     ./hack/make.sh dynbinary
 
-    make -C man
+    %make -C man
 install    : |
     # Main docker daemon
-    install -Dm00755 bundles/dynbinary-daemon/dockerd ${installdir}/usr/bin/dockerd
+    %install_bin bundles/dynbinary-daemon/dockerd
 
     # Now install docker-init
-    ln -s tini-static ${installdir}/usr/bin/docker-init
+    ln -svf /usr/bin/tini-static ${installdir}/usr/bin/docker-init
 
     # Now install proxy service
-    install -Dm00755 ${workdir}/bundles/dynbinary-daemon/docker-proxy ${installdir}/usr/bin/docker-proxy
+    %install_bin bundles/dynbinary-daemon/docker-proxy
 
     # Now install systemd units
-    install -Dm00644 ${pkgfiles}/docker.service -t ${installdir}/%libdir%/systemd/system/
-    install -Dm00644 contrib/init/systemd/docker.socket -t ${installdir}/%libdir%/systemd/system/
+    %install_file ${pkgfiles}/docker.service -t ${installdir}/%libdir%/systemd/system/
+    %install_file contrib/init/systemd/docker.socket -t ${installdir}/%libdir%/systemd/system/
 
-    install -Dm644 ${pkgfiles}/docker.preset ${installdir}/%libdir%/systemd/system-preset/20-docker.preset
+    %install_file ${pkgfiles}/docker.preset ${installdir}/%libdir%/systemd/system-preset/60-docker.preset
 
     # Add the docker group
-    install -Dm00644 ${pkgfiles}/docker.sysusers ${installdir}/%libdir%/sysusers.d/docker.conf
+    %install_file ${pkgfiles}/docker.sysusers ${installdir}/%libdir%/sysusers.d/docker.conf
 
     # Install manpage
-    install -Dm00644 man/man8/dockerd.8 -t ${installdir}/usr/share/man/man8/
+    %install_file man/man8/dockerd.8 -t ${installdir}/usr/share/man/man8/
 
     %install_license LICENSE

--- a/packages/m/moby/pspec_x86_64.xml
+++ b/packages/m/moby/pspec_x86_64.xml
@@ -23,7 +23,7 @@
             <Path fileType="executable">/usr/bin/docker-init</Path>
             <Path fileType="executable">/usr/bin/docker-proxy</Path>
             <Path fileType="executable">/usr/bin/dockerd</Path>
-            <Path fileType="library">/usr/lib64/systemd/system-preset/20-docker.preset</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/60-docker.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/docker.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/docker.socket</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/docker.conf</Path>
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2026-08-02</Date>
-            <Version>29.7.1</Version>
+        <Update release="37">
+            <Date>2026-08-06</Date>
+            <Version>29.7.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://docs.docker.com/engine/release-notes/29/#2972).

**Test Plan**

docker works

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
