### PR TITLE
rhythmbox: Update to v3.5.0

### DIFF
--- a/packages/r/rhythmbox/abi_symbols
+++ b/packages/r/rhythmbox/abi_symbols
@@ -244,6 +244,7 @@ librhythmbox-core.so.10:get_box_widget_at_pos
 librhythmbox-core.so.10:gossip_cell_renderer_expander_get_type
 librhythmbox-core.so.10:gossip_cell_renderer_expander_new
 librhythmbox-core.so.10:integer_property_type
+librhythmbox-core.so.10:is_query_thread
 librhythmbox-core.so.10:media_type_filters
 librhythmbox-core.so.10:mpid_debug
 librhythmbox-core.so.10:mpid_debug_str
@@ -728,11 +729,14 @@ librhythmbox-core.so.10:rb_podcast_post_entry_type_get_type
 librhythmbox-core.so.10:rb_podcast_properties_dialog_get_type
 librhythmbox-core.so.10:rb_podcast_properties_dialog_new
 librhythmbox-core.so.10:rb_podcast_register_entry_types
+librhythmbox-core.so.10:rb_podcast_search_can_resolve
 librhythmbox-core.so.10:rb_podcast_search_cancel
 librhythmbox-core.so.10:rb_podcast_search_entry_type_get_type
 librhythmbox-core.so.10:rb_podcast_search_finished
 librhythmbox-core.so.10:rb_podcast_search_get_type
 librhythmbox-core.so.10:rb_podcast_search_itunes_get_type
+librhythmbox-core.so.10:rb_podcast_search_resolve
+librhythmbox-core.so.10:rb_podcast_search_resolve_finish
 librhythmbox-core.so.10:rb_podcast_search_result
 librhythmbox-core.so.10:rb_podcast_search_start
 librhythmbox-core.so.10:rb_podcast_source_add_feed
@@ -836,7 +840,6 @@ librhythmbox-core.so.10:rb_shell_get_source_by_entry_type
 librhythmbox-core.so.10:rb_shell_get_type
 librhythmbox-core.so.10:rb_shell_guess_source_for_uri
 librhythmbox-core.so.10:rb_shell_load_uri
-librhythmbox-core.so.10:rb_shell_notify_custom
 librhythmbox-core.so.10:rb_shell_player_add_play_order
 librhythmbox-core.so.10:rb_shell_player_do_next
 librhythmbox-core.so.10:rb_shell_player_do_previous
@@ -1173,6 +1176,7 @@ librhythmbox-core.so.10:rhythmdb_import_job_new
 librhythmbox-core.so.10:rhythmdb_import_job_scan_complete
 librhythmbox-core.so.10:rhythmdb_import_job_start
 librhythmbox-core.so.10:rhythmdb_init_monitoring
+librhythmbox-core.so.10:rhythmdb_is_query_thread
 librhythmbox-core.so.10:rhythmdb_load
 librhythmbox-core.so.10:rhythmdb_metadata_cache_get
 librhythmbox-core.so.10:rhythmdb_metadata_cache_get_type

--- a/packages/r/rhythmbox/abi_used_symbols
+++ b/packages/r/rhythmbox/abi_used_symbols
@@ -179,6 +179,7 @@ libgio-2.0.so.0:g_application_new
 libgio-2.0.so.0:g_application_open
 libgio-2.0.so.0:g_application_register
 libgio-2.0.so.0:g_application_run
+libgio-2.0.so.0:g_application_send_notification
 libgio-2.0.so.0:g_application_set_default
 libgio-2.0.so.0:g_bus_get_sync
 libgio-2.0.so.0:g_bus_own_name
@@ -330,6 +331,8 @@ libgio-2.0.so.0:g_mount_is_shadowed
 libgio-2.0.so.0:g_mount_operation_get_type
 libgio-2.0.so.0:g_mount_unmount_with_operation
 libgio-2.0.so.0:g_mount_unmount_with_operation_finish
+libgio-2.0.so.0:g_notification_new
+libgio-2.0.so.0:g_notification_set_body
 libgio-2.0.so.0:g_output_stream_close
 libgio-2.0.so.0:g_output_stream_close_async
 libgio-2.0.so.0:g_output_stream_close_finish
@@ -380,14 +383,17 @@ libgio-2.0.so.0:g_simple_async_result_take_error
 libgio-2.0.so.0:g_static_resource_fini
 libgio-2.0.so.0:g_static_resource_get_resource
 libgio-2.0.so.0:g_static_resource_init
+libgio-2.0.so.0:g_task_get_cancellable
 libgio-2.0.so.0:g_task_get_source_object
 libgio-2.0.so.0:g_task_get_task_data
 libgio-2.0.so.0:g_task_get_type
 libgio-2.0.so.0:g_task_had_error
 libgio-2.0.so.0:g_task_new
 libgio-2.0.so.0:g_task_propagate_boolean
+libgio-2.0.so.0:g_task_propagate_pointer
 libgio-2.0.so.0:g_task_return_boolean
 libgio-2.0.so.0:g_task_return_error
+libgio-2.0.so.0:g_task_return_pointer
 libgio-2.0.so.0:g_task_run_in_thread
 libgio-2.0.so.0:g_task_set_task_data
 libgio-2.0.so.0:g_themed_icon_new
@@ -760,6 +766,7 @@ libglib-2.0.so.0:g_uri_get_path
 libglib-2.0.so.0:g_uri_get_scheme
 libglib-2.0.so.0:g_uri_parse
 libglib-2.0.so.0:g_uri_parse_scheme
+libglib-2.0.so.0:g_uri_split
 libglib-2.0.so.0:g_uri_unescape_string
 libglib-2.0.so.0:g_uri_unref
 libglib-2.0.so.0:g_usleep
@@ -838,7 +845,6 @@ libgobject-2.0.so.0:g_closure_set_marshal
 libgobject-2.0.so.0:g_closure_sink
 libgobject-2.0.so.0:g_closure_unref
 libgobject-2.0.so.0:g_enum_register_static
-libgobject-2.0.so.0:g_error_get_type
 libgobject-2.0.so.0:g_flags_register_static
 libgobject-2.0.so.0:g_gstring_get_type
 libgobject-2.0.so.0:g_object_add_weak_pointer
@@ -1263,7 +1269,6 @@ libgtk-3.so.0:gtk_cell_renderer_get_state
 libgtk-3.so.0:gtk_cell_renderer_get_type
 libgtk-3.so.0:gtk_cell_renderer_pixbuf_get_type
 libgtk-3.so.0:gtk_cell_renderer_pixbuf_new
-libgtk-3.so.0:gtk_cell_renderer_progress_new
 libgtk-3.so.0:gtk_cell_renderer_set_fixed_size
 libgtk-3.so.0:gtk_cell_renderer_set_padding
 libgtk-3.so.0:gtk_cell_renderer_text_new
@@ -1469,6 +1474,7 @@ libgtk-3.so.0:gtk_selection_data_get_target
 libgtk-3.so.0:gtk_selection_data_get_uris
 libgtk-3.so.0:gtk_selection_data_set
 libgtk-3.so.0:gtk_selection_data_set_pixbuf
+libgtk-3.so.0:gtk_separator_get_type
 libgtk-3.so.0:gtk_separator_new
 libgtk-3.so.0:gtk_show_about_dialog
 libgtk-3.so.0:gtk_show_uri
@@ -1861,8 +1867,10 @@ libsoup-3.0.so.0:soup_session_abort
 libsoup-3.0.so.0:soup_session_get_async_result_message
 libsoup-3.0.so.0:soup_session_new
 libsoup-3.0.so.0:soup_session_send
+libsoup-3.0.so.0:soup_session_send_and_read
 libsoup-3.0.so.0:soup_session_send_and_read_async
 libsoup-3.0.so.0:soup_session_send_and_read_finish
+libsoup-3.0.so.0:soup_session_set_timeout
 libsoup-3.0.so.0:soup_session_set_user_agent
 libtdb.so.1:tdb_close
 libtdb.so.1:tdb_delete

--- a/packages/r/rhythmbox/package.yml
+++ b/packages/r/rhythmbox/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : rhythmbox
-version    : 3.4.9
-release    : 66
+version    : 3.5.0
+release    : 67
 source     :
-    - https://download.gnome.org/sources/rhythmbox/3.4/rhythmbox-3.4.9.tar.xz : e42291a18df7a21ffe6b352bf73f05d7e298bb4e05bce5967f98ee8cee4408f1
+    - https://download.gnome.org/sources/rhythmbox/3.5/rhythmbox-3.5.0.tar.xz : c0d19933b8e05e96996ddefb8233680c68abfcfae51ce0c4c10b3c4c7a46df2f
 homepage   : https://gnome.pages.gitlab.gnome.org/rhythmbox/
 license    : GPL-2.0-only
 component  : multimedia.audio

--- a/packages/r/rhythmbox/pspec_x86_64.xml
+++ b/packages/r/rhythmbox/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>rhythmbox</Name>
         <Homepage>https://gnome.pages.gitlab.gnome.org/rhythmbox/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>multimedia.audio</PartOf>
@@ -46,6 +46,9 @@
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/fmradio/libfmradio.so</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/generic-player/generic-player.plugin</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/generic-player/libgeneric-player.so</Path>
+            <Path fileType="library">/usr/lib64/rhythmbox/plugins/gpodder/gpodder.plugin</Path>
+            <Path fileType="library">/usr/lib64/rhythmbox/plugins/gpodder/gpodder.py</Path>
+            <Path fileType="library">/usr/lib64/rhythmbox/plugins/gpodder/sync.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/grilo/grilo.plugin</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/grilo/libgrilo.so</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/im-status/im-status.plugin</Path>
@@ -57,16 +60,13 @@
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/listenbrainz/listenbrainz.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/listenbrainz/queue.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/listenbrainz/settings.py</Path>
-            <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/AstrawebParser.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/DarkLyricsParser.py</Path>
-            <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/JetlyricsParser.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/JlyricParser.py</Path>
-            <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/LyricWikiParser.py</Path>
+            <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/LrclibParser.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/LyricsConfigureDialog.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/LyricsParse.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/LyricsSites.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/TerraParser.py</Path>
-            <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/WinampcnParser.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/lyrics.plugin</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/lyrics/lyrics.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/magnatune/DownloadAlbumHandler.py</Path>
@@ -236,6 +236,16 @@
             <Path fileType="doc">/usr/share/help/ja/rhythmbox/figures/rb-window.png</Path>
             <Path fileType="doc">/usr/share/help/ja/rhythmbox/index.docbook</Path>
             <Path fileType="doc">/usr/share/help/ja/rhythmbox/legal.xml</Path>
+            <Path fileType="doc">/usr/share/help/kk/rhythmbox/figures/rb-iradio-main.png</Path>
+            <Path fileType="doc">/usr/share/help/kk/rhythmbox/figures/rb-notification-zone.png</Path>
+            <Path fileType="doc">/usr/share/help/kk/rhythmbox/figures/rb-podcast-main.png</Path>
+            <Path fileType="doc">/usr/share/help/kk/rhythmbox/figures/rb-toolbar-prevplaynext.png</Path>
+            <Path fileType="doc">/usr/share/help/kk/rhythmbox/figures/rb-toolbar-repeat.png</Path>
+            <Path fileType="doc">/usr/share/help/kk/rhythmbox/figures/rb-toolbar-shuffle.png</Path>
+            <Path fileType="doc">/usr/share/help/kk/rhythmbox/figures/rb-volume-changer.png</Path>
+            <Path fileType="doc">/usr/share/help/kk/rhythmbox/figures/rb-window.png</Path>
+            <Path fileType="doc">/usr/share/help/kk/rhythmbox/index.docbook</Path>
+            <Path fileType="doc">/usr/share/help/kk/rhythmbox/legal.xml</Path>
             <Path fileType="doc">/usr/share/help/oc/rhythmbox/figures/rb-iradio-main.png</Path>
             <Path fileType="doc">/usr/share/help/oc/rhythmbox/figures/rb-notification-zone.png</Path>
             <Path fileType="doc">/usr/share/help/oc/rhythmbox/figures/rb-podcast-main.png</Path>
@@ -296,6 +306,16 @@
             <Path fileType="doc">/usr/share/help/sl/rhythmbox/figures/rb-window.png</Path>
             <Path fileType="doc">/usr/share/help/sl/rhythmbox/index.docbook</Path>
             <Path fileType="doc">/usr/share/help/sl/rhythmbox/legal.xml</Path>
+            <Path fileType="doc">/usr/share/help/sr/rhythmbox/figures/rb-iradio-main.png</Path>
+            <Path fileType="doc">/usr/share/help/sr/rhythmbox/figures/rb-notification-zone.png</Path>
+            <Path fileType="doc">/usr/share/help/sr/rhythmbox/figures/rb-podcast-main.png</Path>
+            <Path fileType="doc">/usr/share/help/sr/rhythmbox/figures/rb-toolbar-prevplaynext.png</Path>
+            <Path fileType="doc">/usr/share/help/sr/rhythmbox/figures/rb-toolbar-repeat.png</Path>
+            <Path fileType="doc">/usr/share/help/sr/rhythmbox/figures/rb-toolbar-shuffle.png</Path>
+            <Path fileType="doc">/usr/share/help/sr/rhythmbox/figures/rb-volume-changer.png</Path>
+            <Path fileType="doc">/usr/share/help/sr/rhythmbox/figures/rb-window.png</Path>
+            <Path fileType="doc">/usr/share/help/sr/rhythmbox/index.docbook</Path>
+            <Path fileType="doc">/usr/share/help/sr/rhythmbox/legal.xml</Path>
             <Path fileType="doc">/usr/share/help/sv/rhythmbox/figures/rb-iradio-main.png</Path>
             <Path fileType="doc">/usr/share/help/sv/rhythmbox/figures/rb-notification-zone.png</Path>
             <Path fileType="doc">/usr/share/help/sv/rhythmbox/figures/rb-podcast-main.png</Path>
@@ -415,10 +435,11 @@
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/rhythmbox.mo</Path>
             <Path fileType="man">/usr/share/man/man1/rhythmbox-client.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/rhythmbox.1.zst</Path>
-            <Path fileType="data">/usr/share/metainfo/org.gnome.Rhythmbox3.appdata.xml</Path>
+            <Path fileType="data">/usr/share/metainfo/org.gnome.Rhythmbox3.metainfo.xml</Path>
             <Path fileType="data">/usr/share/rhythmbox/plugins/audioscrobbler/audioscrobbler-preferences.ui</Path>
             <Path fileType="data">/usr/share/rhythmbox/plugins/audioscrobbler/audioscrobbler-profile.ui</Path>
             <Path fileType="data">/usr/share/rhythmbox/plugins/audioscrobbler/icons/hicolor/scalable/places/Last.fm-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/rhythmbox/plugins/gpodder/gpodder-prefs.ui</Path>
             <Path fileType="data">/usr/share/rhythmbox/plugins/listenbrainz/settings.ui</Path>
             <Path fileType="data">/usr/share/rhythmbox/plugins/lyrics/lyrics-prefs.ui</Path>
             <Path fileType="data">/usr/share/rhythmbox/plugins/magnatune/icons/hicolor/scalable/places/magnatune-symbolic.svg</Path>
@@ -445,7 +466,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="66">rhythmbox</Dependency>
+            <Dependency release="67">rhythmbox</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/rhythmbox/backends/rb-encoder.h</Path>
@@ -532,12 +553,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="66">
-            <Date>2026-05-28</Date>
-            <Version>3.4.9</Version>
+        <Update release="67">
+            <Date>2026-08-12</Date>
+            <Version>3.5.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- New playback backend is enabled by default
- Support for finding lyrics using lrclib.net, in sidecar .lrc files, and embedded in Ogg files
- Reworked notifications for podcast updates and downloads
- Redesigned display of podcast episodes, including indication of episodes that have already been played
- New plugin implementing podcast feed and episode sync using the gPodder.net API

Resolves https://github.com/getsolus/packages/issues/10125

**Test Plan**

- Play a song

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
