### PR TITLE
containerd: Update to v2.3.4

### DIFF
--- a/packages/b/buildkit/package.yml
+++ b/packages/b/buildkit/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : buildkit
-version    : 0.32.1
-release    : 13
+version    : 0.32.2
+release    : 14
 source     :
-    - https://github.com/moby/buildkit/archive/refs/tags/v0.32.1.tar.gz : 23370825c523e11655690818c7e9b571f9b7b498383b49f592791b64977265bb
+    - https://github.com/moby/buildkit/archive/refs/tags/v0.32.2.tar.gz : b19deba3f8cf3eb05407aa85c246e22839770c437439a04d880ef3d645aed0aa
 homepage   : https://github.com/moby/buildkit
 license    : Apache-2.0
 component  : virt

--- a/packages/b/buildkit/pspec_x86_64.xml
+++ b/packages/b/buildkit/pspec_x86_64.xml
@@ -30,9 +30,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-08-04</Date>
-            <Version>0.32.1</Version>
+        <Update release="14">
+            <Date>2026-08-14</Date>
+            <Version>0.32.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/c/containerd/package.yml
+++ b/packages/c/containerd/package.yml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : containerd
-version    : 2.3.3
-release    : 75
+version    : 2.3.4
+release    : 76
 source     :
-    - https://github.com/containerd/containerd/archive/refs/tags/v2.3.3.tar.gz : fcff2096ef20f1bc1d939bc55a8b831ea3eface574463fd7dc770b33ffe317b2
+    - https://github.com/containerd/containerd/archive/refs/tags/v2.3.4.tar.gz : 175bbf57d637c987fa742f846b43b1b8ba2c61af6a9eaec619c625e4a8a19b69
+homepage   : https://containerd.io/
 license    : Apache-2.0
 component  : virt
-homepage   : https://containerd.io/
 summary    : A daemon to control OCI container runtimes
 description: |
     A daemon to control OCI container runtimes
@@ -44,13 +44,13 @@ install    : |
     %install_license LICENSE
 
     # Install the service file, but disable it by default
-    install -Dm00644 containerd.service ${installdir}/%libdir%/systemd/system/containerd.service
-    install -Dm00644 ${pkgfiles}/containerd.preset ${installdir}/%libdir%/systemd/system-preset/containerd.preset
+    %install_file containerd.service ${installdir}/%libdir%/systemd/system/containerd.service
+    %install_file ${pkgfiles}/containerd.preset ${installdir}/%libdir%/systemd/system-preset/containerd.preset
 
     # Shell Completions
-    install -Dm00644 contrib/autocomplete/ctr ${installdir}/usr/share/bash-completion/completions/ctr
-    install -Dm00644 contrib/autocomplete/zsh_autocomplete ${installdir}/usr/share/zsh/site-functions/_ctr
+    %install_file contrib/autocomplete/ctr ${installdir}/usr/share/bash-completion/completions/ctr
+    %install_file contrib/autocomplete/zsh_autocomplete ${installdir}/usr/share/zsh/site-functions/_ctr
 
     # Man pages
-    install -Dm00644 man/*.8 -t ${installdir}/usr/share/man/man8
-    install -Dm00644 man/*.5 -t ${installdir}/usr/share/man/man5
+    %install_file man/*.8 -t ${installdir}/usr/share/man/man8
+    %install_file man/*.5 -t ${installdir}/usr/share/man/man5

--- a/packages/c/containerd/pspec_x86_64.xml
+++ b/packages/c/containerd/pspec_x86_64.xml
@@ -36,9 +36,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="75">
-            <Date>2026-07-10</Date>
-            <Version>2.3.3</Version>
+        <Update release="76">
+            <Date>2026-08-14</Date>
+            <Version>2.3.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes for `containerd` can be found [here](https://github.com/containerd/containerd/releases/tag/v2.3.4).
- Release notes for `buildkit` can be found [here](https://github.com/moby/buildkit/releases/tag/v0.32.2).

**Test Plan**

docker still works

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
