### PR TITLE
gnome-control-center: Drop libgnomekbd dep

### DIFF
--- a/packages/g/gnome-control-center/package.yml
+++ b/packages/g/gnome-control-center/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-control-center
 version    : '50.4'
-release    : 190
+release    : 191
 source     :
     - https://download.gnome.org/sources/gnome-control-center/50/gnome-control-center-50.4.tar.xz : 5856c73999bedf45e74f73bac3d61e2b5ec1689f8bcf1943737baeee8204fb11
 homepage   : https://apps.gnome.org/Settings/
@@ -59,7 +59,6 @@ rundeps    :
     - gnome-keyring
     - gnome-remote-desktop
     - gvfs-goa
-    - libgnomekbd
     - sound-theme-freedesktop
     - tecla
 environment: |

--- a/packages/g/gnome-control-center/pspec_x86_64.xml
+++ b/packages/g/gnome-control-center/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-control-center</Name>
         <Homepage>https://apps.gnome.org/Settings/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>alfi@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -334,19 +334,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="190">gnome-control-center</Dependency>
+            <Dependency release="191">gnome-control-center</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/pkgconfig/gnome-keybindings.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="190">
-            <Date>2026-08-07</Date>
+        <Update release="191">
+            <Date>2026-08-08</Date>
             <Version>50.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>alfi@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
It was replaced by `tecla` somewhere around GNOME 45, and no longer uses `libgnomekbd` even if present.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

TBD (GCC doesn't run on non-GNOME). If a GNOME user could test this, that would be great.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
