### PR TITLE
golang: Update to v1.26.6

### DIFF
--- a/packages/g/golang/package.yml
+++ b/packages/g/golang/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 # If you're updating this package to a new major version of golang, please update gopls to a version with support for that golang version
 name       : golang
-version    : 1.26.5
-release    : 144
+version    : 1.26.6
+release    : 145
 homepage   : https://golang.org
 source     :
-    - https://golang.org/dl/go1.26.5.src.tar.gz : 495be4bc87176ac567392e5b4116abd98466d33d7b49d41e764ccc6976b2dc42
+    - https://golang.org/dl/go1.26.6.src.tar.gz : a0721c54c688901448d77ad9b3ec7ea7c474730755ff891382e92ecb93ff2cb1
 license    : BSD-3-Clause
 summary    : The Go programming language
 description: Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.

--- a/packages/g/golang/pspec_x86_64.xml
+++ b/packages/g/golang/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>golang</Name>
         <Homepage>https://golang.org</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming</PartOf>
@@ -14853,6 +14853,7 @@
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue79186.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7921.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7944.go</Path>
+            <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue79874.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7995.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7995b.dir/x1.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7995b.dir/x2.go</Path>
@@ -14862,8 +14863,11 @@
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7998.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue80004.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8004.go</Path>
+            <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue80097.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8011.go</Path>
+            <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue80127.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8017.go</Path>
+            <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue80188.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8028.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8036.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8039.go</Path>
@@ -14871,6 +14875,10 @@
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8047.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8047b.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8048.go</Path>
+            <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue80517_1.go</Path>
+            <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue80517_2.go</Path>
+            <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue80517_3.go</Path>
+            <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue80577.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8060.dir/a.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8060.dir/b.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue8060.go</Path>
@@ -15766,12 +15774,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="144">
-            <Date>2026-07-15</Date>
-            <Version>1.26.5</Version>
+        <Update release="145">
+            <Date>2026-08-14</Date>
+            <Version>1.26.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://groups.google.com/g/golang-announce/c/94pEornpRlI)

**Security**

- CVE-2026-56865
- CVE-2026-56864
- CVE-2026-56859
- CVE-2026-56853
- CVE-2026-56860
- CVE-2026-46600
- CVE-2026-56862
- CVE-2026-56858
- CVE-2026-39821
- CVE-2026-33818

**Test Plan**

- Build a go package

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
