### PR TITLE
kompose: Add at v1.38.0

### DIFF
--- a/packages/k/kompose/MAINTAINERS.md
+++ b/packages/k/kompose/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Trevor Busk
+    - Matrix: @gearv:matrix.org
+    - Email: trevor@tbusk.com

--- a/packages/k/kompose/monitoring.yaml
+++ b/packages/k/kompose/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 12064
+  rss: https://github.com/kubernetes/kompose/tags.atom
+ # No known CPE, checked 2026-08-19
+security:
+  cpe: ~

--- a/packages/k/kompose/package.yml
+++ b/packages/k/kompose/package.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
+name       : kompose
+version    : 1.38.0
+release    : 1
+source     :
+    - https://github.com/kubernetes/kompose/archive/refs/tags/v1.38.0.tar.gz : 1a6eb3e9a5084d0ce6d1a81628b314686b7cfa41124bace13eb188865f7640a0
+homepage   : https://kompose.io/
+license    : Apache-2.0
+component  : programming.tools
+networking : true
+summary    : A tool to convert Docker Compose files to Kubernetes config files
+description: |
+    Kompose is a convenience tool to transform a local Docker Compose file into a Kubernetes resource manifest.
+builddeps  :
+    - golang
+build      : |
+    %make bin
+install    : |
+    %install_file <(./kompose completion bash) $installdir/usr/share/bash-completion/completions/kompose
+    %install_file <(./kompose completion zsh) $installdir/usr/share/zsh/site-functions/_kompose
+    %install_file <(./kompose completion fish) $installdir/usr/share/fish/vendor_completions.d/kompose.fish
+
+    %install_bin ./kompose
+    %install_license LICENSE

--- a/packages/k/kompose/pspec_x86_64.xml
+++ b/packages/k/kompose/pspec_x86_64.xml
@@ -1,0 +1,39 @@
+<PISI>
+    <Source>
+        <Name>kompose</Name>
+        <Homepage>https://kompose.io/</Homepage>
+        <Packager>
+            <Name>Trevor Busk</Name>
+            <Email>trevor@tbusk.com</Email>
+        </Packager>
+        <License>Apache-2.0</License>
+        <PartOf>programming.tools</PartOf>
+        <Summary xml:lang="en">A tool to convert Docker Compose files to Kubernetes config files</Summary>
+        <Description xml:lang="en">Kompose is a convenience tool to transform a local Docker Compose file into a Kubernetes resource manifest.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>kompose</Name>
+        <Summary xml:lang="en">A tool to convert Docker Compose files to Kubernetes config files</Summary>
+        <Description xml:lang="en">Kompose is a convenience tool to transform a local Docker Compose file into a Kubernetes resource manifest.
+</Description>
+        <PartOf>programming.tools</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/kompose</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/kompose</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/kompose.fish</Path>
+            <Path fileType="data">/usr/share/licenses/kompose/LICENSE</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_kompose</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2026-08-21</Date>
+            <Version>1.38.0</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Trevor Busk</Name>
+            <Email>trevor@tbusk.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

Add the kompose package, which converts Docker Compose files into Kubernetes resource manifests.

Resolves getsolus/packages#10147

**Test Plan**

<!-- Short description of how the package was tested -->

- [X] Converted a multi-service docker compose file into k8 resource manifests

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
