### PR TITLE
kraft: Add missing dependency chain

### DIFF
--- a/packages/k/kraft/abi_used_symbols
+++ b/packages/k/kraft/abi_used_symbols
@@ -510,7 +510,7 @@ libQt6Core.so.6:_ZN9QMetaType29unregisterMutableViewFunctionES_S_
 libQt6Core.so.6:_ZN9QMetaType7convertES_PKvS_Pv
 libQt6Core.so.6:_ZN9QSaveFile4openE6QFlagsIN13QIODeviceBase12OpenModeFlagEE
 libQt6Core.so.6:_ZN9QSaveFile6commitEv
-libQt6Core.so.6:_ZN9QSaveFileC1ERK7QString
+libQt6Core.so.6:_ZN9QSaveFileC1ERK7QStringP7QObject
 libQt6Core.so.6:_ZN9QSaveFileD1Ev
 libQt6Core.so.6:_ZN9QSettings4syncEv
 libQt6Core.so.6:_ZN9QSettings8setValueE14QAnyStringViewRK8QVariant
@@ -793,8 +793,8 @@ libQt6Gui.so.6:_ZN7QPixmap4fillERK6QColor
 libQt6Gui.so.6:_ZN7QPixmapC1Eii
 libQt6Gui.so.6:_ZN7QPixmapC1Ev
 libQt6Gui.so.6:_ZN7QPixmapD1Ev
+libQt6Gui.so.6:_ZN8QPainter10doSetBrushERK6QBrushPS0_
 libQt6Gui.so.6:_ZN8QPainter8setBrushE6QColor
-libQt6Gui.so.6:_ZN8QPainter8setBrushERK6QBrush
 libQt6Gui.so.6:_ZN8QPainter9drawRectsEPK5QRecti
 libQt6Gui.so.6:_ZN8QPainterC1EP12QPaintDevice
 libQt6Gui.so.6:_ZN8QPainterD1Ev

--- a/packages/k/kraft/package.yml
+++ b/packages/k/kraft/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : kraft
 version    : 2.0.0
-release    : 15
+release    : 16
 source     :
     - https://github.com/dragotin/kraft/archive/refs/tags/v2.0.0.tar.gz : 8da453c62a54ad67c711a295a4d562cf856a95253eade1701e0945a83da28571
 homepage   : https://volle-kraft-voraus.de
@@ -28,6 +28,7 @@ rundeps    :
     - python-pypdf2
     - python-reportlab
     - python-six
+    - python-weasyprint
 setup      : |
     # Added StartupWMClass to desktop file
     %patch -p1 -i $pkgfiles/0001-fix-icon-in-overview.patch

--- a/packages/k/kraft/pspec_x86_64.xml
+++ b/packages/k/kraft/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>kraft</Name>
         <Homepage>https://volle-kraft-voraus.de</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office.finance</PartOf>
@@ -190,12 +190,12 @@ With Kraft, writing documents like quotes and invoices is very easy and fast. Re
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2026-01-07</Date>
+        <Update release="16">
+            <Date>2026-08-16</Date>
             <Version>2.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/py/python-pydyf/monitoring.yaml
+++ b/packages/py/python-pydyf/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 179112
+  rss: https://github.com/CourtBouillon/pydyf/tags.atom
+ # No known CPE, checked 2026-08-16
+security:
+  cpe: ~

--- a/packages/py/python-pydyf/package.yml
+++ b/packages/py/python-pydyf/package.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
+name       : python-pydyf
+version    : 0.12.1
+release    : 1
+source     :
+    - https://github.com/CourtBouillon/pydyf/archive/refs/tags/v0.12.1.tar.gz : 7506b3bcf6da5400e6d8f26422eb386bdf4beb4d0e7ab15990fbb03b325884ea
+homepage   : https://courtbouillon.org/pydyf
+license    : MIT
+component  : programming.python
+summary    : A tiny HTML5 parser
+description: |
+    tinyhtml5 is a HTML5 parser that transforms a possibly malformed HTML document into an ElementTree tree. It is a simplified fork of html5lib.
+builddeps  :
+    - python-build
+    - python-flit-core
+    - python-installer
+checkdeps  :
+    - ghostscript
+    - python-pillow
+    - python-pytest
+    - python-ruff
+build      : |
+    %pyproject_build
+install    : |
+    %pyproject_install
+check : |
+    %pytest -v

--- a/packages/py/python-pydyf/pspec_x86_64.xml
+++ b/packages/py/python-pydyf/pspec_x86_64.xml
@@ -1,0 +1,41 @@
+<PISI>
+    <Source>
+        <Name>python-pydyf</Name>
+        <Homepage>https://courtbouillon.org/pydyf</Homepage>
+        <Packager>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">A tiny HTML5 parser</Summary>
+        <Description xml:lang="en">tinyhtml5 is a HTML5 parser that transforms a possibly malformed HTML document into an ElementTree tree. It is a simplified fork of html5lib.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python-pydyf</Name>
+        <Summary xml:lang="en">A tiny HTML5 parser</Summary>
+        <Description xml:lang="en">tinyhtml5 is a HTML5 parser that transforms a possibly malformed HTML document into an ElementTree tree. It is a simplified fork of html5lib.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pydyf-0.12.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pydyf-0.12.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pydyf-0.12.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pydyf-0.12.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pydyf/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pydyf/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pydyf/__pycache__/__init__.cpython-314.pyc</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2026-08-16</Date>
+            <Version>0.12.1</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
+        </Update>
+    </History>
+</PISI>

--- a/packages/py/python-pyphen/monitoring.yaml
+++ b/packages/py/python-pyphen/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 215861
+  rss: https://github.com/Kozea/Pyphen/tags.atom
+ # No known CPE, checked 2026-08-16
+security:
+  cpe: ~

--- a/packages/py/python-pyphen/package.yml
+++ b/packages/py/python-pyphen/package.yml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
+name       : python-pyphen
+version    : 0.17.2
+release    : 1
+source     :
+    - https://github.com/Kozea/Pyphen/archive/refs/tags/0.17.2.tar.gz : b7e67fbbcc52e6ae058479fa8ce393db4d2457f6f38007933cd6761ab9205501
+homepage   : https://github.com/Kozea/Pyphen
+license    : 
+    - GPL-2.0-or-later
+    - LGPL-2.1-or-later
+    - MPL-1.1
+component  : programming.python
+summary    : Pure Python module to hyphenate text
+description: |
+    Pyphen is a pure Python module to hyphenate text using existing Hunspell hyphenation dictionaries.
+builddeps  :
+    - python-build
+    - python-flit-core
+    - python-installer
+checkdeps  :
+    - python-pytest
+    - python-ruff
+build      : |
+    %pyproject_build
+install    : |
+    %pyproject_install
+check : |
+    %pytest -v

--- a/packages/py/python-pyphen/pspec_x86_64.xml
+++ b/packages/py/python-pyphen/pspec_x86_64.xml
@@ -1,0 +1,130 @@
+<PISI>
+    <Source>
+        <Name>python-pyphen</Name>
+        <Homepage>https://github.com/Kozea/Pyphen</Homepage>
+        <Packager>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
+        </Packager>
+        <License>GPL-2.0-or-later</License>
+        <License>LGPL-2.1-or-later</License>
+        <License>MPL-1.1</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">Pure Python module to hyphenate text</Summary>
+        <Description xml:lang="en">Pyphen is a pure Python module to hyphenate text using existing Hunspell hyphenation dictionaries.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python-pyphen</Name>
+        <Summary xml:lang="en">Pure Python module to hyphenate text</Summary>
+        <Description xml:lang="en">Pyphen is a pure Python module to hyphenate text using existing Hunspell hyphenation dictionaries.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen-0.17.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen-0.17.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen-0.17.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen-0.17.2.dist-info/licenses/COPYING.GPL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen-0.17.2.dist-info/licenses/COPYING.LGPL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen-0.17.2.dist-info/licenses/COPYING.MPL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen-0.17.2.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_NO.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_be_BY.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_bg_BG.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_ca.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_cs_CZ.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_da_DK.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_de.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_el_GR.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_en_GB.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_en_US.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_es.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_et_EE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_eu.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_fr.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_gl.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_hr_HR.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_hu_HU.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_is.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_it_IT.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_lt_LT.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_lv_LV.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_pl_PL.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_pt_BR.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_pt_PT.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_ro_RO.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_sk_SK.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_sl_SI.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_sq_AL.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_sr.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_sv.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_te_IN.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_th_TH.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/README_hyph_uk_UA.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_af_ZA.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_as_IN.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_be_BY.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_bg_BG.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_ca.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_cs_CZ.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_da_DK.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_de_AT.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_de_CH.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_de_DE.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_el_GR.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_en_GB.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_en_US.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_eo.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_es.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_et_EE.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_eu.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_fr.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_gl.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_hr_HR.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_hu_HU.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_id_ID.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_is.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_it_IT.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_kn_IN.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_lt.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_lv_LV.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_mn_MN.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_mr_IN.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_nb_NO.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_nl_NL.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_nn_NO.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_or_IN.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_pa_IN.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_pl_PL.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_pt_BR.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_pt_PT.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_ro_RO.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_ru_RU.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_sa_IN.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_sk_SK.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_sl_SI.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_sq_AL.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_sr.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_sr_Latn.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_sv.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_te_IN.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_th_TH.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_uk_UA.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/hyph_zu_ZA.dic</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pyphen/dictionaries/update.sh</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2026-08-16</Date>
+            <Version>0.17.2</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
+        </Update>
+    </History>
+</PISI>

--- a/packages/py/python-tinyhtml5/monitoring.yaml
+++ b/packages/py/python-tinyhtml5/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 375465
+  rss: https://github.com/CourtBouillon/tinyhtml5/tags.atom
+ # No known CPE, checked 2026-08-16
+security:
+  cpe: ~

--- a/packages/py/python-tinyhtml5/package.yml
+++ b/packages/py/python-tinyhtml5/package.yml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
+name       : python-tinyhtml5
+version    : 2.1.0
+release    : 1
+source     :
+    - https://github.com/CourtBouillon/tinyhtml5/archive/refs/tags/2.1.0.tar.gz : f9a94d1b0463bb109d6035e1c41dfebac1c4de8ebfe99701c473729944498706
+homepage   : https://doc.courtbouillon.org/tinyhtml5/latest/
+license    : MIT
+component  : programming.python
+summary    : A tiny HTML5 parser
+description: |
+    tinyhtml5 is a HTML5 parser that transforms a possibly malformed HTML document into an ElementTree tree. It is a simplified fork of html5lib.
+builddeps  :
+    - python-build
+    - python-flit-core
+    - python-installer
+checkdeps  :
+    - python-pytest
+    - python-ruff
+    - python-webencodings
+build      : |
+    %pyproject_build
+install    : |
+    %pyproject_install
+check : |
+    %pytest -v

--- a/packages/py/python-tinyhtml5/pspec_x86_64.xml
+++ b/packages/py/python-tinyhtml5/pspec_x86_64.xml
@@ -1,0 +1,56 @@
+<PISI>
+    <Source>
+        <Name>python-tinyhtml5</Name>
+        <Homepage>https://doc.courtbouillon.org/tinyhtml5/latest/</Homepage>
+        <Packager>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">A tiny HTML5 parser</Summary>
+        <Description xml:lang="en">tinyhtml5 is a HTML5 parser that transforms a possibly malformed HTML document into an ElementTree tree. It is a simplified fork of html5lib.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python-tinyhtml5</Name>
+        <Summary xml:lang="en">A tiny HTML5 parser</Summary>
+        <Description xml:lang="en">tinyhtml5 is a HTML5 parser that transforms a possibly malformed HTML document into an ElementTree tree. It is a simplified fork of html5lib.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5-2.1.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5-2.1.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5-2.1.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5-2.1.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/constants.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/constants.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/inputstream.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/inputstream.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/parser.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/parser.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/tokenizer.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/tokenizer.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/treebuilder.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/__pycache__/treebuilder.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/constants.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/inputstream.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/parser.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/tokenizer.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/tinyhtml5/treebuilder.py</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2026-08-16</Date>
+            <Version>2.1.0</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
+        </Update>
+    </History>
+</PISI>

--- a/packages/py/python-weasyprint/monitoring.yaml
+++ b/packages/py/python-weasyprint/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 11057
+  rss: https://github.com/Kozea/WeasyPrint/tags.atom
+ # No known CPE, checked 2026-08-16
+security:
+  cpe: ~

--- a/packages/py/python-weasyprint/package.yml
+++ b/packages/py/python-weasyprint/package.yml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
+name       : python-weasyprint
+version    : 69.0
+release    : 1
+source     :
+    - https://github.com/Kozea/WeasyPrint/archive/refs/tags/v69.0.tar.gz : fcaf06772eb2936394731f224e42c5d5a1c1790e2e24617aa355846b35f22a13
+homepage   : https://weasyprint.org/
+license    : BSD-3-Clause
+component  : programming.python
+summary    : The Awesome Document Factory (HTML to PDF converter)
+description: |
+    WeasyPrint is a smart solution helping web developers to create PDF documents. It turns simple HTML pages into gorgeous statistical reports, invoices, tickets, and more using a Python-native CSS layout engine.
+builddeps  :
+    - pango-devel
+    - python-build
+    - python-flit-core
+    - python-installer
+rundeps    :
+    - pango
+    - python-cffi
+    - python-cssselect2
+    - python-fonttools
+    - python-pillow
+    - python-pydyf
+    - python-pyphen
+    - python-tinycss2
+    - python-tinyhtml5
+checkdeps  :
+    - dejavu-fonts-ttf
+    - liberation-fonts-ttf
+    - ghostscript
+    - pango
+    - python-cffi
+    - python-cssselect2
+    - python-fonttools
+    - python-pillow
+    - python-pydyf
+    - python-pyphen
+    - python-pytest
+    - python-ruff
+    - python-tinycss2
+    - python-tinyhtml5
+build      : |
+    %pyproject_build
+install    : |
+    %pyproject_install
+check : |
+    %pytest -v -k "not test_emoji_text_svg"

--- a/packages/py/python-weasyprint/package.yml
+++ b/packages/py/python-weasyprint/package.yml
@@ -27,8 +27,8 @@ rundeps    :
     - python-tinyhtml5
 checkdeps  :
     - dejavu-fonts-ttf
-    - liberation-fonts-ttf
     - ghostscript
+    - liberation-fonts-ttf
     - pango
     - python-cffi
     - python-cssselect2

--- a/packages/py/python-weasyprint/pspec_x86_64.xml
+++ b/packages/py/python-weasyprint/pspec_x86_64.xml
@@ -1,0 +1,248 @@
+<PISI>
+    <Source>
+        <Name>python-weasyprint</Name>
+        <Homepage>https://weasyprint.org/</Homepage>
+        <Packager>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
+        </Packager>
+        <License>BSD-3-Clause</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">The Awesome Document Factory (HTML to PDF converter)</Summary>
+        <Description xml:lang="en">WeasyPrint is a smart solution helping web developers to create PDF documents. It turns simple HTML pages into gorgeous statistical reports, invoices, tickets, and more using a Python-native CSS layout engine.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python-weasyprint</Name>
+        <Summary xml:lang="en">The Awesome Document Factory (HTML to PDF converter)</Summary>
+        <Description xml:lang="en">WeasyPrint is a smart solution helping web developers to create PDF documents. It turns simple HTML pages into gorgeous statistical reports, invoices, tickets, and more using a Python-native CSS layout engine.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/weasyprint</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint-69.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint-69.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint-69.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint-69.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint-69.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__main__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/__main__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/__main__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/anchors.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/anchors.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/document.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/document.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/html.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/html.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/images.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/images.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/logger.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/logger.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/matrix.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/matrix.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/stacking.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/stacking.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/urls.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/__pycache__/urls.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/anchors.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/computed_values.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/computed_values.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/counters.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/counters.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/functions.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/functions.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/media_queries.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/media_queries.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/properties.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/properties.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/targets.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/targets.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/tokens.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/tokens.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/units.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/__pycache__/units.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/computed_values.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/counters.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/functions.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/html5_ph.css</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/html5_ua.css</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/html5_ua_form.css</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/media_queries.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/properties.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/targets.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/tokens.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/units.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/__pycache__/descriptors.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/__pycache__/descriptors.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/__pycache__/expanders.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/__pycache__/expanders.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/__pycache__/properties.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/__pycache__/properties.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/descriptors.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/expanders.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/css/validation/properties.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/document.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/__pycache__/border.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/__pycache__/border.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/__pycache__/color.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/__pycache__/color.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/__pycache__/text.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/__pycache__/text.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/border.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/color.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/draw/text.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/formatting_structure/__pycache__/boxes.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/formatting_structure/__pycache__/boxes.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/formatting_structure/__pycache__/build.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/formatting_structure/__pycache__/build.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/formatting_structure/boxes.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/formatting_structure/build.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/html.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/images.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/absolute.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/absolute.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/background.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/background.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/block.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/block.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/column.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/column.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/flex.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/flex.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/float.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/float.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/grid.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/grid.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/inline.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/inline.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/leader.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/leader.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/min_max.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/min_max.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/page.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/page.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/percent.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/percent.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/preferred.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/preferred.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/replaced.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/replaced.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/table.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/__pycache__/table.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/absolute.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/background.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/block.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/column.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/flex.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/float.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/grid.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/inline.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/leader.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/min_max.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/page.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/percent.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/preferred.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/replaced.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/layout/table.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/logger.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/matrix.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/anchors.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/anchors.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/debug.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/debug.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/fonts.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/fonts.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/metadata.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/metadata.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/pdfa.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/pdfa.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/pdfua.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/pdfua.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/pdfx.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/pdfx.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/stream.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/stream.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/tags.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/__pycache__/tags.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/anchors.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/debug.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/fonts.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/metadata.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/pdfa.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/pdfua.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/pdfx.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/sRGB2014.icc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/stream.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/pdf/tags.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/stacking.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/bounding_box.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/bounding_box.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/css.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/css.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/defs.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/defs.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/images.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/images.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/path.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/path.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/shapes.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/shapes.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/text.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/text.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/utils.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/__pycache__/utils.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/bounding_box.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/css.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/defs.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/images.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/path.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/shapes.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/text.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/svg/utils.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/__pycache__/constants.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/__pycache__/constants.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/__pycache__/ffi.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/__pycache__/ffi.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/__pycache__/fonts.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/__pycache__/fonts.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/__pycache__/line_break.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/__pycache__/line_break.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/constants.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/ffi.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/fonts.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/text/line_break.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/weasyprint/urls.py</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2026-08-16</Date>
+            <Version>69.0</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**
- Fix issue where PDF generation would not work due to missing weasyprint 
- Add weasyprint amd its dependencies
- Resolves getsolus/packages#10096

**Test Plan**
- Test with Kraft checking if the PDF generation works and the error saying missing weasyprint is gone

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
