### PR TITLE
apr-util: Update to v1.6.4

### DIFF
--- a/packages/a/apr-util/abi_used_symbols
+++ b/packages/a/apr-util/abi_used_symbols
@@ -1,5 +1,7 @@
 libapr-1.so.0:apr_allocator_align
 libapr-1.so.0:apr_allocator_alloc
+libapr-1.so.0:apr_allocator_create
+libapr-1.so.0:apr_allocator_destroy
 libapr-1.so.0:apr_allocator_free
 libapr-1.so.0:apr_array_make
 libapr-1.so.0:apr_array_push
@@ -157,8 +159,6 @@ libcrypto.so.3:ENGINE_by_id
 libcrypto.so.3:ENGINE_finish
 libcrypto.so.3:ENGINE_free
 libcrypto.so.3:ENGINE_init
-libcrypto.so.3:ENGINE_load_builtin_engines
-libcrypto.so.3:ENGINE_register_all_complete
 libcrypto.so.3:EVP_CIPHER_CTX_free
 libcrypto.so.3:EVP_CIPHER_CTX_new
 libcrypto.so.3:EVP_CIPHER_CTX_reset

--- a/packages/a/apr-util/package.yml
+++ b/packages/a/apr-util/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : apr-util
-version    : 1.6.3
-release    : 20
+version    : 1.6.4
+release    : 21
 source     :
-    - https://dlcdn.apache.org//apr/apr-util-1.6.3.tar.bz2 : a41076e3710746326c3945042994ad9a4fcac0ce0277dd8fea076fec3c9772b5
+    - https://dlcdn.apache.org//apr/apr-util-1.6.4.tar.bz2 : 3e2ae08f40efa0c3701e54a954cefa08242de22a69f91a8ae44fc1e624ba309b
 homepage   : https://apr.apache.org/
 license    : Apache-2.0
 component  : programming
@@ -22,9 +22,9 @@ builddeps  :
     - db5-devel
     - gdbm-devel
 setup      : |
-    %patch -p1 -i $pkgfiles/0001-Prevent-broken-test-from-running.patch
-    %patch -p1 -i $pkgfiles/disable-failing-nss-tests.patch
-    %configure_no_runstatedir \
+    %patch -p1 -i ${pkgfiles}/0001-Prevent-broken-test-from-running.patch
+    %patch -p1 -i ${pkgfiles}/disable-failing-nss-tests.patch
+    %configure \
         --with-apr=/usr \
         --with-crypto \
         --with-gdbm=/usr \
@@ -37,5 +37,6 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license LICENSE
 check      : |
     %make check -j1

--- a/packages/a/apr-util/pspec_x86_64.xml
+++ b/packages/a/apr-util/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>apr-util</Name>
         <Homepage>https://apr.apache.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming</PartOf>
@@ -35,7 +35,8 @@
             <Path fileType="library">/usr/lib64/apr-util-1/apr_ldap.so</Path>
             <Path fileType="library">/usr/lib64/aprutil.exp</Path>
             <Path fileType="library">/usr/lib64/libaprutil-1.so.0</Path>
-            <Path fileType="library">/usr/lib64/libaprutil-1.so.0.6.3</Path>
+            <Path fileType="library">/usr/lib64/libaprutil-1.so.0.6.4</Path>
+            <Path fileType="data">/usr/share/licenses/apr-util/LICENSE</Path>
         </Files>
     </Package>
     <Package>
@@ -45,7 +46,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">apr-util</Dependency>
+            <Dependency release="21">apr-util</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/apr-1/apr_anylock.h</Path>
@@ -88,12 +89,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-02-13</Date>
-            <Version>1.6.3</Version>
+        <Update release="21">
+            <Date>2026-08-09</Date>
+            <Version>1.6.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://downloads.apache.org/apr/CHANGES-APR-UTIL-1.6).

**Security**
Includes fixes for:
- CVE-2026-34502
- CVE-2026-34501
- CVE-2026-34191
- CVE-2026-32327
- CVE-2025-49506

**Test Plan**

Pass tests suite

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
