### PR TITLE
GNOME 50.4

### DIFF
--- a/packages/a/at-spi2/package.yml
+++ b/packages/a/at-spi2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : at-spi2
-version    : 2.60.5
-release    : 60
+version    : 2.60.6
+release    : 61
 source     :
-    - https://download.gnome.org/sources/at-spi2-core/2.60/at-spi2-core-2.60.5.tar.xz : 6059a77d507438ff6c8d6d06025f8f9f5774fa0f8eabe9c9b059b1cc41e1bbc0
+    - https://download.gnome.org/sources/at-spi2-core/2.60/at-spi2-core-2.60.6.tar.xz : a89b64a8b217a8042bdf0e35cbfab629ceee35640dba75df578afde9aa789d57
 homepage   : https://gitlab.gnome.org/GNOME/at-spi2-core
 license    : LGPL-2.1-or-later
 component  : desktop.gtk
@@ -54,6 +54,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 
     # Stateless
     install -dm0755 $installdir/usr/share/xdg/Xwayland-session.d/

--- a/packages/a/at-spi2/pspec_x86_64.xml
+++ b/packages/a/at-spi2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>at-spi2</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/at-spi2-core</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop.gtk</PartOf>
@@ -30,7 +30,7 @@
             <Path fileType="library">/usr/lib64/gnome-settings-daemon-3.0/gtk-modules/at-spi2-atk.desktop</Path>
             <Path fileType="library">/usr/lib64/gtk-2.0/modules/libatk-bridge.so</Path>
             <Path fileType="library">/usr/lib64/libatk-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libatk-1.0.so.0.26014.1</Path>
+            <Path fileType="library">/usr/lib64/libatk-1.0.so.0.26015.1</Path>
             <Path fileType="library">/usr/lib64/libatk-bridge-2.0.so.0</Path>
             <Path fileType="library">/usr/lib64/libatk-bridge-2.0.so.0.0.0</Path>
             <Path fileType="library">/usr/lib64/libatspi.so.0</Path>
@@ -38,6 +38,7 @@
             <Path fileType="data">/usr/share/dbus-1/accessibility-services/org.a11y.atspi.Registry.service</Path>
             <Path fileType="data">/usr/share/dbus-1/services/org.a11y.Bus.service</Path>
             <Path fileType="data">/usr/share/defaults/at-spi2/accessibility.conf</Path>
+            <Path fileType="data">/usr/share/licenses/at-spi2/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/at-spi2-core.mo</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/at-spi2-core.mo</Path>
             <Path fileType="localedata">/usr/share/locale/am/LC_MESSAGES/at-spi2-core.mo</Path>
@@ -158,7 +159,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="60">at-spi2</Dependency>
+            <Dependency release="61">at-spi2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/at-spi2/core/at-spi-bus-launcher</Path>
@@ -166,7 +167,7 @@
             <Path fileType="library">/usr/lib32/gnome-settings-daemon-3.0/gtk-modules/at-spi2-atk.desktop</Path>
             <Path fileType="library">/usr/lib32/gtk-2.0/modules/libatk-bridge.so</Path>
             <Path fileType="library">/usr/lib32/libatk-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libatk-1.0.so.0.26014.1</Path>
+            <Path fileType="library">/usr/lib32/libatk-1.0.so.0.26015.1</Path>
             <Path fileType="library">/usr/lib32/libatk-bridge-2.0.so.0</Path>
             <Path fileType="library">/usr/lib32/libatk-bridge-2.0.so.0.0.0</Path>
             <Path fileType="library">/usr/lib32/libatspi.so.0</Path>
@@ -184,8 +185,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="60">at-spi2-devel</Dependency>
-            <Dependency release="60">at-spi2-32bit</Dependency>
+            <Dependency release="61">at-spi2-32bit</Dependency>
+            <Dependency release="61">at-spi2-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libatk-1.0.so</Path>
@@ -207,7 +208,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="60">at-spi2</Dependency>
+            <Dependency release="61">at-spi2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/at-spi-2.0/atspi/atspi-accessible.h</Path>
@@ -293,12 +294,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="60">
-            <Date>2026-07-07</Date>
-            <Version>2.60.5</Version>
+        <Update release="61">
+            <Date>2026-08-07</Date>
+            <Version>2.60.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/g/gdm/abi_libs
+++ b/packages/g/gdm/abi_libs
@@ -1,5 +1,2 @@
-gdm
-gdm-new-session
-gdm-session-worker
 libgdm.so.1
 pam_gdm.so

--- a/packages/g/gdm/abi_symbols
+++ b/packages/g/gdm/abi_symbols
@@ -1,6 +1,3 @@
-gdm:_IO_stdin_used
-gdm-new-session:_IO_stdin_used
-gdm-session-worker:_IO_stdin_used
 libgdm.so.1:gdm_activate_session_by_id
 libgdm.so.1:gdm_clear_close_on_exec_flag
 libgdm.so.1:gdm_client_error_quark

--- a/packages/g/gdm/package.yml
+++ b/packages/g/gdm/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gdm
-version    : '50.1'
-release    : 86
+version    : '50.2'
+release    : 87
 source     :
-    - https://download.gnome.org/sources/gdm/50/gdm-50.1.tar.xz : 770159373512192410f412b5d0c4678ec1573f1ae4b39c81fe75861fe8890174
+    - https://download.gnome.org/sources/gdm/50/gdm-50.2.tar.xz : 8a4679e47cddfe8b0a1bd9d3836042deb68fb3e1b0e7e62dfd0631dc5b6fc541
 homepage   : https://projects.gnome.org/gdm/
 license    : GPL-2.0-or-later
 component  : desktop.gnome
@@ -45,6 +45,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 
     # Use factory mechanism to ensure GDM config is present
     install -D -m 00644 $pkgfiles/client.conf $installdir/usr/share/factory/var/lib/gdm/.config/pulse/client.conf

--- a/packages/g/gdm/pspec_x86_64.xml
+++ b/packages/g/gdm/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gdm</Name>
         <Homepage>https://projects.gnome.org/gdm/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -121,6 +121,7 @@
             <Path fileType="doc">/usr/share/help/uk/gdm/legal.xml</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gdm/index.docbook</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gdm/legal.xml</Path>
+            <Path fileType="data">/usr/share/licenses/gdm/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/gdm.mo</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/gdm.mo</Path>
             <Path fileType="localedata">/usr/share/locale/am/LC_MESSAGES/gdm.mo</Path>
@@ -252,7 +253,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="86">gdm</Dependency>
+            <Dependency release="87">gdm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gdm/gdm-choice-list-pam-extension.h</Path>
@@ -270,12 +271,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="86">
-            <Date>2026-05-29</Date>
-            <Version>50.1</Version>
+        <Update release="87">
+            <Date>2026-08-07</Date>
+            <Version>50.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/g/gexiv2/package.yml
+++ b/packages/g/gexiv2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gexiv2
-version    : 0.16.1
-release    : 28
+version    : 0.16.2
+release    : 29
 source     :
-    - https://download.gnome.org/sources/gexiv2/0.16/gexiv2-0.16.1.tar.xz : 18e9a05c637a77e800b001d87f70e4d02a7ba41b7745400a314a1072a1ddc943
+    - https://download.gnome.org/sources/gexiv2/0.16/gexiv2-0.16.2.tar.xz : aad9e240fdffbe85e390f46ee0a567e251baea5c29c3d8690260388683dc8d0a
 homepage   : https://gitlab.gnome.org/GNOME/gexiv2
 license    : GPL-2.0-or-later
 component  : desktop.library

--- a/packages/g/gexiv2/pspec_x86_64.xml
+++ b/packages/g/gexiv2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gexiv2</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/gexiv2</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.library</PartOf>
@@ -22,7 +22,7 @@
         <Files>
             <Path fileType="library">/usr/lib64/girepository-1.0/GExiv2-0.16.typelib</Path>
             <Path fileType="library">/usr/lib64/libgexiv2-0.16.so.4</Path>
-            <Path fileType="library">/usr/lib64/libgexiv2-0.16.so.4.16.1</Path>
+            <Path fileType="library">/usr/lib64/libgexiv2-0.16.so.4.16.2</Path>
             <Path fileType="data">/usr/share/licenses/gexiv2/COPYING</Path>
         </Files>
     </Package>
@@ -33,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">gexiv2</Dependency>
+            <Dependency release="29">gexiv2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gexiv2-0.16/gexiv2/gexiv2-enums.h</Path>
@@ -52,12 +52,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2026-07-07</Date>
-            <Version>0.16.1</Version>
+        <Update release="29">
+            <Date>2026-08-07</Date>
+            <Version>0.16.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/g/glibmm/abi_used_symbols
+++ b/packages/g/glibmm/abi_used_symbols
@@ -2328,7 +2328,6 @@ libsigc-2.0.so.0:_ZNK4sigc9trackable27add_destroy_notify_callbackEPvPFS1_S1_E
 libsigc-2.0.so.0:_ZNK4sigc9trackable30remove_destroy_notify_callbackEPv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt6locale2id5_M_idEv
-libstdc++.so.6:_ZNSi10_M_extractIlEERSiRT_
 libstdc++.so.6:_ZNSi4readEPcl
 libstdc++.so.6:_ZNSi5seekgElSt12_Ios_Seekdir
 libstdc++.so.6:_ZNSo5seekpElSt12_Ios_Seekdir
@@ -2348,8 +2347,6 @@ libstdc++.so.6:_ZNSt6localeC1ERKS_
 libstdc++.so.6:_ZNSt6localeC1Ev
 libstdc++.so.6:_ZNSt6localeD1Ev
 libstdc++.so.6:_ZNSt6localeaSERKS_
-libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncEPcmm
-libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx117collateIcE2idE
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
@@ -2364,9 +2361,7 @@ libstdc++.so.6:_ZNSt9basic_iosIwSt11char_traitsIwEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__ostream_insertIwSt11char_traitsIwEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__throw_bad_castv
-libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
-libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt19__throw_regex_errorNSt15regex_constants10error_typeE
@@ -2377,11 +2372,10 @@ libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
 libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
-libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZStrsIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE
 libstdc++.so.6:_ZStrsIwSt11char_traitsIwESaIwEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE
-libstdc++.so.6:_ZTINSt6locale5facetE
+libstdc++.so.6:_ZTINSt7__cxx117collateIcEE
 libstdc++.so.6:_ZTISi
 libstdc++.so.6:_ZTISo
 libstdc++.so.6:_ZTISt11regex_error
@@ -2391,10 +2385,8 @@ libstdc++.so.6:_ZTISt14basic_ifstreamIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTISt14basic_ofstreamIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTISt14overflow_error
 libstdc++.so.6:_ZTISt15underflow_error
-libstdc++.so.6:_ZTISt5ctypeIcE
 libstdc++.so.6:_ZTISt8bad_cast
 libstdc++.so.6:_ZTISt9exception
-libstdc++.so.6:_ZTTNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTTNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTTNSt7__cxx1119basic_ostringstreamIwSt11char_traitsIwESaIwEEE
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
@@ -2402,7 +2394,6 @@ libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv121__vmi_class_type_infoE
 libstdc++.so.6:_ZTVNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTVNSt7__cxx1115basic_stringbufIwSt11char_traitsIwESaIwEEE
-libstdc++.so.6:_ZTVNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTVNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTVNSt7__cxx1119basic_ostringstreamIwSt11char_traitsIwESaIwEEE
 libstdc++.so.6:_ZTVSt11regex_error
@@ -2425,6 +2416,5 @@ libstdc++.so.6:__cxa_guard_acquire
 libstdc++.so.6:__cxa_guard_release
 libstdc++.so.6:__cxa_rethrow
 libstdc++.so.6:__cxa_throw
-libstdc++.so.6:__cxa_throw_bad_array_new_length
 libstdc++.so.6:__dynamic_cast
 libstdc++.so.6:__gxx_personality_v0

--- a/packages/g/glibmm/package.yml
+++ b/packages/g/glibmm/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : glibmm
-version    : 2.66.8
-release    : 34
+version    : 2.66.9
+release    : 35
 source     :
-    - https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.8.tar.xz : 64f11d3b95a24e2a8d4166ecff518730f79ecc27222ef41faf7c7e0340fc9329
+    - https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.9.tar.xz : 5a026e5602085307c7dcb72b71b07261c40f80914277bef5f8d7f2ecab739bec
 homepage   : https://www.gtkmm.org/
 license    : GPL-2.0-only
 component  : desktop.gnome.core
@@ -18,3 +18,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/g/glibmm/pspec_x86_64.xml
+++ b/packages/g/glibmm/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>glibmm</Name>
         <Homepage>https://www.gtkmm.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.gnome.core</PartOf>
@@ -69,6 +69,7 @@
             <Path fileType="library">/usr/lib64/libglibmm-2.4.so.1.3.0</Path>
             <Path fileType="library">/usr/lib64/libglibmm_generate_extra_defs-2.4.so.1</Path>
             <Path fileType="library">/usr/lib64/libglibmm_generate_extra_defs-2.4.so.1.3.0</Path>
+            <Path fileType="data">/usr/share/licenses/glibmm/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -78,7 +79,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">glibmm</Dependency>
+            <Dependency release="35">glibmm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/giomm-2.4/giomm.h</Path>
@@ -482,12 +483,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2025-04-04</Date>
-            <Version>2.66.8</Version>
+        <Update release="35">
+            <Date>2026-08-07</Date>
+            <Version>2.66.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/g/gnome-control-center/package.yml
+++ b/packages/g/gnome-control-center/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-control-center
-version    : '50.3'
-release    : 189
+version    : '50.4'
+release    : 190
 source     :
-    - https://download.gnome.org/sources/gnome-control-center/50/gnome-control-center-50.3.tar.xz : 06eebb0fd3056c4d8d78bbd3754c96108f381d70b760da423c5024946944287c
+    - https://download.gnome.org/sources/gnome-control-center/50/gnome-control-center-50.4.tar.xz : 5856c73999bedf45e74f73bac3d61e2b5ec1689f8bcf1943737baeee8204fb11
 homepage   : https://apps.gnome.org/Settings/
 license    : GPL-2.0-or-later
 component  : desktop.gnome

--- a/packages/g/gnome-control-center/pspec_x86_64.xml
+++ b/packages/g/gnome-control-center/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-control-center</Name>
         <Homepage>https://apps.gnome.org/Settings/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -334,19 +334,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="189">gnome-control-center</Dependency>
+            <Dependency release="190">gnome-control-center</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/pkgconfig/gnome-keybindings.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="189">
-            <Date>2026-07-07</Date>
-            <Version>50.3</Version>
+        <Update release="190">
+            <Date>2026-08-07</Date>
+            <Version>50.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/g/gnome-maps/package.yml
+++ b/packages/g/gnome-maps/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-maps
-version    : '50.2'
-release    : 74
+version    : '50.3'
+release    : 75
 source     :
-    - https://download.gnome.org/sources/gnome-maps/50/gnome-maps-50.2.tar.xz : 28a4467d1ec9fe38eb7f862674c199e884086e25e4c0b0d80eb504568202cebf
+    - https://download.gnome.org/sources/gnome-maps/50/gnome-maps-50.3.tar.xz : 089ca8e15abd72ac83db386cef19cebde05eef8b76eaac81906a4b0535544e2c
 homepage   : https://apps.gnome.org/Maps/
 license    : GPL-2.0-or-later
 component  : office
@@ -33,3 +33,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/g/gnome-maps/pspec_x86_64.xml
+++ b/packages/g/gnome-maps/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-maps</Name>
         <Homepage>https://apps.gnome.org/Maps/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office</PartOf>
@@ -236,6 +236,7 @@
             <Path fileType="data">/usr/share/gnome-maps/org.gnome.Maps.src.gresource</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.gnome.Maps.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/symbolic/apps/org.gnome.Maps-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/licenses/gnome-maps/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/gnome-maps.mo</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/gnome-maps.mo</Path>
             <Path fileType="localedata">/usr/share/locale/an/LC_MESSAGES/gnome-maps.mo</Path>
@@ -312,12 +313,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="74">
-            <Date>2026-07-07</Date>
-            <Version>50.2</Version>
+        <Update release="75">
+            <Date>2026-08-07</Date>
+            <Version>50.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/g/gnome-shell/package.yml
+++ b/packages/g/gnome-shell/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-shell
-version    : '50.3'
-release    : 144
+version    : '50.4'
+release    : 145
 source     :
-    - https://download.gnome.org/sources/gnome-shell/50/gnome-shell-50.3.tar.xz : 450458c44a26d25a9b84288e12b9005d4c5c44648cfc6b790be19a05de7f1735
+    - https://download.gnome.org/sources/gnome-shell/50/gnome-shell-50.4.tar.xz : c531939539db316a41aef23670370abd1330d3254f84bcb0f9f4dae5d6e362cf
 homepage   : https://gitlab.gnome.org/GNOME/gnome-shell
 license    : GPL-2.0-or-later
 component  : desktop.gnome

--- a/packages/g/gnome-shell/pspec_x86_64.xml
+++ b/packages/g/gnome-shell/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-shell</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/gnome-shell</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -193,12 +193,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="144">
-            <Date>2026-07-27</Date>
-            <Version>50.3</Version>
+        <Update release="145">
+            <Date>2026-08-07</Date>
+            <Version>50.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/g/gnome-user-docs/package.yml
+++ b/packages/g/gnome-user-docs/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-user-docs
-version    : '50.2'
-release    : 40
+version    : '50.4'
+release    : 41
 source     :
-    - https://download.gnome.org/sources/gnome-user-docs/50/gnome-user-docs-50.2.tar.xz : 834863d916189ae13f72562be81d3817232e136d0d37ec376811111ffa159542
+    - https://download.gnome.org/sources/gnome-user-docs/50/gnome-user-docs-50.4.tar.xz : cd8768435343635bb2dcff69ca03916715532469c465df4804c37add98a13497
 homepage   : https://gitlab.gnome.org/GNOME/gnome-user-docs
 license    : CC-BY-3.0
 component  : desktop.gnome.doc
@@ -20,3 +20,4 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING

--- a/packages/g/gnome-user-docs/pspec_x86_64.xml
+++ b/packages/g/gnome-user-docs/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-user-docs</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/gnome-user-docs</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>CC-BY-3.0</License>
         <PartOf>desktop.gnome.doc</PartOf>
@@ -186,6 +186,7 @@
             <Path fileType="doc">/usr/share/help/C/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/C/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/C/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/C/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/C/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/C/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/C/gnome-help/figures/shell-appts.png</Path>
@@ -421,6 +422,11 @@
             <Path fileType="doc">/usr/share/help/C/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/C/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/C/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/C/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/C/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/C/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/C/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/C/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/C/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/C/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/C/gnome-help/session-language.page</Path>
@@ -704,6 +710,7 @@
             <Path fileType="doc">/usr/share/help/as/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/as/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/as/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/as/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/as/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/as/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/as/gnome-help/figures/shell-appts.png</Path>
@@ -939,6 +946,11 @@
             <Path fileType="doc">/usr/share/help/as/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/as/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/as/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/as/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/as/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/as/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/as/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/as/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/as/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/as/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/as/gnome-help/session-language.page</Path>
@@ -1165,6 +1177,7 @@
             <Path fileType="doc">/usr/share/help/ca/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ca/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ca/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/ca/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/ca/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/ca/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/ca/gnome-help/figures/shell-appts.png</Path>
@@ -1400,6 +1413,11 @@
             <Path fileType="doc">/usr/share/help/ca/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/ca/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/ca/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/ca/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/ca/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/ca/gnome-help/session-language.page</Path>
@@ -1683,6 +1701,7 @@
             <Path fileType="doc">/usr/share/help/cs/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/cs/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/cs/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/cs/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/cs/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/cs/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/cs/gnome-help/figures/shell-appts.png</Path>
@@ -1918,6 +1937,11 @@
             <Path fileType="doc">/usr/share/help/cs/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/cs/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/cs/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/cs/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/cs/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/cs/gnome-help/session-language.page</Path>
@@ -2201,6 +2225,7 @@
             <Path fileType="doc">/usr/share/help/da/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/da/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/da/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/da/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/da/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/da/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/da/gnome-help/figures/shell-appts.png</Path>
@@ -2436,6 +2461,11 @@
             <Path fileType="doc">/usr/share/help/da/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/da/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/da/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/da/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/da/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/da/gnome-help/session-language.page</Path>
@@ -2662,6 +2692,7 @@
             <Path fileType="doc">/usr/share/help/de/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/de/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/de/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/de/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/de/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/de/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/de/gnome-help/figures/shell-appts.png</Path>
@@ -2897,6 +2928,11 @@
             <Path fileType="doc">/usr/share/help/de/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/de/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/de/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/de/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/de/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/de/gnome-help/session-language.page</Path>
@@ -3180,6 +3216,7 @@
             <Path fileType="doc">/usr/share/help/el/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/el/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/el/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/el/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/el/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/el/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/el/gnome-help/figures/shell-appts.png</Path>
@@ -3415,6 +3452,11 @@
             <Path fileType="doc">/usr/share/help/el/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/el/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/el/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/el/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/el/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/el/gnome-help/session-language.page</Path>
@@ -3641,6 +3683,7 @@
             <Path fileType="doc">/usr/share/help/es/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/es/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/es/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/es/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/es/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/es/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/es/gnome-help/figures/shell-appts.png</Path>
@@ -3876,6 +3919,11 @@
             <Path fileType="doc">/usr/share/help/es/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/es/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/es/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/es/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/es/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/es/gnome-help/session-language.page</Path>
@@ -4159,6 +4207,7 @@
             <Path fileType="doc">/usr/share/help/eu/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/eu/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/eu/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/eu/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/eu/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/eu/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/eu/gnome-help/figures/shell-appts.png</Path>
@@ -4394,6 +4443,11 @@
             <Path fileType="doc">/usr/share/help/eu/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/eu/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/eu/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/eu/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/eu/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/eu/gnome-help/session-language.page</Path>
@@ -4677,6 +4731,7 @@
             <Path fileType="doc">/usr/share/help/fa/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/fa/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/fa/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/fa/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/fa/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/fa/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/fa/gnome-help/figures/shell-appts.png</Path>
@@ -4912,6 +4967,11 @@
             <Path fileType="doc">/usr/share/help/fa/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/fa/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/fa/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/fa/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/fa/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/fa/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/fa/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/fa/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/fa/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/fa/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/fa/gnome-help/session-language.page</Path>
@@ -5195,6 +5255,7 @@
             <Path fileType="doc">/usr/share/help/fi/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/fi/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/fi/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/fi/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/fi/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/fi/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/fi/gnome-help/figures/shell-appts.png</Path>
@@ -5430,6 +5491,11 @@
             <Path fileType="doc">/usr/share/help/fi/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/fi/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/fi/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/fi/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/fi/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/fi/gnome-help/session-language.page</Path>
@@ -5656,6 +5722,7 @@
             <Path fileType="doc">/usr/share/help/fr/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/fr/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/fr/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/fr/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/fr/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/fr/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/fr/gnome-help/figures/shell-appts.png</Path>
@@ -5891,6 +5958,11 @@
             <Path fileType="doc">/usr/share/help/fr/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/fr/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/fr/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/fr/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/fr/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/fr/gnome-help/session-language.page</Path>
@@ -6174,6 +6246,7 @@
             <Path fileType="doc">/usr/share/help/gl/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/gl/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/gl/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/gl/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/gl/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/gl/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/gl/gnome-help/figures/shell-appts.png</Path>
@@ -6409,6 +6482,11 @@
             <Path fileType="doc">/usr/share/help/gl/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/gl/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/gl/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/gl/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/gl/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/gl/gnome-help/session-language.page</Path>
@@ -6692,6 +6770,7 @@
             <Path fileType="doc">/usr/share/help/gu/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/gu/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/gu/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/gu/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/gu/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/gu/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/gu/gnome-help/figures/shell-appts.png</Path>
@@ -6927,6 +7006,11 @@
             <Path fileType="doc">/usr/share/help/gu/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/gu/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/gu/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/gu/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/gu/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/gu/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/gu/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/gu/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/gu/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/gu/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/gu/gnome-help/session-language.page</Path>
@@ -7153,6 +7237,7 @@
             <Path fileType="doc">/usr/share/help/he/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/he/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/he/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/he/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/he/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/he/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/he/gnome-help/figures/shell-appts.png</Path>
@@ -7388,6 +7473,11 @@
             <Path fileType="doc">/usr/share/help/he/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/he/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/he/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/he/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/he/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/he/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/he/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/he/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/he/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/he/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/he/gnome-help/session-language.page</Path>
@@ -7614,6 +7704,7 @@
             <Path fileType="doc">/usr/share/help/hi/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/hi/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/hi/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/hi/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/hi/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/hi/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/hi/gnome-help/figures/shell-appts.png</Path>
@@ -7849,6 +7940,11 @@
             <Path fileType="doc">/usr/share/help/hi/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/hi/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/hi/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/hi/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/hi/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/hi/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/hi/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/hi/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/hi/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/hi/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/hi/gnome-help/session-language.page</Path>
@@ -8075,6 +8171,7 @@
             <Path fileType="doc">/usr/share/help/hr/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/hr/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/hr/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/hr/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/hr/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/hr/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/hr/gnome-help/figures/shell-appts.png</Path>
@@ -8310,6 +8407,11 @@
             <Path fileType="doc">/usr/share/help/hr/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/hr/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/hr/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/hr/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/hr/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/hr/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/hr/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/hr/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/hr/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/hr/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/hr/gnome-help/session-language.page</Path>
@@ -8593,6 +8695,7 @@
             <Path fileType="doc">/usr/share/help/hu/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/hu/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/hu/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/hu/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/hu/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/hu/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/hu/gnome-help/figures/shell-appts.png</Path>
@@ -8828,6 +8931,11 @@
             <Path fileType="doc">/usr/share/help/hu/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/hu/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/hu/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/hu/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/hu/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/hu/gnome-help/session-language.page</Path>
@@ -9111,6 +9219,7 @@
             <Path fileType="doc">/usr/share/help/id/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/id/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/id/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/id/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/id/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/id/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/id/gnome-help/figures/shell-appts.png</Path>
@@ -9346,6 +9455,11 @@
             <Path fileType="doc">/usr/share/help/id/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/id/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/id/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/id/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/id/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/id/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/id/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/id/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/id/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/id/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/id/gnome-help/session-language.page</Path>
@@ -9629,6 +9743,7 @@
             <Path fileType="doc">/usr/share/help/it/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/it/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/figures/shell-appts.png</Path>
@@ -9864,6 +9979,11 @@
             <Path fileType="doc">/usr/share/help/it/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/session-language.page</Path>
@@ -9924,6 +10044,63 @@
             <Path fileType="doc">/usr/share/help/it/gnome-help/wacom-stylus.page</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/wacom-tablet-unknown.page</Path>
             <Path fileType="doc">/usr/share/help/it/gnome-help/wacom.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/appearance.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/autostart-applications.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/backgrounds-extra.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/dconf-custom-defaults.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/dconf-keyfiles.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/dconf-lockdown.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/dconf-nfs-home.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/dconf-profiles.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/dconf-snippets.xml</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/dconf.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/desktop-background.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/desktop-favorite-applications.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/desktop-lockscreen.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/desktop-shield.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/extensions-enable.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/extensions-lockdown.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/extensions.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/fonts-user.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/fonts.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/gsettings-browse.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/index.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/keyboard-compose-key.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/keyboard-layout.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/legal.xml</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/lockdown-command-line.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/lockdown-file-saving.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/lockdown-logout.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/lockdown-online-accounts.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/lockdown-printing.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/lockdown-repartitioning.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/lockdown-single-app-mode.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/login-automatic.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/login-banner.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/login-enterprise.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/login-fingerprint.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/login-logo.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/login-userlist-disable.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/login.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/logout-automatic.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/mime-types-application-user.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/mime-types-application.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/mime-types-custom-user.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/mime-types-custom.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/mime-types.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/network-server-list.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/network-vpn.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/network.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/overrides.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/power-dim-screen.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/processes.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/session-custom.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/session-debug.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/session-user.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/setup.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/software.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/sundry.page</Path>
+            <Path fileType="doc">/usr/share/help/it/system-admin-guide/user-settings.page</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/a11y-bouncekeys.page</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/a11y-braille.page</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/a11y-contrast.page</Path>
@@ -10090,6 +10267,7 @@
             <Path fileType="doc">/usr/share/help/ja/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/ja/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/figures/shell-appts.png</Path>
@@ -10325,6 +10503,11 @@
             <Path fileType="doc">/usr/share/help/ja/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/ja/gnome-help/session-language.page</Path>
@@ -10551,6 +10734,7 @@
             <Path fileType="doc">/usr/share/help/kk/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/kk/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/kk/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/kk/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/kk/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/kk/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/kk/gnome-help/figures/shell-appts.png</Path>
@@ -10786,6 +10970,11 @@
             <Path fileType="doc">/usr/share/help/kk/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/kk/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/kk/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/kk/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/kk/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/kk/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/kk/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/kk/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/kk/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/kk/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/kk/gnome-help/session-language.page</Path>
@@ -11069,6 +11258,7 @@
             <Path fileType="doc">/usr/share/help/kn/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/kn/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/kn/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/kn/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/kn/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/kn/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/kn/gnome-help/figures/shell-appts.png</Path>
@@ -11304,6 +11494,11 @@
             <Path fileType="doc">/usr/share/help/kn/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/kn/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/kn/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/kn/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/kn/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/kn/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/kn/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/kn/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/kn/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/kn/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/kn/gnome-help/session-language.page</Path>
@@ -11530,6 +11725,7 @@
             <Path fileType="doc">/usr/share/help/ko/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ko/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ko/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/ko/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/ko/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/ko/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/ko/gnome-help/figures/shell-appts.png</Path>
@@ -11765,6 +11961,11 @@
             <Path fileType="doc">/usr/share/help/ko/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/ko/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/ko/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/ko/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/ko/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/ko/gnome-help/session-language.page</Path>
@@ -12048,6 +12249,7 @@
             <Path fileType="doc">/usr/share/help/lt/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/lt/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/lt/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/lt/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/lt/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/lt/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/lt/gnome-help/figures/shell-appts.png</Path>
@@ -12283,6 +12485,11 @@
             <Path fileType="doc">/usr/share/help/lt/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/lt/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/lt/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/lt/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/lt/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/lt/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/lt/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/lt/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/lt/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/lt/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/lt/gnome-help/session-language.page</Path>
@@ -12509,6 +12716,7 @@
             <Path fileType="doc">/usr/share/help/lv/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/lv/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/lv/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/lv/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/lv/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/lv/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/lv/gnome-help/figures/shell-appts.png</Path>
@@ -12744,6 +12952,11 @@
             <Path fileType="doc">/usr/share/help/lv/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/lv/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/lv/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/lv/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/lv/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/lv/gnome-help/session-language.page</Path>
@@ -12970,6 +13183,7 @@
             <Path fileType="doc">/usr/share/help/mr/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/mr/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/mr/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/mr/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/mr/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/mr/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/mr/gnome-help/figures/shell-appts.png</Path>
@@ -13205,6 +13419,11 @@
             <Path fileType="doc">/usr/share/help/mr/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/mr/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/mr/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/mr/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/mr/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/mr/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/mr/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/mr/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/mr/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/mr/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/mr/gnome-help/session-language.page</Path>
@@ -13431,6 +13650,7 @@
             <Path fileType="doc">/usr/share/help/nl/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/nl/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/nl/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/nl/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/nl/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/nl/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/nl/gnome-help/figures/shell-appts.png</Path>
@@ -13666,6 +13886,11 @@
             <Path fileType="doc">/usr/share/help/nl/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/nl/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/nl/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/nl/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/nl/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/nl/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/nl/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/nl/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/nl/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/nl/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/nl/gnome-help/session-language.page</Path>
@@ -13949,6 +14174,7 @@
             <Path fileType="doc">/usr/share/help/pa/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/pa/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/pa/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/pa/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/pa/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/pa/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/pa/gnome-help/figures/shell-appts.png</Path>
@@ -14184,6 +14410,11 @@
             <Path fileType="doc">/usr/share/help/pa/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/pa/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/pa/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/pa/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/pa/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/pa/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/pa/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/pa/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/pa/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/pa/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/pa/gnome-help/session-language.page</Path>
@@ -14410,6 +14641,7 @@
             <Path fileType="doc">/usr/share/help/pl/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/pl/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/pl/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/pl/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/pl/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/pl/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/pl/gnome-help/figures/shell-appts.png</Path>
@@ -14645,6 +14877,11 @@
             <Path fileType="doc">/usr/share/help/pl/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/pl/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/pl/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/pl/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/pl/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/pl/gnome-help/session-language.page</Path>
@@ -14871,6 +15108,7 @@
             <Path fileType="doc">/usr/share/help/pt/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/pt/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/pt/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/pt/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/pt/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/pt/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/pt/gnome-help/figures/shell-appts.png</Path>
@@ -15106,6 +15344,11 @@
             <Path fileType="doc">/usr/share/help/pt/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/pt/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/pt/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/pt/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/pt/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/pt/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/pt/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/pt/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/pt/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/pt/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/pt/gnome-help/session-language.page</Path>
@@ -15332,6 +15575,7 @@
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/figures/shell-appts.png</Path>
@@ -15567,6 +15811,11 @@
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/pt_BR/gnome-help/session-language.page</Path>
@@ -15850,6 +16099,7 @@
             <Path fileType="doc">/usr/share/help/ro/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ro/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ro/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/ro/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/ro/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/ro/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/ro/gnome-help/figures/shell-appts.png</Path>
@@ -16085,6 +16335,11 @@
             <Path fileType="doc">/usr/share/help/ro/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/ro/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/ro/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/ro/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ro/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/ro/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/ro/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ro/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/ro/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/ro/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/ro/gnome-help/session-language.page</Path>
@@ -16311,6 +16566,7 @@
             <Path fileType="doc">/usr/share/help/ru/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ru/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ru/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/ru/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/ru/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/ru/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/ru/gnome-help/figures/shell-appts.png</Path>
@@ -16546,6 +16802,11 @@
             <Path fileType="doc">/usr/share/help/ru/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/ru/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/ru/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/ru/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/ru/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/ru/gnome-help/session-language.page</Path>
@@ -16829,6 +17090,7 @@
             <Path fileType="doc">/usr/share/help/sl/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/sl/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/sl/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/sl/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/sl/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/sl/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/sl/gnome-help/figures/shell-appts.png</Path>
@@ -17064,6 +17326,11 @@
             <Path fileType="doc">/usr/share/help/sl/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/sl/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/sl/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/sl/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/sl/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/sl/gnome-help/session-language.page</Path>
@@ -17290,6 +17557,7 @@
             <Path fileType="doc">/usr/share/help/sr/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/sr/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/sr/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/sr/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/sr/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/sr/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/sr/gnome-help/figures/shell-appts.png</Path>
@@ -17525,6 +17793,11 @@
             <Path fileType="doc">/usr/share/help/sr/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/sr/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/sr/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/sr/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/sr/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/sr/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/sr/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/sr/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/sr/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/sr/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/sr/gnome-help/session-language.page</Path>
@@ -17751,6 +18024,7 @@
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/figures/shell-appts.png</Path>
@@ -17986,6 +18260,11 @@
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/sr@latin/gnome-help/session-language.page</Path>
@@ -18212,6 +18491,7 @@
             <Path fileType="doc">/usr/share/help/sv/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/sv/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/sv/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/sv/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/sv/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/sv/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/sv/gnome-help/figures/shell-appts.png</Path>
@@ -18447,6 +18727,11 @@
             <Path fileType="doc">/usr/share/help/sv/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/sv/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/sv/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/sv/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/sv/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/sv/gnome-help/session-language.page</Path>
@@ -18730,6 +19015,7 @@
             <Path fileType="doc">/usr/share/help/ta/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ta/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/ta/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/ta/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/ta/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/ta/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/ta/gnome-help/figures/shell-appts.png</Path>
@@ -18965,6 +19251,11 @@
             <Path fileType="doc">/usr/share/help/ta/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/ta/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/ta/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/ta/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ta/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/ta/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/ta/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/ta/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/ta/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/ta/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/ta/gnome-help/session-language.page</Path>
@@ -19191,6 +19482,7 @@
             <Path fileType="doc">/usr/share/help/te/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/te/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/te/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/te/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/te/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/te/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/te/gnome-help/figures/shell-appts.png</Path>
@@ -19426,6 +19718,11 @@
             <Path fileType="doc">/usr/share/help/te/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/te/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/te/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/te/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/te/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/te/gnome-help/session-language.page</Path>
@@ -19652,6 +19949,7 @@
             <Path fileType="doc">/usr/share/help/th/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/th/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/th/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/th/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/th/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/th/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/th/gnome-help/figures/shell-appts.png</Path>
@@ -19887,6 +20185,11 @@
             <Path fileType="doc">/usr/share/help/th/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/th/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/th/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/th/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/th/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/th/gnome-help/session-language.page</Path>
@@ -20113,6 +20416,7 @@
             <Path fileType="doc">/usr/share/help/tr/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/tr/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/tr/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/tr/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/tr/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/tr/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/tr/gnome-help/figures/shell-appts.png</Path>
@@ -20348,6 +20652,11 @@
             <Path fileType="doc">/usr/share/help/tr/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/tr/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/tr/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/tr/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/tr/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/tr/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/tr/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/tr/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/tr/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/tr/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/tr/gnome-help/session-language.page</Path>
@@ -20631,6 +20940,7 @@
             <Path fileType="doc">/usr/share/help/uk/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/uk/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/uk/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/uk/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/uk/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/uk/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/uk/gnome-help/figures/shell-appts.png</Path>
@@ -20866,6 +21176,11 @@
             <Path fileType="doc">/usr/share/help/uk/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/uk/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/uk/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/uk/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/uk/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/uk/gnome-help/session-language.page</Path>
@@ -21149,6 +21464,7 @@
             <Path fileType="doc">/usr/share/help/vi/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/vi/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/vi/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/vi/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/vi/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/vi/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/vi/gnome-help/figures/shell-appts.png</Path>
@@ -21384,6 +21700,11 @@
             <Path fileType="doc">/usr/share/help/vi/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/vi/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/vi/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/vi/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/vi/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/vi/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/vi/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/vi/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/vi/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/vi/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/vi/gnome-help/session-language.page</Path>
@@ -21610,6 +21931,7 @@
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/figures/rotation-allowed-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/figures/rotation-locked-symbolic.svg</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/figures/screenshot-tool.png</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/figures/search-results-order.png</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/figures/shell-activities-dash.png</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/figures/shell-appts-classic.png</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/figures/shell-appts.png</Path>
@@ -21845,6 +22167,11 @@
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/quick-settings.page</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/remote-login.page</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/screen-shot-record.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/search-all-app.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/search-filesystem-locations.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/search-order.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/search-specific-app.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/search.page</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/session-fingerprint.page</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/session-formats.page</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/session-language.page</Path>
@@ -21905,15 +22232,16 @@
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/wacom-stylus.page</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/wacom-tablet-unknown.page</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gnome-help/wacom.page</Path>
+            <Path fileType="data">/usr/share/licenses/gnome-user-docs/COPYING</Path>
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2026-05-29</Date>
-            <Version>50.2</Version>
+        <Update release="41">
+            <Date>2026-08-07</Date>
+            <Version>50.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/g/gvfs/abi_used_symbols
+++ b/packages/g/gvfs/abi_used_symbols
@@ -48,6 +48,7 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
+libc.so.6:__explicit_bzero_chk
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoll
@@ -89,7 +90,7 @@ libc.so.6:if_indextoname
 libc.so.6:ioctl
 libc.so.6:kill
 libc.so.6:link
-libc.so.6:localtime
+libc.so.6:localtime_r
 libc.so.6:login_tty
 libc.so.6:lseek64
 libc.so.6:lstat64
@@ -560,6 +561,7 @@ libgio-2.0.so.0:g_icon_equal
 libgio-2.0.so.0:g_icon_get_type
 libgio-2.0.so.0:g_icon_new_for_string
 libgio-2.0.so.0:g_icon_to_string
+libgio-2.0.so.0:g_inet_address_equal
 libgio-2.0.so.0:g_inet_address_get_family
 libgio-2.0.so.0:g_inet_address_to_string
 libgio-2.0.so.0:g_inet_socket_address_get_address
@@ -686,6 +688,7 @@ libgio-2.0.so.0:g_socket_connection_get_local_address
 libgio-2.0.so.0:g_socket_connection_get_remote_address
 libgio-2.0.so.0:g_socket_connection_get_socket
 libgio-2.0.so.0:g_socket_get_local_address
+libgio-2.0.so.0:g_socket_get_remote_address
 libgio-2.0.so.0:g_socket_get_type
 libgio-2.0.so.0:g_socket_listen
 libgio-2.0.so.0:g_socket_new

--- a/packages/g/gvfs/package.yml
+++ b/packages/g/gvfs/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gvfs
-version    : 1.60.1
-release    : 113
+version    : 1.60.2
+release    : 114
 source     :
-    - https://download.gnome.org/sources/gvfs/1.60/gvfs-1.60.1.tar.xz : 90eaba333ab7d31a7fdeade45954a513c3661ccebbd9a138aab3fb481dfb9e40
+    - https://download.gnome.org/sources/gvfs/1.60/gvfs-1.60.2.tar.xz : a8d7744615a488a559302fe0cc8f418d5b44aba3c2ba2163e5a9e6f607c1be9a
 homepage   : https://gitlab.gnome.org/GNOME/gvfs
 license    : GPL-2.0-only
 component  :
@@ -56,3 +56,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/g/gvfs/pspec_x86_64.xml
+++ b/packages/g/gvfs/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gvfs</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/gvfs</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.gnome.core</PartOf>
@@ -103,6 +103,7 @@
             <Path fileType="data">/usr/share/gvfs/remote-volume-monitors/gphoto2.monitor</Path>
             <Path fileType="data">/usr/share/gvfs/remote-volume-monitors/mtp.monitor</Path>
             <Path fileType="data">/usr/share/gvfs/remote-volume-monitors/udisks2.monitor</Path>
+            <Path fileType="data">/usr/share/licenses/gvfs/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/gvfs.mo</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/gvfs.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/gvfs.mo</Path>
@@ -196,7 +197,7 @@
 </Description>
         <PartOf>desktop.gnome.core</PartOf>
         <RuntimeDependencies>
-            <Dependency release="113">gvfs</Dependency>
+            <Dependency release="114">gvfs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/systemd/user/gvfs-goa-volume-monitor.service</Path>
@@ -208,12 +209,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="113">
-            <Date>2026-07-07</Date>
-            <Version>1.60.1</Version>
+        <Update release="114">
+            <Date>2026-08-07</Date>
+            <Version>1.60.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/l/libadwaita/package.yml
+++ b/packages/l/libadwaita/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libadwaita
-version    : 1.9.2
-release    : 40
+version    : 1.9.3
+release    : 41
 source     :
-    - https://download.gnome.org/sources/libadwaita/1.9/libadwaita-1.9.2.tar.xz : 6920f813a76c4856591ca56ee842e94efbbe736e8ca2f445c9e9fc3b4e7076f0
+    - https://download.gnome.org/sources/libadwaita/1.9/libadwaita-1.9.3.tar.xz : fc59b37028fe0126308e7b805d2f6e4e80227080a1797715e5e6286b8111e723
 homepage   : https://gnome.pages.gitlab.gnome.org/libadwaita/
 license    : LGPL-2.1-or-later
 component  : desktop.library
@@ -24,5 +24,6 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 #check      : |
 #    %ninja_check

--- a/packages/l/libadwaita/pspec_x86_64.xml
+++ b/packages/l/libadwaita/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libadwaita</Name>
         <Homepage>https://gnome.pages.gitlab.gnome.org/libadwaita/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop.library</PartOf>
@@ -22,6 +22,7 @@
         <Files>
             <Path fileType="library">/usr/lib64/girepository-1.0/Adw-1.typelib</Path>
             <Path fileType="library">/usr/lib64/libadwaita-1.so.0</Path>
+            <Path fileType="data">/usr/share/licenses/libadwaita/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/libadwaita.mo</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/libadwaita.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/libadwaita.mo</Path>
@@ -87,7 +88,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="40">libadwaita</Dependency>
+            <Dependency release="41">libadwaita</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libadwaita-1/adw-about-dialog.h</Path>
@@ -189,12 +190,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2026-07-07</Date>
-            <Version>1.9.2</Version>
+        <Update release="41">
+            <Date>2026-08-07</Date>
+            <Version>1.9.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/l/libshumate/package.yml
+++ b/packages/l/libshumate/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libshumate
-version    : 1.6.2
-release    : 22
+version    : 1.6.3
+release    : 23
 source     :
-    - https://download.gnome.org/sources/libshumate/1.6/libshumate-1.6.2.tar.xz : 22364bb98f8b520334336ab82240196a0963489b86a5b38328e1bea2b64f3a9e
+    - https://download.gnome.org/sources/libshumate/1.6/libshumate-1.6.3.tar.xz : fd15c91396dcd82fce3021648541aa891e71a6bddeffc03d38597580a7da8ca1
 homepage   : https://gitlab.gnome.org/GNOME/libshumate
 license    : LGPL-2.1-or-later
 component  : programming.library
@@ -26,3 +26,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/l/libshumate/pspec_x86_64.xml
+++ b/packages/l/libshumate/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libshumate</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/libshumate</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -23,6 +23,7 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/Shumate-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libshumate-1.0.so.1</Path>
             <Path fileType="library">/usr/lib64/libshumate-1.0.so.1.0</Path>
+            <Path fileType="data">/usr/share/licenses/libshumate/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/shumate1.mo</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/shumate1.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/shumate1.mo</Path>
@@ -86,7 +87,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="22">libshumate</Dependency>
+            <Dependency release="23">libshumate</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/shumate-1.0/shumate/shumate-compass.h</Path>
@@ -131,12 +132,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2026-07-07</Date>
-            <Version>1.6.2</Version>
+        <Update release="23">
+            <Date>2026-08-07</Date>
+            <Version>1.6.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/l/libvte/abi_symbols
+++ b/packages/l/libvte/abi_symbols
@@ -1,4 +1,3 @@
-libvte-2.91-gtk4.so.0:_ZSt19piecewise_construct
 libvte-2.91-gtk4.so.0:_ZTISt11_Mutex_baseILN9__gnu_cxx12_Lock_policyE2EE
 libvte-2.91-gtk4.so.0:_ZTISt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE
 libvte-2.91-gtk4.so.0:_ZTISt18bad_variant_access
@@ -249,7 +248,6 @@ libvte-2.91-gtk4.so.0:vte_uuid_new_v5
 libvte-2.91-gtk4.so.0:vte_uuid_to_string
 libvte-2.91-gtk4.so.0:vte_uuid_validate_string
 libvte-2.91-gtk4.so.0:vte_write_flags_get_type
-libvte-2.91.so.0:_ZSt19piecewise_construct
 libvte-2.91.so.0:_ZTISt11_Mutex_baseILN9__gnu_cxx12_Lock_policyE2EE
 libvte-2.91.so.0:_ZTISt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE
 libvte-2.91.so.0:_ZTISt18bad_variant_access

--- a/packages/l/libvte/abi_used_symbols
+++ b/packages/l/libvte/abi_used_symbols
@@ -828,6 +828,7 @@ libstdc++.so.6:_ZSt17rethrow_exceptionNSt15__exception_ptr13exception_ptrE
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt21__glibcxx_assert_failPKciS0_S0_
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
 libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv

--- a/packages/l/libvte/package.yml
+++ b/packages/l/libvte/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libvte
-version    : 0.84.0
-release    : 84
+version    : 0.84.1
+release    : 85
 source     :
-    - https://download.gnome.org/sources/vte/0.84/vte-0.84.0.tar.xz : 0414e31583836aeb7878da25f67c515f7e8879917ecc37c92e26b83e8d8fc3e3
+    - https://download.gnome.org/sources/vte/0.84/vte-0.84.1.tar.xz : aca1caa8478aebcdbb1d67897fb3511eb7601debae6810e16a15b6fa25f31ac8
 homepage   : https://gitlab.gnome.org/GNOME/vte
 license    : LGPL-3.0-or-later
 component  : desktop.library
@@ -38,5 +38,6 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING*
     mkdir $installdir/usr/share/defaults/
     mv $installdir/etc/ $installdir/usr/share/defaults/

--- a/packages/l/libvte/pspec_x86_64.xml
+++ b/packages/l/libvte/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libvte</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/vte</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>desktop.library</PartOf>
@@ -25,13 +25,18 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/Vte-3.91.typelib</Path>
             <Path fileType="library">/usr/lib64/libvte-2.91-gtk4.so.0</Path>
             <Path fileType="library">/usr/lib64/libvte-2.91.so.0</Path>
-            <Path fileType="library">/usr/lib64/libvte-2.91.so.0.8400.0</Path>
+            <Path fileType="library">/usr/lib64/libvte-2.91.so.0.8400.1</Path>
             <Path fileType="library">/usr/lib64/libvte/vte-urlencode-cwd</Path>
             <Path fileType="data">/usr/share/defaults/etc/profile.d/vte.csh</Path>
             <Path fileType="data">/usr/share/defaults/etc/profile.d/vte.sh</Path>
             <Path fileType="data">/usr/share/glade/catalogs/vte-2.91.xml</Path>
             <Path fileType="data">/usr/share/glade/pixmaps/hicolor/16x16/actions/widget-vte-terminal.png</Path>
             <Path fileType="data">/usr/share/glade/pixmaps/hicolor/22x22/actions/widget-vte-terminal.png</Path>
+            <Path fileType="data">/usr/share/licenses/libvte/COPYING.CC-BY-4-0</Path>
+            <Path fileType="data">/usr/share/licenses/libvte/COPYING.GPL3</Path>
+            <Path fileType="data">/usr/share/licenses/libvte/COPYING.LGPL3</Path>
+            <Path fileType="data">/usr/share/licenses/libvte/COPYING.README</Path>
+            <Path fileType="data">/usr/share/licenses/libvte/COPYING.XTERM</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/vte-2.91.mo</Path>
             <Path fileType="localedata">/usr/share/locale/am/LC_MESSAGES/vte-2.91.mo</Path>
             <Path fileType="localedata">/usr/share/locale/an/LC_MESSAGES/vte-2.91.mo</Path>
@@ -143,7 +148,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="84">libvte</Dependency>
+            <Dependency release="85">libvte</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/vte-2.91-gtk4/vte/vte.h</Path>
@@ -1037,12 +1042,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="84">
-            <Date>2026-03-20</Date>
-            <Version>0.84.0</Version>
+        <Update release="85">
+            <Date>2026-08-07</Date>
+            <Version>0.84.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mutter/package.yml
+++ b/packages/m/mutter/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : mutter
-version    : '50.3'
-release    : 148
+version    : '50.4'
+release    : 149
 source     :
-    - https://download.gnome.org/sources/mutter/50/mutter-50.3.tar.xz : 25663fa7afc96a4c092448990c0da664b7f04dd8d9f5e3b9be2b498b1b303cb4
+    - https://download.gnome.org/sources/mutter/50/mutter-50.4.tar.xz : 273d33c875abcb4b6cbea3f4ec045d18155fbc510c3521fc7e47926371310988
 homepage   : https://gitlab.gnome.org/GNOME/mutter
 license    : GPL-2.0-or-later
 component  : desktop.gnome
@@ -63,3 +63,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/m/mutter/pspec_x86_64.xml
+++ b/packages/m/mutter/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mutter</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/mutter</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -20,7 +20,7 @@
 </Description>
         <PartOf>desktop.gnome</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="148">mutter-common</Dependency>
+            <Dependency releaseFrom="149">mutter-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gdctl</Path>
@@ -50,6 +50,7 @@
             <Path fileType="library">/usr/lib64/mutter/mutter-backlight-helper</Path>
             <Path fileType="library">/usr/lib64/mutter/mutter-x11-frames</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gdctl</Path>
+            <Path fileType="data">/usr/share/licenses/mutter/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/mutter.mo</Path>
             <Path fileType="localedata">/usr/share/locale/am/LC_MESSAGES/mutter.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/mutter.mo</Path>
@@ -179,7 +180,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="148">mutter</Dependency>
+            <Dependency release="149">mutter</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mutter-18/clutter/clutter/clutter-action.h</Path>
@@ -403,12 +404,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="148">
-            <Date>2026-07-07</Date>
-            <Version>50.3</Version>
+        <Update release="149">
+            <Date>2026-08-07</Date>
+            <Version>50.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/p/pango/package.yml
+++ b/packages/p/pango/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 # Updating this package? Remember to update pangomm-2.48 alongside it.
 name       : pango
-version    : 1.58.0
-release    : 65
+version    : 1.58.2
+release    : 66
 source     :
-    - https://download.gnome.org/sources/pango/1.58/pango-1.58.0.tar.xz : bc5bad6213ad4886a47d1e80292fd850b64159b50db67917a43d9ea80ee2298a
+    - https://download.gnome.org/sources/pango/1.58/pango-1.58.2.tar.xz : 342385b6ca3b7c73455d7c80a13b7dbe4489e00bc3bd4c5bd6ed4dce421e374a
 homepage   : https://www.gtk.org/docs/architecture/pango
 license    : LGPL-2.0-or-later
 component  : desktop.library

--- a/packages/p/pango/pspec_x86_64.xml
+++ b/packages/p/pango/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pango</Name>
         <Homepage>https://www.gtk.org/docs/architecture/pango</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>LGPL-2.0-or-later</License>
         <PartOf>desktop.library</PartOf>
@@ -30,13 +30,13 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/PangoOT-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/PangoXft-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libpango-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libpango-1.0.so.0.5800.0</Path>
+            <Path fileType="library">/usr/lib64/libpango-1.0.so.0.5800.2</Path>
             <Path fileType="library">/usr/lib64/libpangocairo-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libpangocairo-1.0.so.0.5800.0</Path>
+            <Path fileType="library">/usr/lib64/libpangocairo-1.0.so.0.5800.2</Path>
             <Path fileType="library">/usr/lib64/libpangoft2-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libpangoft2-1.0.so.0.5800.0</Path>
+            <Path fileType="library">/usr/lib64/libpangoft2-1.0.so.0.5800.2</Path>
             <Path fileType="library">/usr/lib64/libpangoxft-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libpangoxft-1.0.so.0.5800.0</Path>
+            <Path fileType="library">/usr/lib64/libpangoxft-1.0.so.0.5800.2</Path>
             <Path fileType="data">/usr/share/licenses/pango/COPYING</Path>
         </Files>
     </Package>
@@ -47,17 +47,17 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="65">pango</Dependency>
+            <Dependency release="66">pango</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpango-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libpango-1.0.so.0.5800.0</Path>
+            <Path fileType="library">/usr/lib32/libpango-1.0.so.0.5800.2</Path>
             <Path fileType="library">/usr/lib32/libpangocairo-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libpangocairo-1.0.so.0.5800.0</Path>
+            <Path fileType="library">/usr/lib32/libpangocairo-1.0.so.0.5800.2</Path>
             <Path fileType="library">/usr/lib32/libpangoft2-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libpangoft2-1.0.so.0.5800.0</Path>
+            <Path fileType="library">/usr/lib32/libpangoft2-1.0.so.0.5800.2</Path>
             <Path fileType="library">/usr/lib32/libpangoxft-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libpangoxft-1.0.so.0.5800.0</Path>
+            <Path fileType="library">/usr/lib32/libpangoxft-1.0.so.0.5800.2</Path>
         </Files>
     </Package>
     <Package>
@@ -67,8 +67,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="65">pango-devel</Dependency>
-            <Dependency release="65">pango-32bit</Dependency>
+            <Dependency release="66">pango-32bit</Dependency>
+            <Dependency release="66">pango-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpango-1.0.so</Path>
@@ -90,7 +90,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="65">pango</Dependency>
+            <Dependency release="66">pango</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/pango-1.0/pango/pango-attributes.h</Path>
@@ -150,12 +150,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="65">
-            <Date>2026-07-30</Date>
-            <Version>1.58.0</Version>
+        <Update release="66">
+            <Date>2026-08-07</Date>
+            <Version>1.58.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->
[Changelog](https://download.gnome.org/sources/gnome-build-meta/50/gnome-build-meta-50.4.news)

- gdm: Update to v50.2 
- gnome-shell: Update to v50.4  
- gnome-control-center: Update to v50.4  
- mutter: Update to v50.4 
- gnome-maps: Update to v50.3 
- pango: Update to v1.58.2  
- libvte: Update to v0.84.1 
- libshumate: Update to v1.6.3   
- gvfs: Update to v1.60.2  
- gnome-user-docs: Update to v50.4 
- gexiv2: Update to v0.16.2  
- glibmm: Update to v2.66.9 
- libadwaita: Update to v1.9.3
- at-spi2: Update to v2.60.6              

**Test Plan**

<!-- Short description of how the package was tested -->
Install and use desktop as usual

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
