### PR TITLE
python-mistune: Update to 3.3.4

### DIFF
--- a/packages/py/python-mistune/package.yml
+++ b/packages/py/python-mistune/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-mistune
-version    : 3.1.4
-release    : 20
+version    : 3.3.4
+release    : 21
 source     :
-    - https://files.pythonhosted.org/packages/source/m/mistune/mistune-3.1.4.tar.gz : b5a7f801d389f724ec702840c11d8fc48f2b33519102fc7ee739e8177b672164
+    - https://files.pythonhosted.org/packages/source/m/mistune/mistune-3.3.4.tar.gz : 58b5c96d6fcb61190dfe5fae498d2b2065f99cf61e9649418fd54cf1ada86dfe
 homepage   : https://github.com/lepture/mistune
 license    : BSD-3-Clause
 component  : programming.python
@@ -19,8 +19,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    %pytest -v

--- a/packages/py/python-mistune/pspec_x86_64.xml
+++ b/packages/py/python-mistune/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-mistune</Name>
         <Homepage>https://github.com/lepture/mistune</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,13 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune-3.1.4.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune-3.1.4.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune-3.1.4.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune-3.1.4.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune-3.1.4.dist-info/top_level.txt</Path>
+            <Path fileType="executable">/usr/bin/mistune</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune-3.3.4.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune-3.3.4.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune-3.3.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune-3.3.4.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune-3.3.4.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune-3.3.4.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -47,6 +49,15 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/__pycache__/toc.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/__pycache__/util.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/__pycache__/util.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/_inline/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/_inline/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/_inline/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/_inline/__pycache__/emphasis.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/_inline/__pycache__/emphasis.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/_inline/__pycache__/links.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/_inline/__pycache__/links.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/_inline/emphasis.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/_inline/links.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/block_parser.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/core.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mistune/directives/__init__.py</Path>
@@ -134,12 +145,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-06-06</Date>
-            <Version>3.1.4</Version>
+        <Update release="21">
+            <Date>2026-08-19</Date>
+            <Version>3.3.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security
- [Change Log](https://github.com/lepture/mistune/releases#release-v3.3.4)

**Security**
- CVE-2026-44708
- CVE-2026-44897
- CVE-2026-44899

**Test Plan**
- Pass test suite

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
