### PR TITLE
python-wheel: Update to 0.48.0

### DIFF
--- a/packages/py/python-wheel/package.yml
+++ b/packages/py/python-wheel/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-wheel
-version    : 0.47.0
-release    : 26
+version    : 0.48.0
+release    : 27
 source     :
-    - https://pypi.debian.net/wheel/wheel-0.47.0.tar.gz : cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3
+    - https://pypi.debian.net/wheel/wheel-0.48.0.tar.gz : 94800765601e9171bf5d58d066e640662842bcedcbab982b2c90787a2c987322
 homepage   : https://wheel.readthedocs.io/
 license    : MIT
 component  : programming.python
@@ -20,8 +20,9 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
-#check      : |
-#    %python3_test py.test3
+    %pyproject_install
+check      : |
+    # Disable tests that dont work in chroot environtment
+    %pytest -v -k "not (test_network_fetch or test_file_permissions)"

--- a/packages/py/python-wheel/pspec_x86_64.xml
+++ b/packages/py/python-wheel/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-wheel</Name>
         <Homepage>https://wheel.readthedocs.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -21,11 +21,11 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/wheel</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/wheel-0.47.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/wheel-0.47.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/wheel-0.47.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/wheel-0.47.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/wheel-0.47.0.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/wheel-0.48.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/wheel-0.48.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/wheel-0.48.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/wheel-0.48.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/wheel-0.48.0.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/wheel/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/wheel/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/wheel/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -74,12 +74,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2026-06-19</Date>
-            <Version>0.47.0</Version>
+        <Update release="27">
+            <Date>2026-08-12</Date>
+            <Version>0.48.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security
- Re-enabled test suite with compatible settings
- [Change Log](https://github.com/pypa/wheel/releases/tag/0.48.0)

**Security**
- GHSA-vgq5-9859-3mmw

**Test Plan**
- Pass test suite
- python -c "import wheel; print('ok')" See ok


- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
