### PR TITLE
uv: update to 0.12.3

### DIFF
--- a/packages/u/uv/abi_used_libs
+++ b/packages/u/uv/abi_used_libs
@@ -1,5 +1,4 @@
 ld-linux-x86-64.so.2
 libc.so.6
 libgcc_s.so.1
-liblzma.so.5
 libm.so.6

--- a/packages/u/uv/abi_used_symbols
+++ b/packages/u/uv/abi_used_symbols
@@ -205,7 +205,6 @@ libc.so.6:waitpid
 libc.so.6:write
 libc.so.6:writev
 libgcc_s.so.1:_Unwind_Backtrace
-libgcc_s.so.1:_Unwind_DeleteException
 libgcc_s.so.1:_Unwind_FindEnclosingFunction
 libgcc_s.so.1:_Unwind_GetCFA
 libgcc_s.so.1:_Unwind_GetDataRelBase
@@ -214,14 +213,8 @@ libgcc_s.so.1:_Unwind_GetIPInfo
 libgcc_s.so.1:_Unwind_GetLanguageSpecificData
 libgcc_s.so.1:_Unwind_GetRegionStart
 libgcc_s.so.1:_Unwind_GetTextRelBase
-libgcc_s.so.1:_Unwind_RaiseException
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
-liblzma.so.5:lzma_alone_encoder
-liblzma.so.5:lzma_code
-liblzma.so.5:lzma_easy_encoder
-liblzma.so.5:lzma_end
-liblzma.so.5:lzma_lzma_preset
 libm.so.6:log2f
 libm.so.6:pow

--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -2,10 +2,10 @@
 #
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : uv
-version    : 0.11.32
-release    : 19
+version    : 0.12.3
+release    : 20
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.32.tar.gz : 62799114a5914728b0de55e65ae856e599fe3103eef9997b479cfc7acdd6ae67
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.12.3.tar.gz : 7d95d35a941135b96cc344c63b8da427d456900f58621481b909eac00904db7f
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0
@@ -42,7 +42,7 @@ environment: |
     CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO="off"; export CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO;
     CARGO_PROFILE_RELEASE_LTO="off"; export CARGO_PROFILE_RELEASE_LTO;
     CARGO_PROFILE_RELEASE_STRIP="none"; export CARGO_PROFILE_RELEASE_STRIP;
-    
+
     tripple="$(rustc --print host-tuple)"
 setup      : |
     %patch -p1 -i ${pkgfiles}/downstream-bin.patch
@@ -80,7 +80,7 @@ install    : |
 check      : |
     # Run smoke tests
     cd /tmp
-    "${installdir}/usr/bin/uv" run "${workdir}/scripts/smoke-test"
+    "${installdir}/usr/bin/uv" run --no-project "${workdir}/scripts/smoke-test"
 patterns   :
     - ^python-uv :
         - /usr/lib/python3.*/site-packages/uv-*

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>uv</Name>
         <Homepage>https://docs.astral.sh/uv</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>MIT</License>
@@ -38,15 +38,15 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="19">uv</Dependency>
+            <Dependency releaseFrom="20">uv</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/licenses/LICENSE-MIT</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.32.dist-info/sboms/uv.cyclonedx.json</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/sboms/uv.cyclonedx.json</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -67,12 +67,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/uv-build</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/licenses/LICENSE-MIT</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.11.32.dist-info/sboms/uv-build.cyclonedx.json</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/sboms/uv-build.cyclonedx.json</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -83,12 +83,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-07-27</Date>
-            <Version>0.11.32</Version>
+        <Update release="20">
+            <Date>2026-08-07</Date>
+            <Version>0.12.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
## Summary

- **Security:** Harden package validation and installation safety, including stricter archive, hash, certificate, lockfile, and wheel handling.
- Improve compatibility with Python packaging standards and dependency resolution workflows.
- Enhance reliability and correctness across project discovery, virtual environments, package management, and workspace handling.
- Improve performance for lockfile processing and related package management operations.

Release notes:
    - [0.12.3](https://github.com/astral-sh/uv/releases/tag/0.12.3)
    - [0.12.2](https://github.com/astral-sh/uv/releases/tag/0.12.2)
    - [0.12.1](https://github.com/astral-sh/uv/releases/tag/0.12.1)
    - [0.12.0](https://github.com/astral-sh/uv/releases/tag/0.12.0)
    - [0.11.33](https://github.com/astral-sh/uv/releases/tag/0.11.33)

## Test Plan

- Run smoke tests defined in source
- Installed locally and run some commands.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
