### PR TITLE
msodbcsql monitoring yaml file added

### DIFF
--- a/packages/m/msodbcsql/monitoring.yaml
+++ b/packages/m/msodbcsql/monitoring.yaml
@@ -1,0 +1,7 @@
+releases:
+  id: 390777
+  rss: ~
+security:
+  cpe:
+    - vendor: microsoft
+      product: odbc_driver_for_sql_server


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->
Adds monitoring.yaml to msodbcsql (Microsoft ODBC Driver for SQL Server). Part of [#4121](https://github.com/getsolus/packages/issues/4121).

- Anitya ID 390777 - uses a custom backend scraping the MS Learn download page (Microsoft ships via packages.microsoft.com RPMs, so there's no git/RSS feed). Verified project exists on release-monitoring.org: real versions retrieved (17.11.1.1, 18.6.2.1).

- CPE microsoft:odbc_driver_for_sql_server - verified against NVD (30 entries, incl. 17.10.x).

Note: this package tracks the 17 series (17.10.6.1); Anitya reports 18.6.2.1 as latest, so it will show as behind by design — the value here is both release-awareness and CVE monitoring.

**Test Plan**

<!-- Short description of how the package was tested -->

- Confirmed monitoring.yaml is valid YAML
- Confirmed Anitya 390777 resolves with real version data
- Confirmed the CPE matches NVD's microsoft:odbc_driver_for_sql_server

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
