### PR TITLE
noto-sans-ttf: Update to v2026.08.01

### DIFF
--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : noto-sans-ttf
-version    : 2026.07.01
-release    : 46
+version    : 2026.08.01
+release    : 47
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2026.07.01.tar.gz : b614152147d67bfceaaf3409600353e582a477fa64bef4da6a8ca2e370aaf531
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2026.08.01.tar.gz : ef269bd42da0cd1c602c69c9edd81c655662babf495f69cd66d01842a1b7bbb2
 homepage   : https://fonts.google.com/noto
 license    : OFL-1.1
 component  :
@@ -15,22 +15,22 @@ summary    :
 description: |
     Noto's goal is to provide a beautiful reading experience for all languages. It is a free, professionally-designed, open-source collection of fonts with a harmonious look and feel in multiple weights and styles.
 install    : |
-    install -Ddm00755 $installdir/usr/share/fonts/truetype/noto-sans-ttf
+    %install_dir $installdir/usr/share/fonts/truetype/noto-sans-ttf
 
     # Install fonts
     for tff in fonts/Noto*/hinted/ttf; do
         pushd $tff
             rm -f *-{Black,Extra}*.ttf *.ttc
-            install -m00644 * $installdir/usr/share/fonts/truetype/noto-sans-ttf
+            %install_file * $installdir/usr/share/fonts/truetype/noto-sans-ttf
         popd
     done
 
-    install -Dm00644 $pkgfiles/noto-sans-ttf.metainfo.xml $installdir/usr/share/metainfo/noto-sans-ttf.metainfo.xml
-    install -Dm00644 $pkgfiles/noto-serif-ttf.metainfo.xml $installdir/usr/share/metainfo/noto-serif-ttf.metainfo.xml
+    %install_file $pkgfiles/noto-sans-ttf.metainfo.xml $installdir/usr/share/metainfo/noto-sans-ttf.metainfo.xml
+    %install_file $pkgfiles/noto-serif-ttf.metainfo.xml $installdir/usr/share/metainfo/noto-serif-ttf.metainfo.xml
 
-    install -dm00755 $installdir/usr/share/licenses/noto-{sans,serif}-ttf/
-    install -Dm00644 fonts/LICENSE $installdir/usr/share/licenses/noto-sans-ttf/
-    install -Dm00644 fonts/LICENSE $installdir/usr/share/licenses/noto-serif-ttf/
+    %install_dir $installdir/usr/share/licenses/noto-{sans,serif}-ttf/
+    %install_file fonts/LICENSE $installdir/usr/share/licenses/noto-sans-ttf/
+    %install_file fonts/LICENSE $installdir/usr/share/licenses/noto-serif-ttf/
 patterns   :
     - ^noto-serif-ttf :
         - /usr/share/fonts/truetype/noto-sans-ttf/NotoSerif*

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>noto-sans-ttf</Name>
         <Homepage>https://fonts.google.com/noto</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
@@ -1562,12 +1562,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2026-07-06</Date>
-            <Version>2026.07.01</Version>
+        <Update release="47">
+            <Date>2026-08-13</Date>
+            <Version>2026.08.01</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:

No changelog available. Full commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-2026.07.01...noto-monthly-release-2026.08.01)

Packaging change: Use new install macros

**Test Plan**
- Confirmed system UI looked correct using Noto Sans system font
- Wrote some text in LibreOffice Writer using Noto Serif and Noto Sans

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [ ] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
