### PR TITLE
anthy: Rebuild for build_host & generateDebug correction

### DIFF
--- a/packages/a/anthy/package.yml
+++ b/packages/a/anthy/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : anthy
 version    : 9100h
-release    : 5
+release    : 6
 source     :
     - https://sources.getsol.us/anthy-9100h.tar.gz : d256f075f018b4a3cb0d165ed6151fda4ba7db1621727e0eb54569b6e2275547
 homepage   : https://osdn.net/projects/anthy/

--- a/packages/a/anthy/pspec_x86_64.xml
+++ b/packages/a/anthy/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>anthy</Name>
         <Homepage>https://osdn.net/projects/anthy/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -45,7 +45,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">anthy</Dependency>
+            <Dependency release="6">anthy</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/anthy/anthy.h</Path>
@@ -58,12 +58,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-08-06</Date>
+        <Update release="6">
+            <Date>2026-08-13</Date>
             <Version>9100h</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

New build server was misconfigured initially. It used default eopkg.conf up until eopkg.conf
was copied from old build server to new one.
In default eopkg.conf, build_host is set to localhost, and generateDebug to False.
As a result, already built packages miss debug packages and falsely appear as output for
`eopkg li -b localhost`.
This is a pure relbump rebuild to fix this.

**Test Plan**
- Verified package builds successfully
- Verified library function by running `anthy-morphological-analyzer`

**Checklist**
- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes
once merged <!-- Write an appropriate message in the Summary section,
then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous
contributions under the licensing terms in
[LICENSE.md](../blob/main/LICENSE.md) and have the power and authority
to grant those licenses.
