### PR TITLE
virtualenv update

### DIFF
--- a/packages/py/python-discovery/monitoring.yaml
+++ b/packages/py/python-discovery/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 388662
+  rss: https://github.com/tox-dev/python-discovery/tags.atom
+ # No known CPE, checked 2026-08-07
+security:
+  cpe: ~

--- a/packages/py/python-discovery/package.yml
+++ b/packages/py/python-discovery/package.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
+name       : python-discovery
+version    : 1.5.1
+release    : 1
+source     :
+    - https://github.com/tox-dev/python-discovery/archive/refs/tags/1.5.1.tar.gz : c8c49ded6b6eb81e91fca114ee2e90c8eeb20cb597e900594a35b986a9ac0ca6
+homepage   : https://pypi.org/project/python-discovery/
+license    : MIT
+component  : programming.python
+summary    : Python interpreter discovery
+description: |
+    python-discovery is a library for discovering Python interpreters installed on your machine. You may have multiple Python versions from system packages, pyenv, mise, asdf, uv, or the Windows registry (PEP 514). This library finds the right one for you.
+builddeps  :
+    - python-build
+    - python-hatch-vcs
+    - python-installer
+    - python-wheel
+checkdeps  :
+    - python-filelock
+    - python-pytest
+    - python-pytest-mock
+rundeps    :
+    - python-filelock
+build      : |
+    export SETUPTOOLS_SCM_PRETEND_VERSION=${version}
+
+    %pyproject_build
+install    : |
+    %pyproject_install
+check      : |
+    %pytest -v

--- a/packages/py/python-discovery/pspec_x86_64.xml
+++ b/packages/py/python-discovery/pspec_x86_64.xml
@@ -1,0 +1,72 @@
+<PISI>
+    <Source>
+        <Name>python-discovery</Name>
+        <Homepage>https://pypi.org/project/python-discovery/</Homepage>
+        <Packager>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">Python interpreter discovery</Summary>
+        <Description xml:lang="en">python-discovery is a library for discovering Python interpreters installed on your machine. You may have multiple Python versions from system packages, pyenv, mise, asdf, uv, or the Windows registry (PEP 514). This library finds the right one for you.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python-discovery</Name>
+        <Summary xml:lang="en">Python interpreter discovery</Summary>
+        <Description xml:lang="en">python-discovery is a library for discovering Python interpreters installed on your machine. You may have multiple Python versions from system packages, pyenv, mise, asdf, uv, or the Windows registry (PEP 514). This library finds the right one for you.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery-1.5.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery-1.5.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery-1.5.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery-1.5.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_cache.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_cache.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_cached_py_info.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_cached_py_info.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_compat.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_compat.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_discovery.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_discovery.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_py_info.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_py_info.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_py_spec.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_py_spec.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_specifier.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/__pycache__/_specifier.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_cache.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_cached_py_info.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_compat.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_discovery.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_py_info.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_py_spec.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_specifier.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_windows/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_windows/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_windows/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_windows/__pycache__/_pep514.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_windows/__pycache__/_pep514.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_windows/__pycache__/_propose.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_windows/__pycache__/_propose.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_windows/_pep514.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/_windows/_propose.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/python_discovery/py.typed</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2026-08-08</Date>
+            <Version>1.5.1</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
+        </Update>
+    </History>
+</PISI>

--- a/packages/v/virtualenv/package.yml
+++ b/packages/v/virtualenv/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : virtualenv
-version    : 21.6.1
-release    : 24
+version    : 21.7.2
+release    : 25
 source     :
-    - https://pypi.debian.net/virtualenv/virtualenv-21.6.1.tar.gz : 15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128
+    - https://pypi.debian.net/virtualenv/virtualenv-21.7.2.tar.gz : 8bf688bd159b32c3bd6966555c5a2605a07724b93671c32cfe3e45ac28058987
 homepage   : https://virtualenv.pypa.io/
 license    : MIT
 component  : programming.python
@@ -12,30 +12,56 @@ description: |
     virtualenv is a tool to create isolated python environments, allowing for easier management of versions and dependencies in Python applications.
 builddeps  :
     - python-build
-    - python-distlib
-    - python-filelock
     - python-hatch-vcs
     - python-installer
-    - python-platformdirs
-    - python-setuptools-scm
+    - python-wheel
 rundeps    :
     - pip-wheel
+    - python-discovery
     - python-distlib
     - python-filelock
     - python-platformdirs
     - python-setuptools-wheel
-    - python-six
-# checkdeps  :
-#     - python-flaky
-#     - python-pytest-mock
+checkdeps  :
+    - pip-wheel
+    - python-discovery
+    - python-distlib
+    - python-filelock
+    - python-flaky
+    - python-platformdirs
+    - python-pytest
+    - python-pytest-mock
+    - python-pytest-timeout
+    - python-setuptools-wheel
+    - tcsh
 setup      : |
     %patch -p1 -i ${pkgfiles}/system-wheel.patch
 
     rm src/virtualenv/seed/wheels/embed/pip-*
     rm src/virtualenv/seed/wheels/embed/setuptools-*
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
-#check      : |
-#    %python3_test pytest3 -k 'not (test_periodic_update or test_build_c_ext or test_get_wheel_download_cached)'
+    %pyproject_install
+# check      : |
+#     _pytest_args=(
+#         # tests try to find python2
+#         --deselect tests/unit/create/test_creator.py::test_py_pyc_missing[True-False]
+#         --deselect tests/unit/create/test_creator.py::test_py_pyc_missing[False-False]
+#         --deselect tests/unit/discovery/py_info/test_py_info.py::test_fallback_existent_system_executable
+#         --deselect tests/unit/test_util.py::test_reentrant_file_lock_is_thread_safe
+#         # https://github.com/pypa/setuptools_scm/issues/1036
+#         --deselect tests/unit/create/via_global_ref/test_build_c_ext.py::test_can_build_c_extensions
+#         # https://github.com/pypa/virtualenv/issues/2814
+#         --deselect tests/unit/activation/test_csh.py::test_csh[with_prompt]
+#         --deselect tests/unit/activation/test_csh.py::test_csh[no_prompt]
+#         # failures with 21.0.0
+#         --ignore tests/unit/create/test_creator.py
+#         #--deselect tests/unit/create/test_creator.py::test_create_no_seed[root-venv-copies-isolated]
+#         #--deselect tests/unit/create/test_creator.py::test_create_no_seed[root-venv-copies-global]
+#         # Embedded wheels aren't available on Solus
+#         --deselect tests/unit/seed/embed/test_base_embed.py
+#         --deselect tests/unit/seed/wheels/test_acquire.py
+#     )
+#
+#     %pytest -v "${_pytest_args[@]}"

--- a/packages/v/virtualenv/pspec_x86_64.xml
+++ b/packages/v/virtualenv/pspec_x86_64.xml
@@ -21,11 +21,11 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/virtualenv</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv-21.6.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv-21.6.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv-21.6.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv-21.6.1.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv-21.6.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv-21.7.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv-21.7.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv-21.7.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv-21.7.2.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv-21.7.2.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/virtualenv/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -318,9 +318,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2026-07-16</Date>
-            <Version>21.6.1</Version>
+        <Update release="25">
+            <Date>2026-08-08</Date>
+            <Version>21.7.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**

- **python-discovery: Add at v1.5.1**
- **virtualenv: Update to v21.7.2**

**Test Plan**

See that the test suite for discovery passes, and create a new venv and install `eopkg` into it.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
