### PR TITLE
libultrahdr: Update to v2.0.2

### DIFF
--- a/packages/l/libultrahdr/package.yml
+++ b/packages/l/libultrahdr/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libultrahdr
-version    : 2.0.1
-release    : 2
+version    : 2.0.2
+release    : 3
 source     :
-    - https://github.com/google/libultrahdr/archive/refs/tags/v2.0.1.tar.gz : 588232d2c9adcd01541d48dc2e76f8448c52fea7fc2543e700a281b995ab50d2
+    - https://github.com/google/libultrahdr/archive/refs/tags/v2.0.2.tar.gz : aa8d193bb887c348c419780511dd03b374f4e07af8812b6d3f80c8537cf1ef2c
 homepage   : https://github.com/google/libultrahdr
 license    : Apache-2.0
 component  : multimedia.library

--- a/packages/l/libultrahdr/pspec_x86_64.xml
+++ b/packages/l/libultrahdr/pspec_x86_64.xml
@@ -22,7 +22,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/ultrahdr_app</Path>
             <Path fileType="library">/usr/lib64/libuhdr.so.2</Path>
-            <Path fileType="library">/usr/lib64/libuhdr.so.2.0.1</Path>
+            <Path fileType="library">/usr/lib64/libuhdr.so.2.0.2</Path>
             <Path fileType="data">/usr/share/licenses/libultrahdr/LICENSE</Path>
         </Files>
     </Package>
@@ -33,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">libultrahdr</Dependency>
+            <Dependency release="3">libultrahdr</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ultrahdr_api.h</Path>
@@ -42,9 +42,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2026-08-11</Date>
-            <Version>2.0.1</Version>
+        <Update release="3">
+            <Date>2026-08-13</Date>
+            <Version>2.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- cmake: fix static libheif feature probe and cleanup target linking

**Test Plan**

Inspect gammamaps of some Ultra HDR images using `vipsheader` (from `libvips` package)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [ ] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
