### PR TITLE
zip: Add Fedora security patches and install manpages

### DIFF
--- a/packages/z/zip/files/buffer_overflow.patch
+++ b/packages/z/zip/files/buffer_overflow.patch
@@ -1,0 +1,12 @@
+diff -urp zip30/fileio.c zip30/fileio.c
+--- zip30/fileio.c	2008-05-29 03:13:24.000000000 +0300
++++ zip30/fileio.c	2023-05-02 12:19:50.488314853 +0300
+@@ -3502,7 +3502,7 @@ zwchar *local_to_wide_string(local_strin
+   if ((wc_string = (wchar_t *)malloc((wsize + 1) * sizeof(wchar_t))) == NULL) {
+     ZIPERR(ZE_MEM, "local_to_wide_string");
+   }
+-  wsize = mbstowcs(wc_string, local_string, strlen(local_string) + 1);
++  wsize = mbstowcs(wc_string, local_string, wsize + 1);
+   wc_string[wsize] = (wchar_t) 0;
+ 
+   /* in case wchar_t is not zwchar */

--- a/packages/z/zip/files/zip-3.0-currdir.patch
+++ b/packages/z/zip/files/zip-3.0-currdir.patch
@@ -1,0 +1,12 @@
+diff -up zip30/util.c.currdir zip30/util.c
+--- zip30/util.c.currdir	2009-11-16 12:42:17.783961701 +0100
++++ zip30/util.c	2009-11-16 12:42:58.185960707 +0100
+@@ -493,6 +493,8 @@ int cs;                 /* force case-se
+ /* Compare the sh pattern p with the string s and return true if they match,
+    false if they don't or if there is a syntax error in the pattern. */
+ {
++  while (s[0] == '.' && s[1] == '/') 
++    s += 2;                /* strip redundant leading "./" sections */
+   return recmatch(p, s, cs) == 1;
+ }
+ 

--- a/packages/z/zip/files/zip-3.0-exec-shield.patch
+++ b/packages/z/zip/files/zip-3.0-exec-shield.patch
@@ -1,0 +1,20 @@
+diff -up zip30/crc_i386.S.exec_shield zip30/crc_i386.S
+--- zip30/crc_i386.S.exec_shield	2009-11-13 18:37:45.000000000 +0100
++++ zip30/crc_i386.S	2009-11-13 18:39:54.435390166 +0100
+@@ -302,3 +302,6 @@ _crc32:                         /* ulg c
+ #endif /* i386 || _i386 || _I386 || __i386 */
+ 
+ #endif /* !USE_ZLIB && !CRC_TABLE_ONLY */
++
++.section .note.GNU-stack, "", @progbits
++.previous
+diff -up zip30/match.S.exec_shield zip30/match.S
+--- zip30/match.S.exec_shield	2005-01-28 10:40:14.000000000 +0100
++++ zip30/match.S	2009-11-13 18:39:48.570389058 +0100
+@@ -405,3 +405,6 @@ L__return:
+ #endif /* i386 || _I386 || _i386 || __i386  */
+ 
+ #endif /* !USE_ZLIB */
++
++.section .note.GNU-stack, "", @progbits
++.previous

--- a/packages/z/zip/files/zip-3.0-format-security.patch
+++ b/packages/z/zip/files/zip-3.0-format-security.patch
@@ -1,0 +1,20 @@
+--- a/zip.c	
++++ a/zip.c	
+@@ -1028,7 +1028,7 @@ local void help_extended()
+ 
+   for (i = 0; i < sizeof(text)/sizeof(char *); i++)
+   {
+-    printf(text[i]);
++    printf("%s", text[i]);
+     putchar('\n');
+   }
+ #ifdef DOS
+@@ -1225,7 +1225,7 @@ local void version_info()
+             CR_MAJORVER, CR_MINORVER, CR_BETA_VER, CR_VERSION_DATE);
+   for (i = 0; i < sizeof(cryptnote)/sizeof(char *); i++)
+   {
+-    printf(cryptnote[i]);
++    printf("%s", cryptnote[i]);
+     putchar('\n');
+   }
+   ++i;  /* crypt support means there IS at least one compilation option */

--- a/packages/z/zip/files/zip-gnu89-build.patch
+++ b/packages/z/zip/files/zip-gnu89-build.patch
@@ -1,0 +1,15 @@
+zip uses C89-only features, so it needs to be built in C89 mode.
+
+diff --git a/unix/Makefile b/unix/Makefile
+index 86cf54bf0f56cea9..244390893eab5fc6 100644
+--- a/unix/Makefile
++++ b/unix/Makefile
+@@ -202,7 +202,7 @@ generic: flags
+ 	eval $(MAKE) $(MAKEF) zips `cat flags`
+ 
+ generic_gcc:
+-	$(MAKE) $(MAKEF) generic CC=gcc CPP="gcc -E"
++	$(MAKE) $(MAKEF) generic CC="gcc -std=gnu89" CPP="gcc -E"
+ 
+ # AT&T 6300 PLUS (don't know yet how to allocate 64K bytes):
+ att6300nodir:

--- a/packages/z/zip/files/zipnote.patch
+++ b/packages/z/zip/files/zipnote.patch
@@ -1,0 +1,13 @@
+diff --git a/zipnote.c b/zipnote.c
+index 5e02cb6..996f012 100644
+--- a/zipnote.c
++++ b/zipnote.c
+@@ -661,7 +661,7 @@ char **argv;            /* command line tokens */
+     if ((r = zipcopy(z)) != ZE_OK)
+       ziperr(r, "was copying an entry");
+   }
+-  fclose(x);
++  fclose(in_file);
+ 
+   /* Write central directory and end of central directory with new comments */
+   if ((c = zftello(y)) == (zoff_t)-1)    /* get start of central */

--- a/packages/z/zip/package.yml
+++ b/packages/z/zip/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : zip
 version    : '3.0'
-release    : 5
+release    : 6
 source     :
     - https://sourceforge.net/projects/infozip/files/Zip%203.x%20%28latest%29/3.0/zip30.tar.gz : f0e8bb1f9b7eb0b01285495a2699df3a4b766784c1765a8f1aeedf63c0806369
 homepage   : https://infozip.sourceforge.net/
@@ -12,10 +12,19 @@ description: |
     This is InfoZIP's zip program. It produces files that are fully compatible with the popular PKZIP program; however, the command line options are not identical. In other words, the end result is the same, but the methods differ.
 builddeps  :
     - pkgconfig(bzip2)
+setup      : |
+    %patch -p1 -i ${pkgfiles}/zip-3.0-currdir.patch
+    %patch -p1 -i ${pkgfiles}/zip-3.0-exec-shield.patch
+    %patch -p1 -i ${pkgfiles}/zip-3.0-format-security.patch
+    %patch -p1 -i ${pkgfiles}/zipnote.patch
+    %patch -p1 -i ${pkgfiles}/buffer_overflow.patch
+    %patch -p1 -i ${pkgfiles}/zip-gnu89-build.patch
 build      : |
-    %make -f unix/Makefile generic_gcc
+    %make -f unix/Makefile prefix=/usr generic_gcc
 install    : |
-    for bin in zip zipcloak zipnote zipsplit; do
-        install -Dm00755 $bin $installdir/usr/bin/$bin
-    done
-# TODO package man pages and fedora security patches
+    %make -f unix/Makefile \
+        prefix="${installdir}/usr" \
+        MANDIR="${installdir}/usr/share/man/man1" \
+        install
+
+    %install_license LICENSE

--- a/packages/z/zip/pspec_x86_64.xml
+++ b/packages/z/zip/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>zip</Name>
         <Homepage>https://infozip.sourceforge.net/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Info-ZIP</License>
         <PartOf>system.base</PartOf>
@@ -24,15 +24,20 @@
             <Path fileType="executable">/usr/bin/zipcloak</Path>
             <Path fileType="executable">/usr/bin/zipnote</Path>
             <Path fileType="executable">/usr/bin/zipsplit</Path>
+            <Path fileType="data">/usr/share/licenses/zip/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/zip.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/zipcloak.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/zipnote.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/zipsplit.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2023-10-10</Date>
+        <Update release="6">
+            <Date>2026-08-14</Date>
             <Version>3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Add Fedora security patches and install manpages.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Add `abi_libs` to a zip archive.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
