### PR TITLE
openvpn: Update to v2.7.6

### DIFF
--- a/packages/o/openvpn/package.yml
+++ b/packages/o/openvpn/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openvpn
-version    : 2.7.5
-release    : 41
+version    : 2.7.6
+release    : 42
 source     :
-    - https://github.com/OpenVPN/openvpn/archive/v2.7.5.tar.gz : ef91ff9a6b2ed360931d6b96899f6039e18fc708915ba8094771657a136dae1c
+    - https://github.com/OpenVPN/openvpn/archive/v2.7.6.tar.gz : 627125f0a1ee8cfaa6e0c611de58c799b94c067f49c79f531563bc641ab8e8a9
 homepage   : https://openvpn.net/community/
 license    :
     - GPL-2.0-only
@@ -22,10 +22,11 @@ builddeps  :
     - pkgconfig(lzo2)
     - python-docutils
 setup      : |
-    %reconfigure --enable-async-push \
-                 --enable-pkcs11 \
-                 --enable-systemd \
-                 --with-crypto-library=openssl
+    %reconfigure \
+        --enable-async-push \
+        --enable-pkcs11 \
+        --enable-systemd \
+        --with-crypto-library=openssl
 build      : |
     %make
 install    : |

--- a/packages/o/openvpn/pspec_x86_64.xml
+++ b/packages/o/openvpn/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>openvpn</Name>
         <Homepage>https://openvpn.net/community/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>BSD-4-Clause</License>
@@ -43,7 +43,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="41">openvpn</Dependency>
+            <Dependency release="42">openvpn</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openvpn-msg.h</Path>
@@ -51,12 +51,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2026-07-15</Date>
-            <Version>2.7.5</Version>
+        <Update release="42">
+            <Date>2026-08-06</Date>
+            <Version>2.7.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/openvpn/openvpn/releases#release-v2.7.6).

**Security**
- CVE-2026-63649
- CVE-2026-63650

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild `ivpn`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
