### PR TITLE
ibus: Update to v1.5.34

### DIFF
--- a/packages/i/ibus/abi_symbols
+++ b/packages/i/ibus/abi_symbols
@@ -2,6 +2,9 @@ im-ibus.so:g_module_check_init
 im-ibus.so:ibus_im_context_get_type
 im-ibus.so:ibus_im_context_new
 im-ibus.so:ibus_im_context_register_type
+im-ibus.so:ibus_themed_rgba_get_colors
+im-ibus.so:ibus_themed_rgba_get_type
+im-ibus.so:ibus_themed_rgba_new
 im-ibus.so:im_get_context_id
 im-ibus.so:im_module_create
 im-ibus.so:im_module_exit
@@ -12,7 +15,10 @@ libibus-1.0.so.5:ibus_accelerator_parse
 libibus-1.0.so.5:ibus_accelerator_valid
 libibus-1.0.so.5:ibus_attr_background_new
 libibus-1.0.so.5:ibus_attr_foreground_new
+libibus-1.0.so.5:ibus_attr_hint_new
 libibus-1.0.so.5:ibus_attr_list_append
+libibus-1.0.so.5:ibus_attr_list_copy_format_to_hint
+libibus-1.0.so.5:ibus_attr_list_copy_format_to_rgba
 libibus-1.0.so.5:ibus_attr_list_get
 libibus-1.0.so.5:ibus_attr_list_get_type
 libibus-1.0.so.5:ibus_attr_list_new
@@ -129,9 +135,11 @@ libibus-1.0.so.5:ibus_component_new_from_xml_node
 libibus-1.0.so.5:ibus_component_new_varargs
 libibus-1.0.so.5:ibus_component_output
 libibus-1.0.so.5:ibus_component_output_engines
+libibus-1.0.so.5:ibus_compose_error_quark
 libibus-1.0.so.5:ibus_compose_key_flag
 libibus-1.0.so.5:ibus_compose_table_check
 libibus-1.0.so.5:ibus_compose_table_deserialize
+libibus-1.0.so.5:ibus_compose_table_free
 libibus-1.0.so.5:ibus_compose_table_list_add_array
 libibus-1.0.so.5:ibus_compose_table_list_add_file
 libibus-1.0.so.5:ibus_compose_table_list_add_table
@@ -203,9 +211,11 @@ libibus-1.0.so.5:ibus_engine_get_type
 libibus-1.0.so.5:ibus_engine_hide_auxiliary_text
 libibus-1.0.so.5:ibus_engine_hide_lookup_table
 libibus-1.0.so.5:ibus_engine_hide_preedit_text
+libibus-1.0.so.5:ibus_engine_msg_code_get_type
 libibus-1.0.so.5:ibus_engine_new
 libibus-1.0.so.5:ibus_engine_new_with_type
 libibus-1.0.so.5:ibus_engine_register_properties
+libibus-1.0.so.5:ibus_engine_send_message
 libibus-1.0.so.5:ibus_engine_show_auxiliary_text
 libibus-1.0.so.5:ibus_engine_show_lookup_table
 libibus-1.0.so.5:ibus_engine_show_preedit_text
@@ -235,6 +245,7 @@ libibus-1.0.so.5:ibus_factory_new
 libibus-1.0.so.5:ibus_free_strv
 libibus-1.0.so.5:ibus_get_address
 libibus-1.0.so.5:ibus_get_daemon_uid
+libibus-1.0.so.5:ibus_get_group_name
 libibus-1.0.so.5:ibus_get_language_name
 libibus-1.0.so.5:ibus_get_local_machine_id
 libibus-1.0.so.5:ibus_get_session_id
@@ -286,6 +297,8 @@ libibus-1.0.so.5:ibus_input_context_set_cursor_location
 libibus-1.0.so.5:ibus_input_context_set_cursor_location_relative
 libibus-1.0.so.5:ibus_input_context_set_engine
 libibus-1.0.so.5:ibus_input_context_set_post_process_key_event
+libibus-1.0.so.5:ibus_input_context_set_preedit_format
+libibus-1.0.so.5:ibus_input_context_set_selected_color
 libibus-1.0.so.5:ibus_input_context_set_surrounding_text
 libibus-1.0.so.5:ibus_input_hints_get_type
 libibus-1.0.so.5:ibus_input_purpose_get_type
@@ -297,6 +310,7 @@ libibus-1.0.so.5:ibus_keymap_get_type
 libibus-1.0.so.5:ibus_keymap_lookup_keysym
 libibus-1.0.so.5:ibus_keymap_new
 libibus-1.0.so.5:ibus_keysym_to_unicode
+libibus-1.0.so.5:ibus_keysym_to_unicode_with_layout
 libibus-1.0.so.5:ibus_keyval_convert_case
 libibus-1.0.so.5:ibus_keyval_from_name
 libibus-1.0.so.5:ibus_keyval_name
@@ -328,6 +342,16 @@ libibus-1.0.so.5:ibus_lookup_table_set_orientation
 libibus-1.0.so.5:ibus_lookup_table_set_page_size
 libibus-1.0.so.5:ibus_lookup_table_set_round
 libibus-1.0.so.5:ibus_main
+libibus-1.0.so.5:ibus_message_domain_get_type
+libibus-1.0.so.5:ibus_message_get_code
+libibus-1.0.so.5:ibus_message_get_description
+libibus-1.0.so.5:ibus_message_get_domain
+libibus-1.0.so.5:ibus_message_get_progress
+libibus-1.0.so.5:ibus_message_get_serial
+libibus-1.0.so.5:ibus_message_get_timeout
+libibus-1.0.so.5:ibus_message_get_title
+libibus-1.0.so.5:ibus_message_get_type
+libibus-1.0.so.5:ibus_message_new
 libibus-1.0.so.5:ibus_modifier_type_get_type
 libibus-1.0.so.5:ibus_object_destroy
 libibus-1.0.so.5:ibus_object_flags_get_type
@@ -346,6 +370,7 @@ libibus-1.0.so.5:ibus_panel_service_cursor_down
 libibus-1.0.so.5:ibus_panel_service_cursor_up
 libibus-1.0.so.5:ibus_panel_service_forward_process_key_event
 libibus-1.0.so.5:ibus_panel_service_get_type
+libibus-1.0.so.5:ibus_panel_service_msg_code_get_type
 libibus-1.0.so.5:ibus_panel_service_new
 libibus-1.0.so.5:ibus_panel_service_page_down
 libibus-1.0.so.5:ibus_panel_service_page_up
@@ -354,10 +379,14 @@ libibus-1.0.so.5:ibus_panel_service_panel_extension_register_keys
 libibus-1.0.so.5:ibus_panel_service_property_activate
 libibus-1.0.so.5:ibus_panel_service_property_hide
 libibus-1.0.so.5:ibus_panel_service_property_show
+libibus-1.0.so.5:ibus_panel_service_send_message
+libibus-1.0.so.5:ibus_panel_service_set_preedit_format
+libibus-1.0.so.5:ibus_panel_service_set_selected_color
 libibus-1.0.so.5:ibus_panel_service_update_auxiliary_text_received
 libibus-1.0.so.5:ibus_panel_service_update_lookup_table_received
 libibus-1.0.so.5:ibus_panel_service_update_preedit_text_received
 libibus-1.0.so.5:ibus_preedit_focus_mode_get_type
+libibus-1.0.so.5:ibus_preedit_format_get_type
 libibus-1.0.so.5:ibus_prop_list_append
 libibus-1.0.so.5:ibus_prop_list_get
 libibus-1.0.so.5:ibus_prop_list_get_type
@@ -489,4 +518,7 @@ libim-ibus.so:g_io_im_ibus_unload
 libim-ibus.so:ibus_im_context_get_type
 libim-ibus.so:ibus_im_context_new
 libim-ibus.so:ibus_im_context_register_type
+libim-ibus.so:ibus_themed_rgba_get_colors
+libim-ibus.so:ibus_themed_rgba_get_type
+libim-ibus.so:ibus_themed_rgba_new
 libim-ibus.so:im_get_context_id

--- a/packages/i/ibus/abi_used_symbols
+++ b/packages/i/ibus/abi_used_symbols
@@ -63,6 +63,8 @@ libc.so.6:free
 libc.so.6:fstat
 libc.so.6:fwrite
 libc.so.6:getenv
+libc.so.6:getgid
+libc.so.6:getgrgid_r
 libc.so.6:getopt_long
 libc.so.6:getpid
 libc.so.6:getppid
@@ -99,8 +101,6 @@ libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:sysconf
 libc.so.6:textdomain
 libc.so.6:waitpid
@@ -137,6 +137,7 @@ libgdk-3.so.0:gdk_device_get_associated_device
 libgdk-3.so.0:gdk_device_get_position_double
 libgdk-3.so.0:gdk_device_get_source
 libgdk-3.so.0:gdk_device_get_state
+libgdk-3.so.0:gdk_display_beep
 libgdk-3.so.0:gdk_display_get_default
 libgdk-3.so.0:gdk_display_get_default_screen
 libgdk-3.so.0:gdk_display_get_default_seat
@@ -170,7 +171,9 @@ libgdk-3.so.0:gdk_monitor_get_geometry
 libgdk-3.so.0:gdk_monitor_get_workarea
 libgdk-3.so.0:gdk_pixbuf_get_from_surface
 libgdk-3.so.0:gdk_property_get
-libgdk-3.so.0:gdk_rgba_free
+libgdk-3.so.0:gdk_rectangle_get_type
+libgdk-3.so.0:gdk_rgba_copy
+libgdk-3.so.0:gdk_rgba_get_type
 libgdk-3.so.0:gdk_rgba_parse
 libgdk-3.so.0:gdk_screen_get_root_window
 libgdk-3.so.0:gdk_seat_get_pointer
@@ -210,6 +213,7 @@ libgio-2.0.so.0:g_action_map_add_action
 libgio-2.0.so.0:g_application_command_line_get_arguments
 libgio-2.0.so.0:g_application_command_line_print
 libgio-2.0.so.0:g_application_hold
+libgio-2.0.so.0:g_application_quit
 libgio-2.0.so.0:g_application_release
 libgio-2.0.so.0:g_application_run
 libgio-2.0.so.0:g_application_set_inactivity_timeout
@@ -217,7 +221,6 @@ libgio-2.0.so.0:g_async_initable_get_type
 libgio-2.0.so.0:g_async_initable_new_async
 libgio-2.0.so.0:g_async_initable_new_finish
 libgio-2.0.so.0:g_async_result_get_source_object
-libgio-2.0.so.0:g_async_result_get_type
 libgio-2.0.so.0:g_bus_get
 libgio-2.0.so.0:g_bus_get_finish
 libgio-2.0.so.0:g_bus_get_sync
@@ -229,7 +232,6 @@ libgio-2.0.so.0:g_bus_watch_name_with_closures
 libgio-2.0.so.0:g_cancellable_cancel
 libgio-2.0.so.0:g_cancellable_connect
 libgio-2.0.so.0:g_cancellable_disconnect
-libgio-2.0.so.0:g_cancellable_get_type
 libgio-2.0.so.0:g_cancellable_is_cancelled
 libgio-2.0.so.0:g_cancellable_new
 libgio-2.0.so.0:g_cancellable_reset
@@ -285,7 +287,6 @@ libgio-2.0.so.0:g_dbus_message_get_member
 libgio-2.0.so.0:g_dbus_message_get_message_type
 libgio-2.0.so.0:g_dbus_message_get_path
 libgio-2.0.so.0:g_dbus_message_get_sender
-libgio-2.0.so.0:g_dbus_message_get_type
 libgio-2.0.so.0:g_dbus_message_get_unix_fd_list
 libgio-2.0.so.0:g_dbus_message_new_method_error
 libgio-2.0.so.0:g_dbus_message_new_signal
@@ -330,12 +331,15 @@ libgio-2.0.so.0:g_file_monitor_cancel
 libgio-2.0.so.0:g_file_monitor_file
 libgio-2.0.so.0:g_file_new_for_path
 libgio-2.0.so.0:g_file_query_exists
+libgio-2.0.so.0:g_file_replace
 libgio-2.0.so.0:g_initable_get_type
 libgio-2.0.so.0:g_initable_new
 libgio-2.0.so.0:g_io_error_quark
 libgio-2.0.so.0:g_io_extension_point_implement
 libgio-2.0.so.0:g_menu_append
 libgio-2.0.so.0:g_menu_new
+libgio-2.0.so.0:g_output_stream_close
+libgio-2.0.so.0:g_output_stream_write
 libgio-2.0.so.0:g_resources_lookup_data
 libgio-2.0.so.0:g_settings_get_boolean
 libgio-2.0.so.0:g_settings_get_int
@@ -365,7 +369,6 @@ libgio-2.0.so.0:g_task_get_name
 libgio-2.0.so.0:g_task_get_source_object
 libgio-2.0.so.0:g_task_get_source_tag
 libgio-2.0.so.0:g_task_had_error
-libgio-2.0.so.0:g_task_is_valid
 libgio-2.0.so.0:g_task_new
 libgio-2.0.so.0:g_task_propagate_pointer
 libgio-2.0.so.0:g_task_return_boolean
@@ -427,6 +430,7 @@ libglib-2.0.so.0:g_file_set_contents
 libglib-2.0.so.0:g_file_test
 libglib-2.0.so.0:g_find_program_in_path
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_free_sized
 libglib-2.0.so.0:g_get_application_name
 libglib-2.0.so.0:g_get_environ
 libglib-2.0.so.0:g_get_home_dir
@@ -473,7 +477,6 @@ libglib-2.0.so.0:g_list_last
 libglib-2.0.so.0:g_list_length
 libglib-2.0.so.0:g_list_prepend
 libglib-2.0.so.0:g_list_remove
-libglib-2.0.so.0:g_list_remove_link
 libglib-2.0.so.0:g_list_sort
 libglib-2.0.so.0:g_list_sort_with_data
 libglib-2.0.so.0:g_locale_from_utf8
@@ -548,7 +551,12 @@ libglib-2.0.so.0:g_queue_pop_head
 libglib-2.0.so.0:g_queue_push_tail
 libglib-2.0.so.0:g_realloc
 libglib-2.0.so.0:g_realloc_n
+libglib-2.0.so.0:g_regex_error_quark
+libglib-2.0.so.0:g_regex_escape_string
 libglib-2.0.so.0:g_regex_match_simple
+libglib-2.0.so.0:g_regex_new
+libglib-2.0.so.0:g_regex_replace_literal
+libglib-2.0.so.0:g_regex_unref
 libglib-2.0.so.0:g_return_if_fail_warning
 libglib-2.0.so.0:g_set_error
 libglib-2.0.so.0:g_setenv
@@ -558,6 +566,7 @@ libglib-2.0.so.0:g_slice_free1
 libglib-2.0.so.0:g_slist_append
 libglib-2.0.so.0:g_slist_copy
 libglib-2.0.so.0:g_slist_copy_deep
+libglib-2.0.so.0:g_slist_delete_link
 libglib-2.0.so.0:g_slist_find_custom
 libglib-2.0.so.0:g_slist_foreach
 libglib-2.0.so.0:g_slist_free
@@ -566,7 +575,6 @@ libglib-2.0.so.0:g_slist_insert_sorted
 libglib-2.0.so.0:g_slist_length
 libglib-2.0.so.0:g_slist_prepend
 libglib-2.0.so.0:g_slist_remove
-libglib-2.0.so.0:g_slist_remove_link
 libglib-2.0.so.0:g_slist_sort
 libglib-2.0.so.0:g_source_add_poll
 libglib-2.0.so.0:g_source_attach
@@ -612,6 +620,7 @@ libglib-2.0.so.0:g_string_free_and_steal
 libglib-2.0.so.0:g_string_insert_c
 libglib-2.0.so.0:g_string_insert_len
 libglib-2.0.so.0:g_string_new
+libglib-2.0.so.0:g_string_prepend
 libglib-2.0.so.0:g_string_set_size
 libglib-2.0.so.0:g_strjoinv
 libglib-2.0.so.0:g_strndup
@@ -630,6 +639,7 @@ libglib-2.0.so.0:g_tree_lookup_extended
 libglib-2.0.so.0:g_tree_new_full
 libglib-2.0.so.0:g_tree_remove
 libglib-2.0.so.0:g_ucs4_to_utf8
+libglib-2.0.so.0:g_unichar_get_script
 libglib-2.0.so.0:g_unichar_isalnum
 libglib-2.0.so.0:g_unichar_iscntrl
 libglib-2.0.so.0:g_unichar_isgraph
@@ -682,6 +692,7 @@ libglib-2.0.so.0:g_variant_get_int32
 libglib-2.0.so.0:g_variant_get_size
 libglib-2.0.so.0:g_variant_get_string
 libglib-2.0.so.0:g_variant_get_variant
+libglib-2.0.so.0:g_variant_is_floating
 libglib-2.0.so.0:g_variant_iter_free
 libglib-2.0.so.0:g_variant_iter_init
 libglib-2.0.so.0:g_variant_iter_loop
@@ -706,7 +717,6 @@ libglib-2.0.so.0:g_variant_ref
 libglib-2.0.so.0:g_variant_ref_sink
 libglib-2.0.so.0:g_variant_store
 libglib-2.0.so.0:g_variant_take_ref
-libglib-2.0.so.0:g_variant_type_checked_
 libglib-2.0.so.0:g_variant_type_free
 libglib-2.0.so.0:g_variant_type_new
 libglib-2.0.so.0:g_variant_unref
@@ -742,6 +752,7 @@ libgobject-2.0.so.0:g_object_interface_install_property
 libgobject-2.0.so.0:g_object_is_floating
 libgobject-2.0.so.0:g_object_new
 libgobject-2.0.so.0:g_object_new_valist
+libgobject-2.0.so.0:g_object_new_with_properties
 libgobject-2.0.so.0:g_object_notify
 libgobject-2.0.so.0:g_object_notify_by_pspec
 libgobject-2.0.so.0:g_object_ref
@@ -765,6 +776,7 @@ libgobject-2.0.so.0:g_param_spec_object
 libgobject-2.0.so.0:g_param_spec_pointer
 libgobject-2.0.so.0:g_param_spec_string
 libgobject-2.0.so.0:g_param_spec_types
+libgobject-2.0.so.0:g_param_spec_uchar
 libgobject-2.0.so.0:g_param_spec_uint
 libgobject-2.0.so.0:g_param_spec_ulong
 libgobject-2.0.so.0:g_param_spec_unichar
@@ -834,6 +846,7 @@ libgobject-2.0.so.0:g_value_set_int
 libgobject-2.0.so.0:g_value_set_object
 libgobject-2.0.so.0:g_value_set_pointer
 libgobject-2.0.so.0:g_value_set_string
+libgobject-2.0.so.0:g_value_set_uchar
 libgobject-2.0.so.0:g_value_set_uint
 libgobject-2.0.so.0:g_value_set_ulong
 libgobject-2.0.so.0:g_value_set_variant
@@ -867,8 +880,10 @@ libgtk-3.so.0:gtk_box_pack_start
 libgtk-3.so.0:gtk_box_set_homogeneous
 libgtk-3.so.0:gtk_button_get_type
 libgtk-3.so.0:gtk_button_new
+libgtk-3.so.0:gtk_button_new_with_label
 libgtk-3.so.0:gtk_button_set_image
 libgtk-3.so.0:gtk_button_set_relief
+libgtk-3.so.0:gtk_button_set_use_underline
 libgtk-3.so.0:gtk_cairo_should_draw_window
 libgtk-3.so.0:gtk_check_menu_item_get_active
 libgtk-3.so.0:gtk_check_menu_item_get_type
@@ -926,10 +941,12 @@ libgtk-3.so.0:gtk_label_set_line_wrap
 libgtk-3.so.0:gtk_label_set_markup
 libgtk-3.so.0:gtk_label_set_max_width_chars
 libgtk-3.so.0:gtk_label_set_text
+libgtk-3.so.0:gtk_label_set_width_chars
 libgtk-3.so.0:gtk_list_box_get_row_at_index
 libgtk-3.so.0:gtk_list_box_get_row_at_y
 libgtk-3.so.0:gtk_list_box_get_selected_row
 libgtk-3.so.0:gtk_list_box_get_type
+libgtk-3.so.0:gtk_list_box_insert
 libgtk-3.so.0:gtk_list_box_invalidate_filter
 libgtk-3.so.0:gtk_list_box_row_get_index
 libgtk-3.so.0:gtk_list_box_row_get_type
@@ -964,6 +981,7 @@ libgtk-3.so.0:gtk_popover_popup
 libgtk-3.so.0:gtk_progress_bar_new
 libgtk-3.so.0:gtk_progress_bar_set_ellipsize
 libgtk-3.so.0:gtk_progress_bar_set_fraction
+libgtk-3.so.0:gtk_progress_bar_set_text
 libgtk-3.so.0:gtk_radio_menu_item_get_group
 libgtk-3.so.0:gtk_radio_menu_item_get_type
 libgtk-3.so.0:gtk_radio_menu_item_set_group
@@ -990,12 +1008,9 @@ libgtk-3.so.0:gtk_status_icon_set_visible
 libgtk-3.so.0:gtk_style_context_add_class
 libgtk-3.so.0:gtk_style_context_add_provider
 libgtk-3.so.0:gtk_style_context_add_provider_for_screen
-libgtk-3.so.0:gtk_style_context_get
+libgtk-3.so.0:gtk_style_context_get_type
 libgtk-3.so.0:gtk_style_context_lookup_color
-libgtk-3.so.0:gtk_style_context_new
 libgtk-3.so.0:gtk_style_context_remove_provider_for_screen
-libgtk-3.so.0:gtk_style_context_set_parent
-libgtk-3.so.0:gtk_style_context_set_path
 libgtk-3.so.0:gtk_text_buffer_get_has_selection
 libgtk-3.so.0:gtk_text_buffer_get_insert
 libgtk-3.so.0:gtk_text_buffer_get_iter_at_mark
@@ -1003,6 +1018,7 @@ libgtk-3.so.0:gtk_text_buffer_get_selection_bounds
 libgtk-3.so.0:gtk_text_iter_get_offset
 libgtk-3.so.0:gtk_text_view_get_buffer
 libgtk-3.so.0:gtk_text_view_get_type
+libgtk-3.so.0:gtk_text_view_new
 libgtk-3.so.0:gtk_toggle_tool_button_get_active
 libgtk-3.so.0:gtk_toggle_tool_button_get_type
 libgtk-3.so.0:gtk_toggle_tool_button_set_active
@@ -1022,8 +1038,10 @@ libgtk-3.so.0:gtk_widget_get_allocation
 libgtk-3.so.0:gtk_widget_get_default_direction
 libgtk-3.so.0:gtk_widget_get_display
 libgtk-3.so.0:gtk_widget_get_name
+libgtk-3.so.0:gtk_widget_get_pango_context
 libgtk-3.so.0:gtk_widget_get_preferred_width
 libgtk-3.so.0:gtk_widget_get_scale_factor
+libgtk-3.so.0:gtk_widget_get_style
 libgtk-3.so.0:gtk_widget_get_style_context
 libgtk-3.so.0:gtk_widget_get_toplevel
 libgtk-3.so.0:gtk_widget_get_type
@@ -1031,10 +1049,8 @@ libgtk-3.so.0:gtk_widget_get_visible
 libgtk-3.so.0:gtk_widget_get_window
 libgtk-3.so.0:gtk_widget_grab_focus
 libgtk-3.so.0:gtk_widget_hide
-libgtk-3.so.0:gtk_widget_path_append_type
-libgtk-3.so.0:gtk_widget_path_new
-libgtk-3.so.0:gtk_widget_path_unref
 libgtk-3.so.0:gtk_widget_queue_draw
+libgtk-3.so.0:gtk_widget_set_can_default
 libgtk-3.so.0:gtk_widget_set_events
 libgtk-3.so.0:gtk_widget_set_halign
 libgtk-3.so.0:gtk_widget_set_margin_bottom
@@ -1100,8 +1116,13 @@ libpango-1.0.so.0:pango_font_description_from_string
 libpango-1.0.so.0:pango_font_description_get_family
 libpango-1.0.so.0:pango_font_description_get_size
 libpango-1.0.so.0:pango_font_description_get_type
+libpango-1.0.so.0:pango_font_has_char
+libpango-1.0.so.0:pango_glyph_item_get_type
 libpango-1.0.so.0:pango_language_from_string
+libpango-1.0.so.0:pango_layout_get_line_readonly
 libpango-1.0.so.0:pango_layout_get_size
+libpango-1.0.so.0:pango_layout_line_get_pixel_extents
+libpango-1.0.so.0:pango_layout_new
 libpango-1.0.so.0:pango_layout_set_font_description
 libpango-1.0.so.0:pango_layout_set_text
 libpangocairo-1.0.so.0:pango_cairo_create_layout

--- a/packages/i/ibus/files/segv-bus-proxy.patch
+++ b/packages/i/ibus/files/segv-bus-proxy.patch
@@ -1,6 +1,6 @@
-From 1286ce92a5ccf68b5dcf1b4a7c0884ce29d5c51b Mon Sep 17 00:00:00 2001
+From 656390df46ba963afe51420ecb9399b6dde9a2bd Mon Sep 17 00:00:00 2001
 From: fujiwarat <takao.fujiwara1@gmail.com>
-Date: Fri, 12 Jul 2024 23:30:25 +0900
+Date: Thu, 30 Apr 2026 09:00:00 +0900
 Subject: [PATCH] Fix SEGV in bus_panel_proxy_focus_in()
 
 rhbz#1350291 SEGV in BUS_IS_CONNECTION(skip_connection) in
@@ -21,9 +21,6 @@ WIP: Add a GError to get the error message to check why the SEGV happened.
 rhbz#1663528 SEGV in g_mutex_clear() in bus_dbus_impl_destroy()
 If the mutex is not unlocked, g_mutex_clear() causes assert.
 
-rhbz#1767691 SEGV in client/x11/main.c:_sighandler().
-Do not call atexit functions in _sighandler().
-
 rhbz#2195895 SEGV in client/x11/main.c:_xim_set_cursor_location()
 check if IBusInputContext was disconnected.
 
@@ -35,9 +32,6 @@ rhbz#1771238 SEGV in assert(m_loop == null) in switcher.vala.
 Grabbing keyboard could be failed and switcher received the keyboard
 events and m_loop was not released.
 
-rhbz#1797120 SEGV in assert(bus.is_connected()) in panel_binding_construct()
-Check m_ibus in extension.vala:bus_name_acquired_cb()
-
 rhbz#2151344 SEGV with portal_context->owner in name_owner_changed()
 Maybe g_object_unref() is called but not finalized yet.
 
@@ -45,33 +39,37 @@ rhbz#2239633 SEGV with g_object_unref() in
 ibus_portal_context_handle_destroy()
 Connect "handle-destroy" signal after g_list_prepend().
 
-BUG=rhbz#1350291
-BUG=rhbz#1601577
-BUG=rhbz#1663528
-BUG=rhbz#1767691
-BUG=rhbz#1795499
-BUG=rhbz#1771238
-BUG=rhbz#1767976
-BUG=rhbz#1797120
-BUG=rhbz#2151344
-BUG=rhbz#2195895
-BUG=rhbz#2239633
+rhbz#2480408 SEGV with zwp_input_method_context_v1_preedit_string() in
+_context_hide_preedit_text_cb()
+If the `zwp_input_method_context_v1` is deactivate, the `IBusIMContext`
+is should be cleared and the "hide-preedit-text" signal is also
+disconnected.
+
+Closes: rhbz#1350291
+Closes: rhbz#1601577
+Closes: rhbz#1663528
+Closes: rhbz#1795499
+Closes: rhbz#1771238
+Closes: rhbz#1767976
+Closes: rhbz#2151344
+Closes: rhbz#2195895
+Closes: rhbz#2239633
+Closes: rhbz#2480408
 ---
- bus/dbusimpl.c         | 47 ++++++++++++++++++++++++---
- bus/engineproxy.c      | 44 +++++++++++++++++++------
- bus/panelproxy.c       |  9 +++++-
- client/x11/main.c      | 56 ++++++++++++++++++++++++++++----
- portal/portal.c        | 25 ++++++++++++---
- src/ibusbus.c          |  6 ++++
- ui/gtk3/extension.vala |  4 +++
- ui/gtk3/switcher.vala  | 73 +++++++++++++++++++++++++-----------------
- 8 files changed, 208 insertions(+), 56 deletions(-)
+ bus/engineproxy.c              | 44 +++++++++++++++++++++++-------
+ bus/panelproxy.c               |  9 ++++++-
+ client/wayland/ibuswaylandim.c | 20 +++++++++++++-
+ client/x11/main.c              | 49 ++++++++++++++++++++++++++++++----
+ portal/portal.c                | 25 +++++++++++++----
+ src/ibusbus.c                  |  6 +++++
+ ui/gtk3/switcher.vala          | 48 ++++++++++++++++++++-------------
+ 8 files changed, 203 insertions(+), 45 deletions(-)
 
 diff --git a/bus/dbusimpl.c b/bus/dbusimpl.c
-index 110d864a..391d576a 100644
+index 70792be..9c535bf 100644
 --- a/bus/dbusimpl.c
 +++ b/bus/dbusimpl.c
-@@ -621,6 +621,7 @@ static void
+@@ -634,6 +634,7 @@ static void
  bus_dbus_impl_destroy (BusDBusImpl *dbus)
  {
      GList *p;
@@ -79,7 +77,7 @@ index 110d864a..391d576a 100644
  
      for (p = dbus->objects; p != NULL; p = p->next) {
          IBusService *object = (IBusService *) p->data;
-@@ -644,6 +645,10 @@ bus_dbus_impl_destroy (BusDBusImpl *dbus)
+@@ -657,6 +658,10 @@ bus_dbus_impl_destroy (BusDBusImpl *dbus)
  
      for (p = dbus->connections; p != NULL; p = p->next) {
          BusConnection *connection = BUS_CONNECTION (p->data);
@@ -90,7 +88,7 @@ index 110d864a..391d576a 100644
          g_signal_handlers_disconnect_by_func (connection,
                  bus_dbus_impl_connection_destroy_cb, dbus);
          ibus_object_destroy (IBUS_OBJECT (connection));
-@@ -658,12 +663,39 @@ bus_dbus_impl_destroy (BusDBusImpl *dbus)
+@@ -675,12 +680,39 @@ bus_dbus_impl_destroy (BusDBusImpl *dbus)
      dbus->unique_names = NULL;
      dbus->names = NULL;
  
@@ -132,7 +130,7 @@ index 110d864a..391d576a 100644
  
      /* FIXME destruct _lock and _queue members. */
      IBUS_OBJECT_CLASS(bus_dbus_impl_parent_class)->destroy ((IBusObject *)dbus);
-@@ -1539,13 +1571,20 @@ bus_dbus_impl_connection_filter_cb (GDBusConnection *dbus_connection,
+@@ -1556,13 +1588,20 @@ bus_dbus_impl_connection_filter_cb (GDBusConnection *dbus_connection,
                                      gboolean         incoming,
                                      gpointer         user_data)
  {
@@ -156,10 +154,10 @@ index 110d864a..391d576a 100644
      if (incoming) {
          /* is incoming message */
 diff --git a/bus/engineproxy.c b/bus/engineproxy.c
-index b3e16066..ba479b59 100644
+index 37736b6..7f34604 100644
 --- a/bus/engineproxy.c
 +++ b/bus/engineproxy.c
-@@ -693,10 +693,12 @@ bus_engine_proxy_g_signal (GDBusProxy  *proxy,
+@@ -775,10 +775,12 @@ bus_engine_proxy_g_signal (GDBusProxy  *proxy,
      g_return_if_reached ();
  }
  
@@ -173,7 +171,7 @@ index b3e16066..ba479b59 100644
  {
      GDBusProxyFlags flags;
      BusEngineProxy *engine;
-@@ -706,12 +708,20 @@ bus_engine_proxy_new_internal (const gchar     *path,
+@@ -788,12 +790,20 @@ bus_engine_proxy_new_internal (const gchar     *path,
      g_assert (path);
      g_assert (IBUS_IS_ENGINE_DESC (desc));
      g_assert (G_IS_DBUS_CONNECTION (connection));
@@ -195,7 +193,7 @@ index b3e16066..ba479b59 100644
              "desc",              desc,
              "g-connection",      connection,
              "g-interface-name",  IBUS_INTERFACE_ENGINE,
-@@ -719,6 +729,12 @@ bus_engine_proxy_new_internal (const gchar     *path,
+@@ -801,6 +811,12 @@ bus_engine_proxy_new_internal (const gchar     *path,
              "g-default-timeout", g_gdbus_timeout,
              "g-flags",           flags,
              NULL);
@@ -208,7 +206,7 @@ index b3e16066..ba479b59 100644
      const gchar *layout = ibus_engine_desc_get_layout (desc);
      if (layout != NULL && layout[0] != '\0') {
          engine->keymap = ibus_keymap_get (layout);
-@@ -756,6 +772,7 @@ bus_engine_proxy_new_internal (const gchar     *path,
+@@ -838,6 +854,7 @@ bus_engine_proxy_new_internal (const gchar     *path,
  
      return engine;
  }
@@ -216,7 +214,7 @@ index b3e16066..ba479b59 100644
  
  typedef struct {
      GTask           *task;
-@@ -818,23 +835,30 @@ create_engine_ready_cb (BusFactoryProxy    *factory,
+@@ -900,23 +917,30 @@ create_engine_ready_cb (BusFactoryProxy    *factory,
                          GAsyncResult       *res,
                          EngineProxyNewData *data)
  {
@@ -256,10 +254,10 @@ index b3e16066..ba479b59 100644
      /* FIXME: set destroy callback ? */
      g_task_return_pointer (data->task, engine, NULL);
 diff --git a/bus/panelproxy.c b/bus/panelproxy.c
-index e6001ebf..00828fbc 100644
+index 4c2c888..a7bec19 100644
 --- a/bus/panelproxy.c
 +++ b/bus/panelproxy.c
-@@ -122,6 +122,8 @@ bus_panel_proxy_new (BusConnection *connection,
+@@ -124,6 +124,8 @@ bus_panel_proxy_new (BusConnection *connection,
      const gchar *path = NULL;
      GObject *obj;
      BusPanelProxy *panel;
@@ -268,7 +266,7 @@ index e6001ebf..00828fbc 100644
  
      g_assert (BUS_IS_CONNECTION (connection));
  
-@@ -138,7 +140,7 @@ bus_panel_proxy_new (BusConnection *connection,
+@@ -140,7 +142,7 @@ bus_panel_proxy_new (BusConnection *connection,
  
      obj = g_initable_new (BUS_TYPE_PANEL_PROXY,
                            NULL,
@@ -277,7 +275,7 @@ index e6001ebf..00828fbc 100644
                            "g-object-path",     path,
                            "g-interface-name",  IBUS_INTERFACE_PANEL,
                            "g-connection",      bus_connection_get_dbus_connection (connection),
-@@ -146,6 +148,11 @@ bus_panel_proxy_new (BusConnection *connection,
+@@ -148,6 +150,11 @@ bus_panel_proxy_new (BusConnection *connection,
                            "g-flags",           G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                            NULL);
  
@@ -289,8 +287,81 @@ index e6001ebf..00828fbc 100644
      panel = BUS_PANEL_PROXY (obj);
      panel->panel_type = panel_type;
      return panel;
+diff --git a/client/wayland/ibuswaylandim.c b/client/wayland/ibuswaylandim.c
+index 5762f10..f1e3b9e 100644
+--- a/client/wayland/ibuswaylandim.c
++++ b/client/wayland/ibuswaylandim.c
+@@ -387,7 +387,7 @@ ibus_wayland_im_commit_text (IBusWaylandIM *wlim,
+                              const char    *str)
+ {
+     IBusWaylandIMPrivate *priv;
+-    g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
++    g_assert (IBUS_IS_WAYLAND_IM (wlim));
+     priv = ibus_wayland_im_get_instance_private (wlim);
+     switch (priv->version) {
+     case INPUT_METHOD_V1:
+@@ -822,6 +822,14 @@ _context_commit_text_cb (IBusInputContext *context,
+                          IBusText         *text,
+                          IBusWaylandIM    *wlim)
+ {
++    IBusWaylandIMPrivate *priv;
++
++    g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
++    priv = ibus_wayland_im_get_instance_private (wlim);
++    /* FIXME: rhbz#2480408 If priv->ibuscontext exists,
++     * priv->context also should exists.
++     */
++    g_assert (priv->ibuscontext);
+     ibus_wayland_im_commit_text (wlim, text->text);
+ }
+ 
+@@ -838,6 +846,8 @@ _context_forward_key_event_cb (IBusInputContext *context,
+ 
+     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
+     priv = ibus_wayland_im_get_instance_private (wlim);
++    /* FIXME: rhbz#2480408 */
++    g_assert (priv->ibuscontext);
+     if (modifiers & IBUS_RELEASE_MASK)
+         state = WL_KEYBOARD_KEY_STATE_RELEASED;
+     else
+@@ -1055,6 +1065,8 @@ _context_show_preedit_text_cb (IBusInputContext *context,
+     const char *commit = "";
+     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
+     priv = ibus_wayland_im_get_instance_private (wlim);
++    /* FIXME: rhbz#2480408 */
++    g_assert (priv->ibuscontext);
+     /* CURSOR is byte offset.  */
+     cursor =
+         g_utf8_offset_to_pointer (priv->preedit_text->text,
+@@ -1098,6 +1110,8 @@ _context_hide_preedit_text_cb (IBusInputContext *context,
+     IBusWaylandIMPrivate *priv;
+     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
+     priv = ibus_wayland_im_get_instance_private (wlim);
++    /* FIXME: rhbz#2480408 */
++    g_assert (priv->ibuscontext);
+     switch (priv->version) {
+     case INPUT_METHOD_V1:
+         zwp_input_method_context_v1_preedit_string (priv->context,
+@@ -1137,6 +1151,8 @@ _context_update_preedit_text_cb (IBusInputContext *context,
+     priv->preedit_cursor_pos = cursor_pos;
+     priv->preedit_mode = mode;
+ 
++    /* FIXME: rhbz#2480408 */
++    g_assert (priv->ibuscontext);
+     if (visible)
+         _context_show_preedit_text_cb (context, wlim);
+     else
+@@ -1161,6 +1177,8 @@ _context_delete_surrounding_text_cb (IBusInputContext *context,
+     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
+     priv = ibus_wayland_im_get_instance_private (wlim);
+ 
++    /* FIXME: rhbz#2480408 */
++    g_assert (priv->ibuscontext);
+     if (!priv->surrounding_text)
+         return;
+ 
 diff --git a/client/x11/main.c b/client/x11/main.c
-index b7eb5961..3075d5d0 100644
+index accebde..cac4cd6 100644
 --- a/client/x11/main.c
 +++ b/client/x11/main.c
 @@ -45,6 +45,7 @@
@@ -436,22 +507,8 @@ index b7eb5961..3075d5d0 100644
  
      ibus_input_context_reset (x11ic->context);
  
-@@ -1309,7 +1348,12 @@ _atexit_cb ()
- static void
- _sighandler (int sig)
- {
--    exit(EXIT_FAILURE);
-+    /* rhbz#1767691 _sighandler() is called with SIGTERM
-+     * and exit() causes SEGV during calling atexit functions.
-+     * _atexit_cb() might be broken. _exit() does not call
-+     * atexit functions.
-+     */
-+    _exit(EXIT_FAILURE);
- }
- 
- static void
 diff --git a/portal/portal.c b/portal/portal.c
-index 5cd38779..5110baad 100644
+index 5cd3877..5110baa 100644
 --- a/portal/portal.c
 +++ b/portal/portal.c
 @@ -92,6 +92,11 @@ static void portal_context_g_signal (GDBusProxy        *proxy,
@@ -510,10 +567,10 @@ index 5cd38779..5110baad 100644
                  g_object_unref (portal_context);
              }
 diff --git a/src/ibusbus.c b/src/ibusbus.c
-index 0e6d67f1..fcc742b6 100644
+index 540d1da..defdb73 100644
 --- a/src/ibusbus.c
 +++ b/src/ibusbus.c
-@@ -742,6 +742,12 @@ ibus_bus_destroy (IBusObject *object)
+@@ -750,6 +750,12 @@ ibus_bus_destroy (IBusObject *object)
      _bus = NULL;
  
      if (bus->priv->monitor) {
@@ -526,26 +583,11 @@ index 0e6d67f1..fcc742b6 100644
          g_object_unref (bus->priv->monitor);
          bus->priv->monitor = NULL;
      }
-diff --git a/ui/gtk3/extension.vala b/ui/gtk3/extension.vala
-index a6f2e8e6..b7a04081 100644
---- a/ui/gtk3/extension.vala
-+++ b/ui/gtk3/extension.vala
-@@ -73,6 +73,10 @@ class ExtensionGtk : Gtk.Application {
-                                       string         signal_name,
-                                       Variant        parameters) {
-         debug("signal_name = %s", signal_name);
-+        /* rhbz#1797120 Fix assert(bus.is_connected()) in
-+         * panel_binding_construct()
-+         */
-+        return_if_fail(m_bus.is_connected());
-         m_panel = new PanelBinding(m_bus, this);
-         m_panel.load_settings();
-     }
 diff --git a/ui/gtk3/switcher.vala b/ui/gtk3/switcher.vala
-index 26bded99..21ede7be 100644
+index d4a5fa1..788eea0 100644
 --- a/ui/gtk3/switcher.vala
 +++ b/ui/gtk3/switcher.vala
-@@ -236,16 +236,18 @@ class Switcher : Gtk.Window {
+@@ -251,27 +251,37 @@ class Switcher : Gtk.Window {
                             null,
                             event,
                             null);
@@ -560,6 +602,13 @@ index 26bded99..21ede7be 100644
 -                           null);
 -        if (status != Gdk.GrabStatus.SUCCESS)
 -            warning("Grab pointer failed! status = %d", status);
+-
+-        // Probably we can delete m_popup_delay_time in 1.6
+-        pointer.get_position_double(null,
+-                                    out m_mouse_init_x,
+-                                    out m_mouse_init_y);
+-        m_mouse_moved = false;
+-
 +        } else {
 +            status = seat.grab(get_window(),
 +                               Gdk.SeatCapabilities.POINTER,
@@ -570,45 +619,10 @@ index 26bded99..21ede7be 100644
 +            if (status != Gdk.GrabStatus.SUCCESS)
 +                warning("Grab pointer failed! status = %d", status);
 +        }
- #else
-         Gdk.Device device = event.get_device();
-         if (device == null) {
-@@ -281,30 +283,41 @@ class Switcher : Gtk.Window {
-                                Gdk.EventMask.KEY_RELEASE_MASK,
-                                null,
-                                Gdk.CURRENT_TIME);
--        if (status != Gdk.GrabStatus.SUCCESS)
-+        if (status != Gdk.GrabStatus.SUCCESS) {
-             warning("Grab keyboard failed! status = %d", status);
--        // Grab all pointer events
--        status = pointer.grab(get_window(),
--                              Gdk.GrabOwnership.NONE,
--                              true,
--                              Gdk.EventMask.BUTTON_PRESS_MASK |
--                              Gdk.EventMask.BUTTON_RELEASE_MASK,
--                              null,
--                              Gdk.CURRENT_TIME);
--        if (status != Gdk.GrabStatus.SUCCESS)
--            warning("Grab pointer failed! status = %d", status);
-+        } else {
-+            // Grab all pointer events
-+            status = pointer.grab(get_window(),
-+                                  Gdk.GrabOwnership.NONE,
-+                                  true,
-+                                  Gdk.EventMask.BUTTON_PRESS_MASK |
-+                                  Gdk.EventMask.BUTTON_RELEASE_MASK,
-+                                  null,
-+                                  Gdk.CURRENT_TIME);
-+            if (status != Gdk.GrabStatus.SUCCESS)
-+                warning("Grab pointer failed! status = %d", status);
-+        }
- #endif
  
--        // Probably we can delete m_popup_delay_time in 1.6
--        pointer.get_position_double(null,
--                                    out m_mouse_init_x,
--                                    out m_mouse_init_y);
--        m_mouse_moved = false;
+-        m_loop = new GLib.MainLoop();
+-        m_loop.run();
+-        m_loop = null;
 +        /* Fix RHBZ #1771238 assert(m_loop == null)
 +         * Grabbing keyboard can be failed when the second Super-e is typed
 +         * before Switcher dialog is focused. And m_loop could not be released
@@ -622,18 +636,14 @@ index 26bded99..21ede7be 100644
 +                                        out m_mouse_init_x,
 +                                        out m_mouse_init_y);
 +            m_mouse_moved = false;
- 
- 
--        m_loop = new GLib.MainLoop();
--        m_loop.run();
--        m_loop = null;
++
 +            m_loop = new GLib.MainLoop();
 +            m_loop.run();
 +            m_loop = null;
 +        }
  
- #if VALA_0_34
          seat.ungrab();
+ 
 -- 
-2.45.0
+2.53.0
 

--- a/packages/i/ibus/package.yml
+++ b/packages/i/ibus/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ibus
-version    : 1.5.32
-release    : 35
+version    : 1.5.34
+release    : 36
 source     :
-    - https://github.com/ibus/ibus/releases/download/1.5.32/ibus-1.5.32.tar.gz : b24f41ae38b236b254c09f1a8f53c2354b69b0789e89cea888d0494b09d15d67
+    - https://github.com/ibus/ibus/releases/download/1.5.34/ibus-1.5.34.tar.gz : 12a72210ce5250f8a66df562a75e034e67b2bce74c4df2983dc86d1154894943
 homepage   : https://github.com/ibus/ibus
 license    : LGPL-2.0-only
 component  : desktop.core
@@ -43,6 +43,7 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
 
     # Pre-compile the dconf db
     pushd data/dconf

--- a/packages/i/ibus/pspec_x86_64.xml
+++ b/packages/i/ibus/pspec_x86_64.xml
@@ -40,7 +40,7 @@
             <Path fileType="library">/usr/lib64/ibus/ibus-wayland</Path>
             <Path fileType="library">/usr/lib64/ibus/ibus-x11</Path>
             <Path fileType="library">/usr/lib64/libibus-1.0.so.5</Path>
-            <Path fileType="library">/usr/lib64/libibus-1.0.so.5.0.532</Path>
+            <Path fileType="library">/usr/lib64/libibus-1.0.so.5.0.534</Path>
             <Path fileType="data">/usr/share/GConf/gsettings/ibus.convert</Path>
             <Path fileType="data">/usr/share/applications/org.freedesktop.IBus.Panel.Emojier.desktop</Path>
             <Path fileType="data">/usr/share/applications/org.freedesktop.IBus.Panel.Extension.Gtk3.desktop</Path>
@@ -187,33 +187,42 @@
             <Path fileType="data">/usr/share/ibus/keymaps/kr</Path>
             <Path fileType="data">/usr/share/ibus/keymaps/modifiers</Path>
             <Path fileType="data">/usr/share/ibus/keymaps/us</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/emojilang.cpython-314.opt-1.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/emojilang.cpython-314.opt-2.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/emojilang.cpython-314.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/engineabout.cpython-314.opt-1.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/engineabout.cpython-314.opt-2.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/engineabout.cpython-314.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/enginecombobox.cpython-314.opt-1.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/enginecombobox.cpython-314.opt-2.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/enginecombobox.cpython-314.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/enginedialog.cpython-314.opt-1.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/enginedialog.cpython-314.opt-2.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/enginedialog.cpython-314.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/enginetreeview.cpython-314.opt-1.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/enginetreeview.cpython-314.opt-2.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/enginetreeview.cpython-314.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/i18n.cpython-314.opt-1.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/i18n.cpython-314.opt-2.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/i18n.cpython-314.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/icon.cpython-314.opt-1.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/icon.cpython-314.opt-2.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/icon.cpython-314.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/keyboardshortcut.cpython-314.opt-1.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/keyboardshortcut.cpython-314.opt-2.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/keyboardshortcut.cpython-314.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/main.cpython-314.opt-1.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/main.cpython-314.opt-2.pyc</Path>
+            <Path fileType="data">/usr/share/ibus/setup/__pycache__/main.cpython-314.pyc</Path>
             <Path fileType="data">/usr/share/ibus/setup/emojilang.py</Path>
-            <Path fileType="data">/usr/share/ibus/setup/emojilang.pyc</Path>
-            <Path fileType="data">/usr/share/ibus/setup/emojilang.pyo</Path>
             <Path fileType="data">/usr/share/ibus/setup/engineabout.py</Path>
-            <Path fileType="data">/usr/share/ibus/setup/engineabout.pyc</Path>
-            <Path fileType="data">/usr/share/ibus/setup/engineabout.pyo</Path>
             <Path fileType="data">/usr/share/ibus/setup/enginecombobox.py</Path>
-            <Path fileType="data">/usr/share/ibus/setup/enginecombobox.pyc</Path>
-            <Path fileType="data">/usr/share/ibus/setup/enginecombobox.pyo</Path>
             <Path fileType="data">/usr/share/ibus/setup/enginedialog.py</Path>
-            <Path fileType="data">/usr/share/ibus/setup/enginedialog.pyc</Path>
-            <Path fileType="data">/usr/share/ibus/setup/enginedialog.pyo</Path>
             <Path fileType="data">/usr/share/ibus/setup/enginetreeview.py</Path>
-            <Path fileType="data">/usr/share/ibus/setup/enginetreeview.pyc</Path>
-            <Path fileType="data">/usr/share/ibus/setup/enginetreeview.pyo</Path>
             <Path fileType="data">/usr/share/ibus/setup/i18n.py</Path>
-            <Path fileType="data">/usr/share/ibus/setup/i18n.pyc</Path>
-            <Path fileType="data">/usr/share/ibus/setup/i18n.pyo</Path>
             <Path fileType="data">/usr/share/ibus/setup/icon.py</Path>
-            <Path fileType="data">/usr/share/ibus/setup/icon.pyc</Path>
-            <Path fileType="data">/usr/share/ibus/setup/icon.pyo</Path>
             <Path fileType="data">/usr/share/ibus/setup/keyboardshortcut.py</Path>
-            <Path fileType="data">/usr/share/ibus/setup/keyboardshortcut.pyc</Path>
-            <Path fileType="data">/usr/share/ibus/setup/keyboardshortcut.pyo</Path>
             <Path fileType="data">/usr/share/ibus/setup/main.py</Path>
-            <Path fileType="data">/usr/share/ibus/setup/main.pyc</Path>
-            <Path fileType="data">/usr/share/ibus/setup/main.pyo</Path>
             <Path fileType="data">/usr/share/ibus/setup/setup.ui</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/ibus-keyboard.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/22x22/apps/ibus-keyboard.png</Path>
@@ -224,6 +233,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/ibus-keyboard.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/ibus-setup.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/ibus.svg</Path>
+            <Path fileType="data">/usr/share/licenses/ibus/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/as/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/ibus10.mo</Path>
@@ -251,6 +261,7 @@
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/kab/LC_MESSAGES/ibus10.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kk/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/kn/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lv/LC_MESSAGES/ibus10.mo</Path>
@@ -265,6 +276,7 @@
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/ibus10.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sq/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/ibus10.mo</Path>
@@ -280,12 +292,12 @@
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_HK/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/ibus10.mo</Path>
-            <Path fileType="man">/usr/share/man/man1/ibus-daemon.1</Path>
-            <Path fileType="man">/usr/share/man/man1/ibus-setup.1</Path>
-            <Path fileType="man">/usr/share/man/man1/ibus.1</Path>
-            <Path fileType="man">/usr/share/man/man5/00-upstream-settings.5</Path>
-            <Path fileType="man">/usr/share/man/man5/ibus.5</Path>
-            <Path fileType="man">/usr/share/man/man7/ibus-emoji.7</Path>
+            <Path fileType="man">/usr/share/man/man1/ibus-daemon.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/ibus-setup.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/ibus.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/00-upstream-settings.5.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/ibus.5.zst</Path>
+            <Path fileType="man">/usr/share/man/man7/ibus-emoji.7.zst</Path>
             <Path fileType="data">/usr/share/xdg/Xwayland-session.d/10-ibus-x11</Path>
         </Files>
     </Package>
@@ -296,9 +308,10 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">ibus</Dependency>
+            <Dependency release="36">ibus</Dependency>
         </RuntimeDependencies>
         <Files>
+            <Path fileType="header">/usr/include/ibus-1.0/ibus-visibility.h</Path>
             <Path fileType="header">/usr/include/ibus-1.0/ibus.h</Path>
             <Path fileType="header">/usr/include/ibus-1.0/ibusaccelgroup.h</Path>
             <Path fileType="header">/usr/include/ibus-1.0/ibusattribute.h</Path>
@@ -322,6 +335,7 @@
             <Path fileType="header">/usr/include/ibus-1.0/ibuskeysyms-compat.h</Path>
             <Path fileType="header">/usr/include/ibus-1.0/ibuskeysyms.h</Path>
             <Path fileType="header">/usr/include/ibus-1.0/ibuslookuptable.h</Path>
+            <Path fileType="header">/usr/include/ibus-1.0/ibusmessage.h</Path>
             <Path fileType="header">/usr/include/ibus-1.0/ibusobject.h</Path>
             <Path fileType="header">/usr/include/ibus-1.0/ibusobservedpath.h</Path>
             <Path fileType="header">/usr/include/ibus-1.0/ibuspanelservice.h</Path>
@@ -408,9 +422,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2025-04-15</Date>
-            <Version>1.5.32</Version>
+        <Update release="36">
+            <Date>2026-08-09</Date>
+            <Version>1.5.34</Version>
             <Comment>Packaging update</Comment>
             <Name>Gavin Zhao</Name>
             <Email>me@gzgz.dev</Email>


### PR DESCRIPTION
**Summary**

Update `ibus` to v1.5.34, the latest release. Also sync the ibus SIGSEV patches from Fedora.

I really only need this for ibus/ibus#2861 so that my ibus doesn't randomly crash after I leave my computer running for a while night, but while I'm there might as well properly update it.

**Test Plan**

- [x] `ibus-rime` runs as usual.
- [ ] Leave it running for 24 hours and make sure it no longer crashes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
