### PR TITLE
python google updates

### DIFF
--- a/packages/py/python-google-auth-oauthlib/monitoring.yaml
+++ b/packages/py/python-google-auth-oauthlib/monitoring.yaml
@@ -1,5 +1,5 @@
 releases:
-  id: 236291
+  id: 23895
   rss: https://github.com/googleapis/google-auth-library-python-oauthlib/releases.atom
 security:
   cpe: ~ # Last checked 2025-02-26

--- a/packages/py/python-google-auth-oauthlib/package.yml
+++ b/packages/py/python-google-auth-oauthlib/package.yml
@@ -1,10 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-google-auth-oauthlib
-version    : 0.4.6
-release    : 9
+version    : 1.4.0
+release    : 10
 source     :
-    - https://github.com/googleapis/google-auth-library-python-oauthlib/archive/refs/tags/v0.4.6.tar.gz : 07d363a0da6007217c3aa94b947ce66f80f47b4c90bd5d705b397bfed7dc0dc1
-homepage   : https://github.com/googleapis/google-auth-library-python-oauthlib
+    - https://github.com/googleapis/google-cloud-python/archive/refs/tags/google-auth-oauthlib-v1.4.0.tar.gz : 
+        2cc838fb4b6c9f084aa116fb1da9a9cef57004e820e6e61139144212ca16f4cc
+homepage   : https://pypi.org/project/google-auth-oauthlib/
 license    : Apache-2.0
 component  : programming.python
 summary    : oauthlib integration for Google Auth
@@ -14,10 +15,19 @@ builddeps  :
     - python-build
     - python-installer
     - python-setuptools
+checkdeps  :
+    - python-google-auth
+    - python-pytest
+    - python-requests-oauthlib
 rundeps    :
     - python-google-auth
     - python-requests-oauthlib
 build      : |
-    %python3_setup
+    pushd packages/google-auth-oauthlib
+    %pyproject_build
 install    : |
-    %python3_install
+    pushd packages/google-auth-oauthlib
+    %pyproject_install
+check      : |
+    pushd packages/google-auth-oauthlib
+    %pytest -v

--- a/packages/py/python-google-auth-oauthlib/pspec_x86_64.xml
+++ b/packages/py/python-google-auth-oauthlib/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>python-google-auth-oauthlib</Name>
-        <Homepage>https://github.com/googleapis/google-auth-library-python-oauthlib</Homepage>
+        <Homepage>https://pypi.org/project/google-auth-oauthlib/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -21,12 +21,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/google-oauthlib-tool</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-0.4.6.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-0.4.6.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-0.4.6.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-0.4.6.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-0.4.6.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-0.4.6.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-1.4.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-1.4.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-1.4.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-1.4.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-1.4.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib-1.4.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth_oauthlib/__pycache__/__init__.cpython-314.pyc</Path>
@@ -48,12 +48,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2026-06-06</Date>
-            <Version>0.4.6</Version>
+        <Update release="10">
+            <Date>2026-08-10</Date>
+            <Version>1.4.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/py/python-google-auth/package.yml
+++ b/packages/py/python-google-auth/package.yml
@@ -1,10 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-google-auth
-version    : 2.14.1
-release    : 10
+version    : 2.56.3
+release    : 11
 source     :
-    - https://pypi.io/packages/source/g/google-auth/google-auth-2.14.1.tar.gz : ccaa901f31ad5cbb562615eb8b664b3dd0bf5404a67618e642307f00613eda4d
-homepage   : https://github.com/googleapis/google-auth-library-python
+    - https://github.com/googleapis/google-cloud-python/archive/refs/tags/google-auth-v2.56.3.tar.gz : 
+        0d96ed9deef233e168ef5b52b6d74cad5c6d2c461fef110d9f8469b1ff0a335f
+homepage   : https://pypi.org/project/google-auth/
 license    : Apache-2.0
 component  : programming.python
 summary    : Google Auth Python Library
@@ -14,12 +15,24 @@ builddeps  :
     - python-build
     - python-installer
     - python-setuptools
+    - python-wheel
+# checkdeps  :
+#     - flask
+#     - python-aiohttp
+#     - python-asn1-modules
+#     - python-cryptography
+#     - python-freezegun
+#     - python-pytest
+#     - python-pytest-asyncio
 rundeps    :
     - python-asn1-modules
-    - python-cachetools
-    - python-rsa
-    - python-six
+    - python-cryptography
 build      : |
-    %python3_setup
+    pushd packages/google-auth
+    %pyproject_build
 install    : |
-    %python3_install
+    pushd packages/google-auth
+    %pyproject_install
+# check      : |
+#     pushd packages/google-auth
+#     %pytest -v

--- a/packages/py/python-google-auth/pspec_x86_64.xml
+++ b/packages/py/python-google-auth/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>python-google-auth</Name>
-        <Homepage>https://github.com/googleapis/google-auth-library-python</Homepage>
+        <Homepage>https://pypi.org/project/google-auth/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -23,10 +23,16 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_agent_identity_utils.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_agent_identity_utils.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_cache.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_cache.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_cloud_sdk.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_cloud_sdk.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_credentials_async.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_credentials_async.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_credentials_base.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_credentials_base.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_default.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_default.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_default_async.cpython-314.opt-1.pyc</Path>
@@ -39,8 +45,14 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_jwt_async.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_oauth2client.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_oauth2client.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_refresh_worker.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_refresh_worker.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_regional_access_boundary_utils.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_regional_access_boundary_utils.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_service_account_info.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/_service_account_info.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/api_key.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/api_key.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/app_engine.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/app_engine.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/aws.cpython-314.opt-1.pyc</Path>
@@ -65,19 +77,48 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/impersonated_credentials.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/jwt.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/jwt.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/metrics.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/metrics.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/pluggable.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/pluggable.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/version.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/__pycache__/version.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_agent_identity_utils.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_cache.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_cloud_sdk.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_credentials_async.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_credentials_base.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_default.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_default_async.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_exponential_backoff.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_helpers.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_jwt_async.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_oauth2client.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_refresh_worker.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_regional_access_boundary_utils.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/_service_account_info.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/__pycache__/_helpers.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/__pycache__/_helpers.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/__pycache__/credentials.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/__pycache__/credentials.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/_helpers.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/credentials.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/__pycache__/aiohttp.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/__pycache__/aiohttp.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/__pycache__/mtls.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/__pycache__/mtls.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/__pycache__/sessions.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/__pycache__/sessions.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/aiohttp.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/mtls.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aio/transport/sessions.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/api_key.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/app_engine.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/aws.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/compute_engine/__init__.py</Path>
@@ -85,9 +126,12 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/compute_engine/__pycache__/__init__.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/compute_engine/__pycache__/_metadata.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/compute_engine/__pycache__/_metadata.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/compute_engine/__pycache__/_mtls.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/compute_engine/__pycache__/_mtls.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/compute_engine/__pycache__/credentials.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/compute_engine/__pycache__/credentials.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/compute_engine/_metadata.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/compute_engine/_mtls.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/compute_engine/credentials.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/credentials.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/__init__.py</Path>
@@ -101,6 +145,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/__pycache__/_python_rsa.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/__pycache__/base.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/__pycache__/base.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/__pycache__/es.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/__pycache__/es.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/__pycache__/es256.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/__pycache__/es256.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/__pycache__/rsa.cpython-314.opt-1.pyc</Path>
@@ -109,6 +155,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/_helpers.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/_python_rsa.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/base.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/es.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/es256.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/crypt/rsa.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/downscoped.py</Path>
@@ -120,7 +167,9 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/identity_pool.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/impersonated_credentials.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/jwt.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/metrics.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/pluggable.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/py.typed</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/__pycache__/__init__.cpython-314.pyc</Path>
@@ -132,6 +181,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/__pycache__/_http_client.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/__pycache__/_mtls_helper.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/__pycache__/_mtls_helper.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/__pycache__/_requests_base.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/__pycache__/_requests_base.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/__pycache__/grpc.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/__pycache__/grpc.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/__pycache__/mtls.cpython-314.opt-1.pyc</Path>
@@ -144,6 +195,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/_custom_tls_signer.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/_http_client.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/_mtls_helper.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/_requests_base.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/grpc.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/mtls.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/auth/transport/requests.py</Path>
@@ -180,6 +232,12 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/__pycache__/sts.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/__pycache__/utils.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/__pycache__/utils.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/__pycache__/webauthn_handler.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/__pycache__/webauthn_handler.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/__pycache__/webauthn_handler_factory.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/__pycache__/webauthn_handler_factory.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/__pycache__/webauthn_types.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/__pycache__/webauthn_types.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/_client.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/_client_async.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/_credentials_async.py</Path>
@@ -190,26 +248,28 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/credentials.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/gdch_credentials.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/id_token.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/py.typed</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/reauth.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/service_account.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/sts.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/utils.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.14.1-py3.14-nspkg.pth</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.14.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.14.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.14.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.14.1.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.14.1.dist-info/namespace_packages.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.14.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/webauthn_handler.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/webauthn_handler_factory.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/oauth2/webauthn_types.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.56.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.56.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.56.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.56.3.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google_auth-2.56.3.dist-info/top_level.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2026-06-06</Date>
-            <Version>2.14.1</Version>
+        <Update release="11">
+            <Date>2026-08-10</Date>
+            <Version>2.56.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/py/python-googleapis-common-protos/package.yml
+++ b/packages/py/python-googleapis-common-protos/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-googleapis-common-protos
-version    : 1.57.0
-release    : 5
+version    : 1.75.1
+release    : 6
 source     :
-    - https://files.pythonhosted.org/packages/source/g/googleapis-common-protos/googleapis-common-protos-1.56.1.tar.gz : 6b5ee59dc646eb61a8eb65ee1db186d3df6687c8804830024f32573298bca19b
-homepage   : https://github.com/googleapis/python-api-common-protos
+    - https://github.com/googleapis/google-cloud-python/archive/refs/tags/googleapis-common-protos-v1.75.1.tar.gz : d3bc073645fa8d971c0b3201d7352fcf89a95602b4a0391321d28bdb4855fc08
+homepage   : https://pypi.org/project/googleapis-common-protos/
 license    : Apache-2.0
 component  : programming.python
 summary    : Common protobufs used in Google APIs
@@ -14,9 +14,18 @@ builddeps  :
     - python-build
     - python-installer
     - python-setuptools
+    - python-wheel
+checkdeps  :
+    - python-protobuf
+    - python-pytest
 rundeps    :
     - python-protobuf
 build      : |
-    %python3_setup
+    pushd packages/googleapis-common-protos
+    %pyproject_build
 install    : |
-    %python3_install
+    pushd packages/googleapis-common-protos
+    %pyproject_install
+check      : |
+    pushd packages/googleapis-common-protos
+    %pytest -v

--- a/packages/py/python-googleapis-common-protos/pspec_x86_64.xml
+++ b/packages/py/python-googleapis-common-protos/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>python-googleapis-common-protos</Name>
-        <Homepage>https://github.com/googleapis/python-api-common-protos</Homepage>
+        <Homepage>https://pypi.org/project/googleapis-common-protos/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,9 +20,6 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/__init__.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/annotations_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/annotations_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/auth_pb2.cpython-314.opt-1.pyc</Path>
@@ -51,6 +48,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/error_reason_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/field_behavior_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/field_behavior_pb2.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/field_info_pb2.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/field_info_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/http_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/http_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/httpbody_pb2.cpython-314.opt-1.pyc</Path>
@@ -69,6 +68,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/monitored_resource_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/monitoring_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/monitoring_pb2.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/policy_pb2.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/policy_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/quota_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/quota_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/resource_pb2.cpython-314.opt-1.pyc</Path>
@@ -87,95 +88,133 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/__pycache__/visibility_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/annotations.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/annotations_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/annotations_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/auth.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/auth_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/auth_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/backend.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/backend_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/backend_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/billing.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/billing_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/billing_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/client.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/client_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/client_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/config_change.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/config_change_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/config_change_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/consumer.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/consumer_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/consumer_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/context.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/context_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/context_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/control.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/control_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/control_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/distribution.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/distribution_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/distribution_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/documentation.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/documentation_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/documentation_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/endpoint.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/endpoint_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/endpoint_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/error_reason.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/error_reason_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/error_reason_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/field_behavior.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/field_behavior_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/field_behavior_pb2.pyi</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/field_info.proto</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/field_info_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/field_info_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/http.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/http_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/http_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/httpbody.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/httpbody_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/httpbody_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/label.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/label_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/label_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/launch_stage.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/launch_stage_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/launch_stage_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/log.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/log_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/log_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/logging.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/logging_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/logging_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/metric.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/metric_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/metric_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/monitored_resource.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/monitored_resource_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/monitored_resource_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/monitoring.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/monitoring_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/monitoring_pb2.pyi</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/policy.proto</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/policy_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/policy_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/quota.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/quota_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/quota_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/resource.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/resource_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/resource_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/routing.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/routing_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/routing_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/service.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/service_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/service_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/source_info.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/source_info_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/source_info_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/system_parameter.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/system_parameter_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/system_parameter_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/usage.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/usage_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/usage_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/visibility.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/visibility_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/api/visibility_pb2.pyi</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/__pycache__/common_resources_pb2.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/__pycache__/common_resources_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/__pycache__/extended_operations_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/__pycache__/extended_operations_pb2.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/common_resources.proto</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/common_resources_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/common_resources_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/extended_operations.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/extended_operations_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/extended_operations_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/location/__pycache__/locations_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/location/__pycache__/locations_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/location/locations.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/location/locations_pb2.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/gapic/metadata/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/gapic/metadata/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/gapic/metadata/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/cloud/location/locations_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/gapic/metadata/__pycache__/gapic_metadata_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/gapic/metadata/__pycache__/gapic_metadata_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/gapic/metadata/gapic_metadata.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/gapic/metadata/gapic_metadata_pb2.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/gapic/metadata/gapic_metadata_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/__pycache__/http_request_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/__pycache__/http_request_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/__pycache__/log_severity_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/__pycache__/log_severity_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/http_request.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/http_request_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/http_request_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/log_severity.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/log_severity_pb2.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/logging/type/log_severity_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/__pycache__/operations_grpc.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/__pycache__/operations_grpc.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/__pycache__/operations_grpc_pb2.cpython-314.opt-1.pyc</Path>
@@ -188,38 +227,44 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/__pycache__/operations_proto.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/__pycache__/operations_proto_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/__pycache__/operations_proto_pb2.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/operations.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/operations_grpc.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/operations_grpc_pb2.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/operations_pb2.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/operations_pb2_grpc.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/operations_proto.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/operations_proto.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/operations_proto_pb2.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/longrunning/operations_proto_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/__pycache__/code_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/__pycache__/code_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/__pycache__/error_details_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/__pycache__/error_details_pb2.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/__pycache__/http_pb2.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/__pycache__/http_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/__pycache__/status_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/__pycache__/status_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/code.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/code_pb2.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/code_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/__pycache__/attribute_context_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/__pycache__/attribute_context_pb2.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/__pycache__/audit_context_pb2.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/__pycache__/audit_context_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/attribute_context.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/attribute_context_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/attribute_context_pb2.pyi</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/audit_context.proto</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/audit_context_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/context/audit_context_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/error_details.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/error_details_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/error_details_pb2.pyi</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/http.proto</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/http_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/http_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/status.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/status_pb2.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/rpc/status_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/__pycache__/calendar_period_pb2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/__pycache__/calendar_period_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/__pycache__/color_pb2.cpython-314.opt-1.pyc</Path>
@@ -256,54 +301,69 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/__pycache__/timeofday_pb2.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/calendar_period.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/calendar_period_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/calendar_period_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/color.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/color_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/color_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/date.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/date_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/date_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/datetime.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/datetime_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/datetime_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/dayofweek.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/dayofweek_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/dayofweek_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/decimal.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/decimal_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/decimal_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/expr.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/expr_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/expr_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/fraction.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/fraction_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/fraction_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/interval.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/interval_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/interval_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/latlng.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/latlng_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/latlng_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/localized_text.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/localized_text_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/localized_text_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/money.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/money_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/money_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/month.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/month_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/month_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/phone_number.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/phone_number_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/phone_number_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/postal_address.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/postal_address_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/postal_address_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/quaternion.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/quaternion_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/quaternion_pb2.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/timeofday.proto</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/timeofday_pb2.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.56.1-py3.14-nspkg.pth</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.56.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.56.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.56.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.56.1.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.56.1.dist-info/namespace_packages.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.56.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/google/type/timeofday_pb2.pyi</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.75.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.75.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.75.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.75.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/googleapis_common_protos-1.75.1.dist-info/top_level.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-06-06</Date>
-            <Version>1.57.0</Version>
+        <Update release="6">
+            <Date>2026-08-10</Date>
+            <Version>1.75.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- **python-google-auth: Update to v2.56.3**
- **python-google-auth-oauthlib: Update to v1.4.0**
- **python-googleapis-common-protos: Update to v1.75.1**

The test suite for `python-google-auth` is disabled because it requires unpackaged deps that require `flit-core` 4. Problem with that is some of our other packages require `flit-core` < 4. So figure out that mess later.

**Test Plan**

See that the test suites passed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
