### PR TITLE
systemd: Backport patch for locale issue

### DIFF
--- a/packages/s/systemd/abi_symbols
+++ b/packages/s/systemd/abi_symbols
@@ -7908,6 +7908,7 @@ libsystemd-shared-261.so:x11_context_empty_to_null
 libsystemd-shared-261.so:x11_context_equal
 libsystemd-shared-261.so:x11_context_is_safe
 libsystemd-shared-261.so:x11_context_isempty
+libsystemd-shared-261.so:x11_context_normalize
 libsystemd-shared-261.so:x11_context_replace
 libsystemd-shared-261.so:x11_convert_to_vconsole
 libsystemd-shared-261.so:x509_fingerprint

--- a/packages/s/systemd/abi_symbols32
+++ b/packages/s/systemd/abi_symbols32
@@ -6902,6 +6902,7 @@ libsystemd-shared-261.so:x11_context_empty_to_null
 libsystemd-shared-261.so:x11_context_equal
 libsystemd-shared-261.so:x11_context_is_safe
 libsystemd-shared-261.so:x11_context_isempty
+libsystemd-shared-261.so:x11_context_normalize
 libsystemd-shared-261.so:x11_context_replace
 libsystemd-shared-261.so:x11_convert_to_vconsole
 libsystemd-shared-261.so:xattr_is_acl

--- a/packages/s/systemd/files/patches/upstream/systemd-261-dont-discard-x11-context.patch
+++ b/packages/s/systemd/files/patches/upstream/systemd-261-dont-discard-x11-context.patch
@@ -1,0 +1,130 @@
+From 05791203a5a2f5c9ed22081bf82871db1207e6ee Mon Sep 17 00:00:00 2001
+From: Liu Zheng <liuzheng@uniontech.com>
+Date: Tue, 28 Jul 2026 08:07:16 +0800
+Subject: [PATCH] localed: normalize empty X11 option values to NULL after
+ parsing
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+x11_read_data() parses an 'Option "XkbVariant" ""' line in
+00-keyboard.conf with strv_split_full(..., EXTRACT_UNQUOTE), which turns
+the empty quoted value into a non-NULL empty string rather than NULL.
+Since 812aa57d2c ("string-util: beef up string_is_safe()") an empty
+string is rejected by string_is_safe() unless STRING_ALLOW_EMPTY is
+passed, so x11_context_is_safe() now refuses such a context and
+x11_context_verify() discards the whole thing. As a result "localectl
+status" reports "X11 Layout: (unset)" even though the file names a valid
+layout, and compositors reading org.freedesktop.locale1 (e.g. the SDDM
+greeter) fall back to the us layout.
+
+Introduce x11_context_normalize(), suggested by @lionheartyu, which
+converts empty strings to NULL while freeing the heap allocation —
+unlike x11_context_empty_to_null() which only NULLs the pointer without
+freeing. Call it at the end of x11_read_data(), before
+x11_context_verify(), so empty option values are treated as unset. This
+also keeps x11_context_equal() comparisons consistent with the setter
+path (method_set_x11_keyboard) and vconsole_read_data(), which both
+store NULL for empty values.
+
+Fixes #43007
+---
+ src/locale/localed-util.c      |  2 ++
+ src/locale/test-localed-util.c | 27 +++++++++++++++++++++++++++
+ src/shared/vconsole-util.c     | 19 +++++++++++++++++++
+ src/shared/vconsole-util.h     |  1 +
+ 4 files changed, 49 insertions(+)
+
+diff --git a/src/locale/localed-util.c b/src/locale/localed-util.c
+index ab2abd7daea..f66db07b145 100644
+--- a/src/locale/localed-util.c
++++ b/src/locale/localed-util.c
+@@ -288,6 +288,8 @@ int x11_read_data(Context *c, sd_bus_message *m) {
+                         in_section = false;
+         }
+ 
++        x11_context_normalize(&c->x11_from_xorg);
++
+         if (x11_context_verify(&c->x11_from_xorg) < 0)
+                 x11_context_clear(&c->x11_from_xorg);
+ 
+diff --git a/src/locale/test-localed-util.c b/src/locale/test-localed-util.c
+index 9bcc8020096..094f300266c 100644
+--- a/src/locale/test-localed-util.c
++++ b/src/locale/test-localed-util.c
+@@ -231,6 +231,33 @@ TEST(x11_convert_to_vconsole) {
+         ASSERT_STREQ(vc.keymap, "ru");
+ }
+ 
++TEST(x11_context_normalize) {
++        _cleanup_(x11_context_clear) X11Context xc = {};
++
++        /* x11_read_data() parses 'Option "XkbVariant" ""' into a non-NULL
++         * empty string. x11_context_normalize() converts empty strings back
++         * to NULL (with freeing), so that x11_context_is_safe() and
++         * x11_context_equal() treat them as unset. See issue #43007. */
++
++        /* Empty fields are normalized to NULL. */
++        ASSERT_OK(free_and_strdup(&xc.layout, "gb"));
++        ASSERT_OK(free_and_strdup(&xc.variant, ""));
++        ASSERT_OK(free_and_strdup(&xc.options, ""));
++        x11_context_normalize(&xc);
++        ASSERT_STREQ(xc.layout, "gb");
++        ASSERT_NULL(xc.variant);
++        ASSERT_NULL(xc.options);
++        ASSERT_TRUE(x11_context_is_safe(&xc));
++        ASSERT_OK(x11_context_verify(&xc));
++
++        /* An empty layout leaves the context empty, not unsafe. */
++        x11_context_clear(&xc);
++        ASSERT_OK(free_and_strdup(&xc.layout, ""));
++        x11_context_normalize(&xc);
++        ASSERT_NULL(xc.layout);
++        ASSERT_TRUE(x11_context_isempty(&xc));
++}
++
+ static int intro(void) {
+         _cleanup_free_ char *map = NULL;
+ 
+diff --git a/src/shared/vconsole-util.c b/src/shared/vconsole-util.c
+index a780b273aab..048c44b55b1 100644
+--- a/src/shared/vconsole-util.c
++++ b/src/shared/vconsole-util.c
+@@ -84,6 +84,25 @@ void x11_context_empty_to_null(X11Context *xc) {
+         xc->options = empty_to_null(xc->options);
+ }
+ 
++static char* empty_to_null_and_free(char *p) {
++        return isempty(p) ? mfree(p) : p;
++}
++
++void x11_context_normalize(X11Context *xc) {
++        assert(xc);
++
++        /* Like x11_context_empty_to_null(), but also frees the heap memory
++         * owned by the fields. Use this for contexts whose strings are
++         * heap-allocated (e.g. x11_read_data()), not for borrowed contexts
++         * such as the one built by method_set_x11_keyboard() from a D-Bus
++         * message. */
++
++        xc->layout  = empty_to_null_and_free(xc->layout);
++        xc->model   = empty_to_null_and_free(xc->model);
++        xc->variant = empty_to_null_and_free(xc->variant);
++        xc->options = empty_to_null_and_free(xc->options);
++}
++
+ bool x11_context_is_safe(const X11Context *xc) {
+         assert(xc);
+ 
+diff --git a/src/shared/vconsole-util.h b/src/shared/vconsole-util.h
+index 624674b7ba5..97fb5f4d9ec 100644
+--- a/src/shared/vconsole-util.h
++++ b/src/shared/vconsole-util.h
+@@ -19,6 +19,7 @@ void x11_context_clear(X11Context *xc);
+ void x11_context_replace(X11Context *dest, X11Context *src);
+ bool x11_context_isempty(const X11Context *xc);
+ void x11_context_empty_to_null(X11Context *xc);
++void x11_context_normalize(X11Context *xc);
+ bool x11_context_is_safe(const X11Context *xc);
+ bool x11_context_equal(const X11Context *a, const X11Context *b);
+ int x11_context_copy(X11Context *dest, const X11Context *src);

--- a/packages/s/systemd/package.yml
+++ b/packages/s/systemd/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : systemd
 version    : '261.2'
-release    : 189
+release    : 190
 source     :
     - https://github.com/systemd/systemd/archive/refs/tags/v261.2.tar.gz : ed1059ff964f5df35b6056434cc17cc83f86dc913f10489948a0b19b6081c5ec
 license    :
@@ -98,6 +98,7 @@ setup      : |
     %patch -p1 -i ${pkgfiles}/patches/downstream/0001-Remove-etc-os-release-from-tmpfiles.patch
 
     # Upstream patches
+    %patch -p1 -i ${pkgfiles}/patches/upstream/systemd-261-dont-discard-x11-context.patch
 
     # ERROR: File fuzz-unit-file/dm-back-slash.swap does not exist.
     # mv "test/fuzz/fuzz-unit-file/dm-back\x2dslash.swap" "test/fuzz/fuzz-unit-file/dm-back-slash.swap"

--- a/packages/s/systemd/pspec_x86_64.xml
+++ b/packages/s/systemd/pspec_x86_64.xml
@@ -154,6 +154,7 @@
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p42100-lenovo-thinkbook-16.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p42100-microsoft-surface-pro-12in.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p64100-acer-swift-sf14-11.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/solus-mok.cer</Path>
             <Path fileType="library">/usr/lib/systemd/catalog/systemd.be.catalog</Path>
             <Path fileType="library">/usr/lib/systemd/catalog/systemd.be@latin.catalog</Path>
             <Path fileType="library">/usr/lib/systemd/catalog/systemd.bg.catalog</Path>
@@ -1656,7 +1657,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="189">systemd</Dependency>
+            <Dependency release="190">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnss_myhostname.so.2</Path>
@@ -1679,8 +1680,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="189">systemd-32bit</Dependency>
-            <Dependency release="189">systemd-devel</Dependency>
+            <Dependency release="190">systemd-32bit</Dependency>
+            <Dependency release="190">systemd-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib32/pkgconfig/libsystemd.pc</Path>
@@ -1694,7 +1695,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="189">systemd</Dependency>
+            <Dependency release="190">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libudev.h</Path>
@@ -2597,8 +2598,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="189">
-            <Date>2026-08-04</Date>
+        <Update release="190">
+            <Date>2026-08-15</Date>
             <Version>261.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
Backport patch for locale issue.

After pushing, please see if it can be cleanly cherry-picked to Polaris, and do the cherry-pick if so.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Fix verifed by forum user.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
