### PR TITLE
libfprint: Update to v1.94.100

### DIFF
--- a/packages/l/libfprint/abi_used_libs
+++ b/packages/l/libfprint/abi_used_libs
@@ -2,6 +2,7 @@ libc.so.6
 libcrypto.so.3
 libgio-2.0.so.0
 libglib-2.0.so.0
+libgmodule-2.0.so.0
 libgobject-2.0.so.0
 libgudev-1.0.so.0
 libgusb.so.2

--- a/packages/l/libfprint/abi_used_symbols
+++ b/packages/l/libfprint/abi_used_symbols
@@ -7,6 +7,7 @@ libc.so.6:calloc
 libc.so.6:close
 libc.so.6:free
 libc.so.6:fwrite
+libc.so.6:getenv
 libc.so.6:ioctl
 libc.so.6:memcmp
 libc.so.6:memcpy
@@ -19,8 +20,9 @@ libc.so.6:stderr
 libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:strncmp
-libc.so.6:strncpy
+libc.so.6:strnlen
 libc.so.6:strstr
+libc.so.6:usleep
 libc.so.6:write
 libcrypto.so.3:ERR_error_string_n
 libcrypto.so.3:ERR_get_error
@@ -43,6 +45,7 @@ libgio-2.0.so.0:g_input_stream_read_all_async
 libgio-2.0.so.0:g_input_stream_read_all_finish
 libgio-2.0.so.0:g_input_stream_read_async
 libgio-2.0.so.0:g_input_stream_read_finish
+libgio-2.0.so.0:g_io_error_enum_get_type
 libgio-2.0.so.0:g_io_error_from_errno
 libgio-2.0.so.0:g_io_error_quark
 libgio-2.0.so.0:g_io_stream_close
@@ -91,11 +94,16 @@ libglib-2.0.so.0:g_ascii_strtoull
 libglib-2.0.so.0:g_assertion_message
 libglib-2.0.so.0:g_assertion_message_cmpnum
 libglib-2.0.so.0:g_assertion_message_expr
+libglib-2.0.so.0:g_build_filename
 libglib-2.0.so.0:g_byte_array_append
 libglib-2.0.so.0:g_byte_array_new
 libglib-2.0.so.0:g_byte_array_set_size
 libglib-2.0.so.0:g_byte_array_unref
+libglib-2.0.so.0:g_bytes_get_data
 libglib-2.0.so.0:g_bytes_get_size
+libglib-2.0.so.0:g_bytes_new
+libglib-2.0.so.0:g_bytes_new_take
+libglib-2.0.so.0:g_bytes_unref
 libglib-2.0.so.0:g_clear_error
 libglib-2.0.so.0:g_date_copy
 libglib-2.0.so.0:g_date_free
@@ -134,6 +142,7 @@ libglib-2.0.so.0:g_list_foreach
 libglib-2.0.so.0:g_list_free
 libglib-2.0.so.0:g_log
 libglib-2.0.so.0:g_log_structured
+libglib-2.0.so.0:g_log_writer_default_would_drop
 libglib-2.0.so.0:g_main_context_get_thread_default
 libglib-2.0.so.0:g_main_context_iteration
 libglib-2.0.so.0:g_malloc
@@ -144,7 +153,9 @@ libglib-2.0.so.0:g_nullify_pointer
 libglib-2.0.so.0:g_once_init_enter
 libglib-2.0.so.0:g_once_init_leave
 libglib-2.0.so.0:g_propagate_error
+libglib-2.0.so.0:g_propagate_prefixed_error
 libglib-2.0.so.0:g_ptr_array_add
+libglib-2.0.so.0:g_ptr_array_copy
 libglib-2.0.so.0:g_ptr_array_find
 libglib-2.0.so.0:g_ptr_array_find_with_equal_func
 libglib-2.0.so.0:g_ptr_array_insert
@@ -153,10 +164,13 @@ libglib-2.0.so.0:g_ptr_array_new_with_free_func
 libglib-2.0.so.0:g_ptr_array_ref
 libglib-2.0.so.0:g_ptr_array_remove_index
 libglib-2.0.so.0:g_ptr_array_remove_index_fast
+libglib-2.0.so.0:g_ptr_array_set_free_func
 libglib-2.0.so.0:g_ptr_array_sized_new
+libglib-2.0.so.0:g_ptr_array_steal_index
 libglib-2.0.so.0:g_ptr_array_unref
 libglib-2.0.so.0:g_qsort_with_data
 libglib-2.0.so.0:g_quark_from_static_string
+libglib-2.0.so.0:g_quark_to_string
 libglib-2.0.so.0:g_rand_free
 libglib-2.0.so.0:g_rand_int_range
 libglib-2.0.so.0:g_rand_new
@@ -177,6 +191,7 @@ libglib-2.0.so.0:g_slist_nth_data
 libglib-2.0.so.0:g_slist_prepend
 libglib-2.0.so.0:g_slist_remove
 libglib-2.0.so.0:g_slist_reverse
+libglib-2.0.so.0:g_snprintf
 libglib-2.0.so.0:g_source_attach
 libglib-2.0.so.0:g_source_destroy
 libglib-2.0.so.0:g_source_get_time
@@ -201,6 +216,7 @@ libglib-2.0.so.0:g_string_free
 libglib-2.0.so.0:g_string_new
 libglib-2.0.so.0:g_string_prepend
 libglib-2.0.so.0:g_string_set_size
+libglib-2.0.so.0:g_strlcpy
 libglib-2.0.so.0:g_strndup
 libglib-2.0.so.0:g_strsplit
 libglib-2.0.so.0:g_strv_contains
@@ -228,12 +244,16 @@ libglib-2.0.so.0:g_variant_get_string
 libglib-2.0.so.0:g_variant_n_children
 libglib-2.0.so.0:g_variant_new
 libglib-2.0.so.0:g_variant_new_fixed_array
-libglib-2.0.so.0:g_variant_new_from_data
+libglib-2.0.so.0:g_variant_new_from_bytes
 libglib-2.0.so.0:g_variant_new_string
 libglib-2.0.so.0:g_variant_new_variant
 libglib-2.0.so.0:g_variant_store
 libglib-2.0.so.0:g_variant_type_checked_
 libglib-2.0.so.0:g_variant_unref
+libglib-2.0.so.0:g_warn_message
+libgmodule-2.0.so.0:g_module_close
+libgmodule-2.0.so.0:g_module_open
+libgmodule-2.0.so.0:g_module_symbol
 libgobject-2.0.so.0:g_boxed_type_register_static
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__OBJECT
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__VOID
@@ -323,6 +343,7 @@ libgusb.so.2:g_usb_device_control_transfer_async
 libgusb.so.2:g_usb_device_control_transfer_finish
 libgusb.so.2:g_usb_device_error_quark
 libgusb.so.2:g_usb_device_get_bus
+libgusb.so.2:g_usb_device_get_interface
 libgusb.so.2:g_usb_device_get_interfaces
 libgusb.so.2:g_usb_device_get_parent
 libgusb.so.2:g_usb_device_get_pid

--- a/packages/l/libfprint/package.yml
+++ b/packages/l/libfprint/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libfprint
-version    : 1.94.10
-release    : 10
+version    : 1.94.100
+release    : 11
 source     :
-    - https://gitlab.freedesktop.org/libfprint/libfprint/-/archive/v1.94.10/libfprint-v1.94.10.tar.bz2 : 3c781e7920c9af5313d1a51101aadbd18e6e8edb35df3532850477fd96a0e952
+    - https://gitlab.freedesktop.org/libfprint/libfprint/-/archive/v1.94.100/libfprint-v1.94.100.tar.bz2 : ee5d07aa6c0acd8465b5b1b8b9d7bd96d4ce459d4091abc2c2656e876b7cfa52
 homepage   : https://fprint.freedesktop.org/
 license    : LGPL-2.1-or-later
 component  : desktop.library

--- a/packages/l/libfprint/pspec_x86_64.xml
+++ b/packages/l/libfprint/pspec_x86_64.xml
@@ -35,7 +35,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libfprint</Dependency>
+            <Dependency release="11">libfprint</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libfprint-2/fp-context.h</Path>
@@ -64,6 +64,7 @@
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/FpPrint.html</Path>
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/advanced-topics.html</Path>
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/api-index.html</Path>
+            <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/driver-data.html</Path>
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/driver-dev.html</Path>
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/driver-helpers.html</Path>
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/driver-img.html</Path>
@@ -75,6 +76,8 @@
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/intro.html</Path>
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/left-insensitive.png</Path>
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/left.png</Path>
+            <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/libfprint-2-FpiByteReader.html</Path>
+            <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/libfprint-2-FpiByteWriter.html</Path>
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/libfprint-2-Image-frame-assembly.html</Path>
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/libfprint-2-Internal-FpDevice.html</Path>
             <Path fileType="doc">/usr/share/gtk-doc/html/libfprint-2/libfprint-2-Internal-FpImage.html</Path>
@@ -97,9 +100,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2026-04-06</Date>
-            <Version>1.94.10</Version>
+        <Update release="11">
+            <Date>2026-08-18</Date>
+            <Version>1.94.100</Version>
             <Comment>Packaging update</Comment>
             <Name>Robert Gonzalez</Name>
             <Email>uni.dos12@outlook.com</Email>


### PR DESCRIPTION
**Summary**
- changelog can be found [here](https://gitlab.freedesktop.org/libfprint/libfprint/-/releases/v1.94.100)

**Test Plan**

run `fprint-verify`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
