### PR TITLE
python-editables: Update to v0.6

### DIFF
--- a/packages/py/python-editables/package.yml
+++ b/packages/py/python-editables/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-editables
-version    : '0.5'
-release    : 6
+version    : '0.6'
+release    : 7
 source     :
-    - https://github.com/pfmoore/editables/archive/refs/tags/0.5.tar.gz : 1ff2663aa1669eb89115a38e2d4067c21bb847e7006f72bf979a1a91b8bc2304
+    - https://github.com/pfmoore/editables/archive/refs/tags/0.6.tar.gz : 766d9b40616dbcf5cc920e9db26dd915de999cfab75768ff05b3ebf9c389acb2
 homepage   : https://github.com/pfmoore/editables
 license    : MIT
 component  : programming.python
@@ -14,12 +14,12 @@ builddeps  :
     - python-build
     - python-flit-core
     - python-installer
-    - python-packaging
+    - python-wheel
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    %pytest -v

--- a/packages/py/python-editables/pspec_x86_64.xml
+++ b/packages/py/python-editables/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-editables</Name>
         <Homepage>https://github.com/pfmoore/editables</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/editables-0.5.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/editables-0.5.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/editables-0.5.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/editables-0.5.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/editables-0.6.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/editables-0.6.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/editables-0.6.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/editables-0.6.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/editables/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/editables/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/editables/__pycache__/__init__.cpython-314.pyc</Path>
@@ -34,12 +34,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-06-06</Date>
-            <Version>0.5</Version>
+        <Update release="7">
+            <Date>2026-08-08</Date>
+            <Version>0.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/pfmoore/editables/blob/0.6/CHANGELOG.md).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
