### PR TITLE
fastfetch: Update to v2.67.1

### DIFF
--- a/packages/f/fastfetch/package.yml
+++ b/packages/f/fastfetch/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fastfetch
-version    : 2.67.0
-release    : 80
+version    : 2.67.1
+release    : 81
 source     :
-    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.67.0.tar.gz : d962730d14454cc24a31b796f02459274741034b4b774888b1426be0854b615e
+    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.67.1.tar.gz : 52489550d1fdeac8bde8b3442064e3bc78d28fda752a171dc46a6cd97454f237
 homepage   : https://github.com/fastfetch-cli/fastfetch
 license    : MIT
 component  : system.utils

--- a/packages/f/fastfetch/pspec_x86_64.xml
+++ b/packages/f/fastfetch/pspec_x86_64.xml
@@ -67,9 +67,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="80">
-            <Date>2026-08-06</Date>
-            <Version>2.67.0</Version>
+        <Update release="81">
+            <Date>2026-08-14</Date>
+            <Version>2.67.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.67.1).

**Test Plan**

Run `fastfetch`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
