### PR TITLE
dua-cli: Update to v2.42.0

### DIFF
--- a/packages/d/dua-cli/package.yml
+++ b/packages/d/dua-cli/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dua-cli
-version    : 2.41.1
-release    : 10
+version    : 2.42.0
+release    : 11
 source     :
-    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.41.1.tar.gz : 68a37e947aa19d2aeed3f24180e6c52017a7c185677456acabcde38ce10cbb9e
+    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.42.0.tar.gz : 1be17656a08653ed75f9187a8909c2fbed0f03da0a5d1a11ab648ab2ee08e332
 homepage   : https://github.com/Byron/dua-cli
 license    : MIT
 component  : system.utils

--- a/packages/d/dua-cli/pspec_x86_64.xml
+++ b/packages/d/dua-cli/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2026-08-05</Date>
-            <Version>2.41.1</Version>
+        <Update release="11">
+            <Date>2026-08-14</Date>
+            <Version>2.42.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Byron/dua-cli/releases/tag/v2.42.0).

**Test Plan**

See sizes and file system

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
