### PR TITLE
xdg-dbus-proxy: Update to v0.1.8

### DIFF
--- a/packages/x/xdg-dbus-proxy/package.yml
+++ b/packages/x/xdg-dbus-proxy/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xdg-dbus-proxy
-version    : 0.1.7
-release    : 7
+version    : 0.1.8
+release    : 8
 source     :
-    - https://github.com/flatpak/xdg-dbus-proxy/releases/download/0.1.7/xdg-dbus-proxy-0.1.7.tar.xz : 3ad3d27ba574e178acb5e4d438ba36ace25e3564f899c36f31c56f82c7adbbe7
+    - https://github.com/flatpak/xdg-dbus-proxy/releases/download/0.1.8/xdg-dbus-proxy-0.1.8.tar.xz : b6630bd24f8161b0e2546d2acbb014a3b3249f5c0d75f2a863ade898b9034d3d
 license    : LGPL-2.1-or-later
 component  : security
 homepage   : https://github.com/flatpak/xdg-dbus-proxy

--- a/packages/x/xdg-dbus-proxy/pspec_x86_64.xml
+++ b/packages/x/xdg-dbus-proxy/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2026-04-10</Date>
-            <Version>0.1.7</Version>
+        <Update release="8">
+            <Date>2026-08-11</Date>
+            <Version>0.1.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/flatpak/xdg-dbus-proxy/releases/tag/0.1.8).

**Security**
- GHSA-r7hp-698j-2h6c

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Launch a flatpak app.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
