### PR TITLE
argon2: Rebuild for build_host & generateDebug correction

### DIFF
--- a/packages/a/argon2/package.yml
+++ b/packages/a/argon2/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : argon2
 version    : '20190702'
-release    : 7
+release    : 8
 source     :
     - https://github.com/P-H-C/phc-winner-argon2/archive/20190702.tar.gz : daf972a89577f8772602bf2eb38b6a3dd3d922bf5724d45e7f9589b5e830442c
 homepage   : https://github.com/P-H-C/phc-winner-argon2/

--- a/packages/a/argon2/pspec_x86_64.xml
+++ b/packages/a/argon2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>argon2</Name>
         <Homepage>https://github.com/P-H-C/phc-winner-argon2/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>CC0-1.0</License>
@@ -34,7 +34,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">argon2</Dependency>
+            <Dependency release="8">argon2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/argon2.h</Path>
@@ -43,12 +43,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2026-08-06</Date>
+        <Update release="8">
+            <Date>2026-08-16</Date>
             <Version>20190702</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

New build server was misconfigured initially. It used default eopkg.conf up until eopkg.conf
was copied from old build server to new one.
In default eopkg.conf, build_host is set to localhost, and generateDebug to False.
As a result, already built packages miss debug packages and falsely appear as output for
`eopkg li -b localhost`.
This is a pure relbump rebuild to fix this.

**Test Plan**
- Verified package builds successfully

**Checklist**
- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes
once merged <!-- Write an appropriate message in the Summary section,
then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous
contributions under the licensing terms in
[LICENSE.md](../blob/main/LICENSE.md) and have the power and authority
to grant those licenses.