### PR TITLE
python-filelock: Update to 3.32.2

### DIFF
--- a/packages/py/python-filelock/package.yml
+++ b/packages/py/python-filelock/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-filelock
-version    : 3.17.0
-release    : 20
+version    : 3.32.2
+release    : 21
 source     :
-    - https://pypi.io/packages/source/f/filelock/filelock-3.17.0.tar.gz : ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e
+    - https://pypi.io/packages/source/f/filelock/filelock-3.32.2.tar.gz : c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8
 homepage   : https://github.com/tox-dev/py-filelock/
-license    : Unlicense
+license    : MIT
 component  : programming.python
 summary    : A platform independent file lock for Python
 description: |
@@ -14,13 +14,17 @@ builddeps  :
     - python-build
     - python-hatch-vcs
     - python-installer
+    - python-wheel
 checkdeps  :
+    - python-pytest
+    - python-pytest-asyncio
     - python-pytest-mock
     - python-pytest-timeout
     - virtualenv
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    # Operation probably succeeds because tests are run as root
+    %pytest -v --deselect tests/test_strict_soft.py::test_strict_soft_unreadable_claim_fails_closed

--- a/packages/py/python-filelock/pspec_x86_64.xml
+++ b/packages/py/python-filelock/pspec_x86_64.xml
@@ -3,10 +3,10 @@
         <Name>python-filelock</Name>
         <Homepage>https://github.com/tox-dev/py-filelock/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
-        <License>Unlicense</License>
+        <License>MIT</License>
         <PartOf>programming.python</PartOf>
         <Summary xml:lang="en">A platform independent file lock for Python</Summary>
         <Description xml:lang="en">This package contains a single module, which implements a platform independent file lock in Python, which provides a simple way of inter-process communication.
@@ -20,19 +20,37 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock-3.17.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock-3.17.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock-3.17.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock-3.17.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock-3.32.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock-3.32.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock-3.32.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock-3.32.2.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/__init__.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_api.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_api.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_async.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_async.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_async_read_write.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_async_read_write.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_descriptor.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_descriptor.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_error.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_error.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_identity.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_identity.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_lease.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_lease.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_marker.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_marker.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_read_write.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_read_write.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_soft.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_soft.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_soft_protocol.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_soft_protocol.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_strict.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_strict.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_unix.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_unix.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/_util.cpython-314.opt-1.pyc</Path>
@@ -44,8 +62,26 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/version.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/__pycache__/version.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_api.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_async.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_async_read_write.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_descriptor.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_error.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_identity.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_lease.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_marker.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_read_write.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_soft.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_soft_protocol.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_soft_rw/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_soft_rw/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_soft_rw/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_soft_rw/__pycache__/_async.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_soft_rw/__pycache__/_async.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_soft_rw/__pycache__/_sync.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_soft_rw/__pycache__/_sync.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_soft_rw/_async.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_soft_rw/_sync.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_strict.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_unix.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_util.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/filelock/_windows.py</Path>
@@ -55,12 +91,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-06-06</Date>
-            <Version>3.17.0</Version>
+        <Update release="21">
+            <Date>2026-08-08</Date>
+            <Version>3.32.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changelog available [here](https://github.com/tox-dev/filelock/blob/3.32.2/docs/changelog.rst).

Depends on https://github.com/getsolus/packages/pull/10051

**Test Plan**

See that the test suite passed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
