### PR TITLE
sudo: Clean up package and fix prompt

### DIFF
--- a/packages/s/sudo/package.yml
+++ b/packages/s/sudo/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : sudo
 version    : 1.9.17_p2
-release    : 58
+release    : 59
 source     :
     - https://www.sudo.ws/dist/sudo-1.9.17p2.tar.gz : 4a38a1ab3adb1199257edc2a7c4a2bd714665eb605b04368843b06dada2cfcfb
 homepage   : https://www.sudo.ws/
@@ -11,32 +11,39 @@ component  : system.base
 description: |
     The Sudo package allows a system administrator to give certain users (or groups of users) the ability to run some (or all) commands as root or another user while logging the commands and arguments.
 setup      : |
-    %patch -p1 -i $pkgfiles/visudo-stateless.patch
-    %configure --with-all-insults \
-               --with-env-editor \
-               --enable-adminconf=/etc/ \
-               --sysconfdir=/usr/share/defaults/etc/sudo/ \
-               --with-editor=/usr/bin/nano \
-               --with-tty-tickets \
-               --with-passprompt="[sudo] password for %p:" \
-               --without-sendmail
+    %patch -p1 -i ${pkgfiles}/visudo-stateless.patch
+
+    %configure \
+        --with-all-insults \
+        --with-env-editor \
+        --enable-adminconf=/etc/ \
+        --sysconfdir=/usr/share/defaults/etc/sudo/ \
+        --with-editor=/usr/bin/nano \
+        --with-tty-tickets \
+        --with-passprompt="[sudo] password for %p: " \
+        --without-sendmail
 build      : |
     %make
 install    : |
     %make_install
-    rm -rvf $installdir/{etc,var,run}
-    rm -v $installdir/usr/share/defaults/etc/sudo/sudoers.dist
-    # sysusers group it
-    install -Dm00644 $pkgfiles/sudo.sysusers $installdir/%libdir%/sysusers.d/sudo.conf
-    # tmpfiles
-    rm -rfv $installdir/usr/lib
-    install -Dm00644 $pkgfiles/sudo.tmpfiles $installdir/%libdir%/tmpfiles.d/sudo.conf
-    # sudoers file
+    %install_license LICENSE.md
 
-    rm -fv $installdir/usr/share/defaults/etc/sudo/sudoers
-    install -Dm00644 $pkgfiles/sudoers $installdir/usr/share/defaults/etc/sudo/sudoers
-    # sudo pam
-    install -Dm00644 $pkgfiles/pam.d/sudo $installdir/usr/share/defaults/etc/pam.d/sudo
+    rm -rvf ${installdir}/{etc,var,run}
+    rm -v ${installdir}/usr/share/defaults/etc/sudo/sudoers.dist
+
+    # sysusers
+    %install_file ${pkgfiles}/sudo.sysusers ${installdir}/%libdir%/sysusers.d/sudo.conf
+
+    # tmpfiles
+    rm -rfv ${installdir}/usr/lib
+    %install_file ${pkgfiles}/sudo.tmpfiles ${installdir}/%libdir%/tmpfiles.d/sudo.conf
+
+    # sudoers file
+    rm -fv ${installdir}/usr/share/defaults/etc/sudo/sudoers
+    %install_file -t ${installdir}/usr/share/defaults/etc/sudo ${pkgfiles}/sudoers
+
+    # PAM config
+    %install_file -t ${installdir}/usr/share/defaults/etc/pam.d ${pkgfiles}/pam.d/sudo
 patterns   :
     - docs :
         - /usr/share/doc

--- a/packages/s/sudo/pspec_x86_64.xml
+++ b/packages/s/sudo/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>sudo</Name>
         <Homepage>https://www.sudo.ws/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>ISC</License>
         <PartOf>system.base</PartOf>
@@ -43,6 +43,7 @@
             <Path fileType="data">/usr/share/defaults/etc/sudo/sudo_logsrvd.conf</Path>
             <Path fileType="data">/usr/share/defaults/etc/sudo/sudoers</Path>
             <Path fileType="data">/usr/share/defaults/etc/sudo/sudoers.d</Path>
+            <Path fileType="data">/usr/share/licenses/sudo/LICENSE.md</Path>
             <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/sudo.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/sudoers.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/sudo.mo</Path>
@@ -140,7 +141,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="58">sudo</Dependency>
+            <Dependency release="59">sudo</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/sudo_plugin.h</Path>
@@ -172,12 +173,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="58">
-            <Date>2025-12-01</Date>
+        <Update release="59">
+            <Date>2026-08-16</Date>
             <Version>1.9.17_p2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Clean up package and fix prompt.

Fixes https://github.com/getsolus/packages/issues/9798

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install package, open new terminal and run `sudo ls /home`. See that there is now a space after the prompt.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
