### PR TITLE
openjdk-21: Update to v21.0.12

### DIFF
--- a/packages/o/openjdk-21/abi_used_symbols
+++ b/packages/o/openjdk-21/abi_used_symbols
@@ -33,6 +33,7 @@ libX11.so.6:XDefaultDepthOfScreen
 libX11.so.6:XDefaultGCOfScreen
 libX11.so.6:XDefaultScreenOfDisplay
 libX11.so.6:XDefaultVisualOfScreen
+libX11.so.6:XDeleteContext
 libX11.so.6:XDeleteProperty
 libX11.so.6:XDestroyIC
 libX11.so.6:XDestroyRegion
@@ -54,6 +55,7 @@ libX11.so.6:XFillPolygon
 libX11.so.6:XFillRectangle
 libX11.so.6:XFillRectangles
 libX11.so.6:XFilterEvent
+libX11.so.6:XFindContext
 libX11.so.6:XFlush
 libX11.so.6:XFree
 libX11.so.6:XFreeColormap
@@ -129,6 +131,7 @@ libX11.so.6:XResizeWindow
 libX11.so.6:XRestackWindows
 libX11.so.6:XRootWindow
 libX11.so.6:XRootWindowOfScreen
+libX11.so.6:XSaveContext
 libX11.so.6:XScreenCount
 libX11.so.6:XScreenNumberOfScreen
 libX11.so.6:XSelectInput
@@ -189,6 +192,7 @@ libX11.so.6:XkbTranslateKeyCode
 libX11.so.6:XmbDrawString
 libX11.so.6:XmbLookupString
 libX11.so.6:XmbResetIC
+libX11.so.6:XrmUniqueQuark
 libX11.so.6:Xutf8TextListToTextProperty
 libXext.so.6:XShapeCombineMask
 libXext.so.6:XShapeCombineRectangles
@@ -833,6 +837,7 @@ libm.so.6:ceil
 libm.so.6:ceilf
 libm.so.6:cos
 libm.so.6:exp
+libm.so.6:exp2
 libm.so.6:fegetenv
 libm.so.6:fesetenv
 libm.so.6:floor
@@ -843,6 +848,7 @@ libm.so.6:fmod
 libm.so.6:fmodf
 libm.so.6:frexp
 libm.so.6:log
+libm.so.6:log10
 libm.so.6:log2
 libm.so.6:log2f
 libm.so.6:pow

--- a/packages/o/openjdk-21/package.yml
+++ b/packages/o/openjdk-21/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openjdk-21
-version    : 21.0.11
-release    : 8
+version    : 21.0.12
+release    : 9
 source     :
-    - https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.11-ga.tar.gz : 76b8310966649ea8a6340f92d4f19f6f84e3083b682a514c8f1999c93373385f
+    - https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.12-ga.tar.gz : 1efd38fa2729d32cdf0ed4c9197c31ee31890ad1b7bff82984992e0c2c67c72b
     # Detection seems broken, we can't use system gtest (TODO fix this)
     - https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz : 8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
 license    : GPL-2.0-only WITH Classpath-exception-2.0

--- a/packages/o/openjdk-21/pspec_x86_64.xml
+++ b/packages/o/openjdk-21/pspec_x86_64.xml
@@ -533,7 +533,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">openjdk-21</Dependency>
+            <Dependency release="9">openjdk-21</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openjdk-21/classfile_constants.h</Path>
@@ -549,9 +549,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2026-06-15</Date>
-            <Version>21.0.11</Version>
+        <Update release="9">
+            <Date>2026-08-11</Date>
+            <Version>21.0.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://mail.openjdk.org/archives/list/jdk-updates-dev@openjdk.org/thread/6SFPOG22M5ULSXJVOBASMH2NCS2JCEZG/).

**Security**
Includes fixes for:
  - CVE-2026-46968
  - CVE-2026-46917
  - CVE-2026-47010
  - CVE-2026-47021
  - CVE-2026-47027
  - CVE-2026-60147
  - CVE-2026-47059
  - CVE-2026-47063
  - CVE-2026-41254

**Test Plan**
- Tested some Java applications.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
