### PR TITLE
repo_data: Deprecate missed cheese packages

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -3279,6 +3279,8 @@
 		<Package>cheese</Package>
 		<Package>cheese-devel</Package>
 		<Package>cheese-dbginfo</Package>
+		<Package>cheese-docs</Package>
+		<Package>libcheese</Package>
 		<Package>wiznote</Package>
 		<Package>wiznote-dbginfo</Package>
 		<Package>semantik</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -4516,6 +4516,8 @@
 		<Package>cheese</Package>
 		<Package>cheese-devel</Package>
 		<Package>cheese-dbginfo</Package>
+		<Package>cheese-docs</Package>
+		<Package>libcheese</Package>
 
 		<!-- Dead upstream, depended on qt5-webengine -->
 		<Package>wiznote</Package>


### PR DESCRIPTION
**Summary**
Follow-up to https://github.com/getsolus/packages/pull/10145

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

n/a

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
