### PR TITLE
openexr: Update to v3.4.14

### DIFF
--- a/packages/o/openexr/abi_used_libs
+++ b/packages/o/openexr/abi_used_libs
@@ -1,4 +1,5 @@
 UNKNOWN
+ld-linux-x86-64.so.2
 libImath-3_1.so.29
 libc.so.6
 libgcc_s.so.1

--- a/packages/o/openexr/abi_used_symbols
+++ b/packages/o/openexr/abi_used_symbols
@@ -43,6 +43,7 @@ UNKNOWN:_ZTIN7Imf_3_47OStreamE
 UNKNOWN:_ZTIN7Imf_3_49AttributeE
 UNKNOWN:_ZTVN7Imf_3_414TypedAttributeINS_7KeyCodeEEE
 UNKNOWN:_ZTVN7Imf_3_414TypedAttributeINS_8TimeCodeEEE
+ld-linux-x86-64.so.2:__tls_get_addr
 libImath-3_1.so.29:imath_half_to_float_table
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
@@ -83,6 +84,7 @@ libc.so.6:pthread_mutex_destroy
 libc.so.6:pthread_mutex_init
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
+libc.so.6:pthread_once
 libc.so.6:putchar
 libc.so.6:puts
 libc.so.6:pwrite64
@@ -123,6 +125,7 @@ libm.so.6:atan2f
 libm.so.6:ceil
 libm.so.6:ceilf
 libm.so.6:expf
+libm.so.6:ldexpf
 libm.so.6:log
 libm.so.6:logf
 libm.so.6:pow
@@ -211,6 +214,8 @@ libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZNSt9exceptionD2Ev
+libstdc++.so.6:_ZSt11__once_call
+libstdc++.so.6:_ZSt15__once_callable
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
@@ -271,3 +276,4 @@ libstdc++.so.6:__cxa_throw
 libstdc++.so.6:__cxa_throw_bad_array_new_length
 libstdc++.so.6:__dynamic_cast
 libstdc++.so.6:__gxx_personality_v0
+libstdc++.so.6:__once_proxy

--- a/packages/o/openexr/package.yml
+++ b/packages/o/openexr/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openexr
-version    : 3.4.13
-release    : 16
+version    : 3.4.14
+release    : 17
 source     :
-    - https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.4.13.tar.gz : 1ed0cee48ac8c77da235c8ca8ab85d031d43cd790eda36af87fed4cf316cf2df
+    - https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.4.14.tar.gz : 13c3327100a7b92e4c6a048db03ef07ee2db8e79baa4c517c6fae71e5b80034b
 homepage   : https://www.openexr.com/
 license    : BSD-3-Clause
 component  :

--- a/packages/o/openexr/pspec_x86_64.xml
+++ b/packages/o/openexr/pspec_x86_64.xml
@@ -28,7 +28,7 @@ OpenEXR is widely used in host application software where accuracy is critical, 
 </Description>
         <PartOf>multimedia.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="16">openexr-libs</Dependency>
+            <Dependency release="17">openexr-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/exr2aces</Path>
@@ -56,8 +56,8 @@ OpenEXR is widely used in host application software where accuracy is critical, 
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="16">openexr</Dependency>
-            <Dependency releaseFrom="16">openexr-libs</Dependency>
+            <Dependency release="17">openexr</Dependency>
+            <Dependency releaseFrom="17">openexr-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/OpenEXR/Iex.h</Path>
@@ -272,21 +272,21 @@ OpenEXR is widely used in host application software where accuracy is critical, 
         <PartOf>multimedia.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libIex-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libIex-3_4.so.33.3.4.13</Path>
+            <Path fileType="library">/usr/lib64/libIex-3_4.so.33.3.4.14</Path>
             <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33.3.4.13</Path>
+            <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33.3.4.14</Path>
             <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33.3.4.13</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33.3.4.14</Path>
             <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33.3.4.13</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33.3.4.14</Path>
             <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33.3.4.13</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33.3.4.14</Path>
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2026-06-19</Date>
-            <Version>3.4.13</Version>
+        <Update release="17">
+            <Date>2026-08-07</Date>
+            <Version>3.4.14</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.4.14).

**Security**
Includes fixes for:
- CVE-2026-68514
- CVE-2026-68513
- CVE-2026-62986
- CVE-2026-61703
- CVE-2026-61555
- CVE-2026-59985
- CVE-2026-59984
- CVE-2026-59983
- CVE-2026-59982
- CVE-2026-59981
- CVE-2026-59189
- CVE-2026-59187
- CVE-2026-59186
- CVE-2026-59184
- CVE-2026-59183

**Test Plan**

Passed test suite

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
