### PR TITLE
glibc: Update to 2.43+git.a388c400

### DIFF
--- a/packages/g/glibc/package.yml
+++ b/packages/g/glibc/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : glibc
 version    : '2.43'
-release    : 143
+release    : 144
 source     :
     # release/2.43/master
-    - git|https://sourceware.org/git/glibc.git : 1c9988e52540c844928c6d93ff45305adc2c24a0
+    - git|https://forge.sourceware.org/glibc/glibc-mirror.git : a388c4002d42d83f2858897c947308df648310b1
 homepage   : https://www.gnu.org/software/libc/
 license    :
     - GPL-2.0-or-later
@@ -159,77 +159,78 @@ install    : |
             %make_install localedata/install-locale-files
 
             # Hardlink everything to save space
-            pushd $installdir/usr/lib64/locale/
+            pushd ${installdir}/usr/lib64/locale/
             hardlink -c ../locale
             # Convert some of the hardlinks to symlinks in case we split out the additional locales (C.utf8 must stay in the glibc package)
             for r in LC_CTYPE LC_MEASUREMENT LC_PAPER; do
-                for f in $(find eo syr *_* -samefile C.utf8/$r); do
-                    rm $f && ln -s "../C.utf8/$r" $f
+                for f in $(find eo syr *_* -samefile C.utf8/${r}); do
+                    rm ${f} && ln -s "../C.utf8/${r}" ${f}
                 done
             done
             popd
 
-            if [[ -f $installdir/etc/ld.so.cache ]]; then
-                rm -v $installdir/etc/ld.so.cache
+            if [[ -f ${installdir}/etc/ld.so.cache ]]; then
+                rm -v ${installdir}/etc/ld.so.cache
             fi
 
-            if [[ -f $installdir/etc/localetime ]]; then
-                rm -v $installdir/etc/localetime
+            if [[ -f ${installdir}/etc/localetime ]]; then
+                rm -v ${installdir}/etc/localetime
             fi
 
-            if [[ -d $installdir/usr/share/zoneinfo ]]; then
-                rm -rfv $installdir/usr/share/zoneinfo
+            if [[ -d ${installdir}/usr/share/zoneinfo ]]; then
+                rm -rfv ${installdir}/usr/share/zoneinfo
             fi
 
-            if [[ -f $installdir/usr/sbin/zdump ]]; then
-                rm -v $installdir/usr/sbin/zdump
+            if [[ -f ${installdir}/usr/sbin/zdump ]]; then
+                rm -v ${installdir}/usr/sbin/zdump
             fi
 
             # This is a vendored copy from the 5.0 systemtap package, it should be kept in sync with the systemtap version
-            install -Dm00644 $pkgfiles/systemtap/{sdt.h,sdt-config.h} -t $installdir/usr/include/sys
+            %install_file -t ${installdir}/usr/include/sys ${pkgfiles}/systemtap/{sdt.h,sdt-config.h}
 
             # Install stateless ld.so.conf
-            install -Dm00644 $pkgfiles/ld.so.conf $installdir/usr/share/defaults/etc/ld.so.conf
+            %install_file -t ${installdir}/usr/share/defaults/etc ${pkgfiles}/ld.so.conf
 
             # More stateless
-            mv $installdir/etc/rpc $installdir/usr/share/defaults/etc/
-            rmdir -v $installdir/etc
+            mv ${installdir}/etc/rpc ${installdir}/usr/share/defaults/etc/
+            rmdir -v ${installdir}/etc
 
             # iconv cache file
             # LD_LIBRARY_PATH hacks to get this working, fixed in 2.36.
-            LD_LIBRARY_PATH=$installdir/%libdir% $installdir/%libdir%/ld-linux-x86-64.so.2 $installdir/usr/sbin/iconvconfig --prefix=$installdir
+            LD_LIBRARY_PATH=${installdir}/%libdir% ${installdir}/%libdir%/ld-linux-x86-64.so.2 ${installdir}/usr/sbin/iconvconfig --prefix=${installdir}
 
             # We need to create these in the 64-bit build otherwise the avx build would mangle them
             # Test for the existence of the 32-bit dynamic loader so we can tell if an emul32 build was done
-            if test -f $installdir/usr/lib32/ld-linux.so.2; then
-                install -dm00755 $installdir/{,usr/}lib{32,64}
-                ln -srv $installdir/usr/lib32/ld-linux.so.2 $installdir/usr/lib64/ld-linux.so.2
-                ln -srv $installdir/usr/lib32/ld-linux.so.2 $installdir/lib64/ld-linux.so.2
-                ln -srv $installdir/usr/lib32/ld-linux.so.2 $installdir/lib32/ld-linux.so.2
+            if test -f ${installdir}/usr/lib32/ld-linux.so.2; then
+                %install_dir ${installdir}/{,usr/}lib{32,64}
+                ln -srv ${installdir}/usr/lib32/ld-linux.so.2 ${installdir}/usr/lib64/ld-linux.so.2
+                ln -srv ${installdir}/usr/lib32/ld-linux.so.2 ${installdir}/lib64/ld-linux.so.2
+                ln -srv ${installdir}/usr/lib32/ld-linux.so.2 ${installdir}/lib32/ld-linux.so.2
             fi
         fi
     fi
 
     # Benchmarks
     if [[ -z "${AVX2BUILD}" ]]; then
-        for f in benchtests/*; do [ -x $f -a ! -d $f ] && cp -a $f $installdir/usr/bin/; done
+        for f in benchtests/*; do [ -x ${f} -a ! -d ${f} ] && %install_bin ${f}; done
     fi
 
     # Clear out unneeded haswell files
     if [[ ! -z "${AVX2BUILD}" ]]; then
-        for nuke in `ls $installdir/%libdir% | grep -v -E "libm.so.6|libm-$version.so|libc.so.6|libc-$version.so|libmvec|libcrypt"`; do
-            rm -rfv $installdir/%libdir%/${nuke}
+        for nuke in `ls ${installdir}/%libdir% | grep -v -E "libm.so.6|libm-${version}.so|libc.so.6|libc-${version}.so|libmvec|libcrypt"`; do
+            rm -rfv ${installdir}/%libdir%/${nuke}
         done
     fi
 
     # None of these are needed on Solus, but could be added back by user demand (though in a stateless way)
     # libnss_db is particularly problematic for statelessness due to /var/db/Makefile
-    rm -fv $installdir/%libdir%/libnss_db.so* \
-           $installdir/%libdir%/libnss_hesiod.so* \
-           $installdir/usr/bin/makedb \
-           $installdir/var/db/Makefile
+    rm -fv ${installdir}/%libdir%/libnss_db.so* \
+           ${installdir}/%libdir%/libnss_hesiod.so* \
+           ${installdir}/usr/bin/makedb \
+           ${installdir}/var/db/Makefile
+
     # Cleanup
-    find $installdir -type d -empty -print -delete
+    find ${installdir} -type d -empty -print -delete
 
     popd
 

--- a/packages/g/glibc/pspec_x86_64.xml
+++ b/packages/g/glibc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>glibc</Name>
         <Homepage>https://www.gnu.org/software/libc/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -7020,7 +7020,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="143">glibc</Dependency>
+            <Dependency release="144">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib32/ld-linux.so.2</Path>
@@ -7321,8 +7321,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="143">glibc-devel</Dependency>
-            <Dependency release="143">glibc-32bit</Dependency>
+            <Dependency release="144">glibc-devel</Dependency>
+            <Dependency release="144">glibc-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/Mcrt1.o</Path>
@@ -7856,7 +7856,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="143">glibc</Dependency>
+            <Dependency release="144">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mtrace</Path>
@@ -8377,12 +8377,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="143">
-            <Date>2026-07-27</Date>
+        <Update release="144">
+            <Date>2026-08-12</Date>
             <Version>2.43</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix wordexp WRDE_APPEND to preserve state on non-NOSPACE errors

**Security**
- CVE-2026-6368

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild `nano`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
