### PR TITLE
python-pytest-rerunfailures: Update to 16.6

### DIFF
--- a/packages/py/python-pytest-rerunfailures/package.yml
+++ b/packages/py/python-pytest-rerunfailures/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-pytest-rerunfailures
-version    : '16.4'
-release    : 6
+version    : '16.6'
+release    : 7
 source     :
-    - https://files.pythonhosted.org/packages/source/p/pytest-rerunfailures/pytest_rerunfailures-16.4.tar.gz : 8222d17c37eb7b9e4d6fc96a3c724ff4e1a5c97a5cc7cbb2c19e9282cfd21a11
+    - https://files.pythonhosted.org/packages/source/p/pytest-rerunfailures/pytest_rerunfailures-16.6.tar.gz : 29dbfee46f542073c888e0ed4e81c51e15b9096f49a299eb1a759629c601684a
 homepage   : https://github.com/pytest-dev/pytest-rerunfailures/
 license    : MPL-2.0
 component  : programming.python
@@ -22,8 +22,8 @@ checkdeps  :
 rundeps    :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    %pytest -v

--- a/packages/py/python-pytest-rerunfailures/pspec_x86_64.xml
+++ b/packages/py/python-pytest-rerunfailures/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-pytest-rerunfailures</Name>
         <Homepage>https://github.com/pytest-dev/pytest-rerunfailures/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,25 +20,25 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/__pycache__/pytest_rerunfailures.cpython-314-pytest-9.1.0.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/__pycache__/pytest_rerunfailures.cpython-314-pytest-9.1.1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/__pycache__/pytest_rerunfailures.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/__pycache__/pytest_rerunfailures.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.4.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.4.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.4.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.4.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.4.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.4.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.6.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.6.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.6.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.6.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.6.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures-16.6.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/pytest_rerunfailures.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-07-11</Date>
-            <Version>16.4</Version>
+        <Update release="7">
+            <Date>2026-08-18</Date>
+            <Version>16.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- [Change Log](https://github.com/pytest-dev/pytest-rerunfailures/blob/master/CHANGES.rst)

**Test Plan**
- Pass test suite


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
