### PR TITLE
glibc: Update to 2.43+git.7d26579873

### DIFF
--- a/packages/g/glibc/package.yml
+++ b/packages/g/glibc/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : glibc
 version    : '2.43'
-release    : 144
+release    : 145
 source     :
     # release/2.43/master
-    - git|https://forge.sourceware.org/glibc/glibc-mirror.git : a388c4002d42d83f2858897c947308df648310b1
+    - git|https://forge.sourceware.org/glibc/glibc-mirror.git : 7d26579873791748c20d874adb66e877412175dd
 homepage   : https://www.gnu.org/software/libc/
 license    :
     - GPL-2.0-or-later

--- a/packages/g/glibc/pspec_x86_64.xml
+++ b/packages/g/glibc/pspec_x86_64.xml
@@ -7020,7 +7020,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="144">glibc</Dependency>
+            <Dependency release="145">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib32/ld-linux.so.2</Path>
@@ -7321,8 +7321,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="144">glibc-devel</Dependency>
-            <Dependency release="144">glibc-32bit</Dependency>
+            <Dependency release="145">glibc-32bit</Dependency>
+            <Dependency release="145">glibc-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/Mcrt1.o</Path>
@@ -7856,7 +7856,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="144">glibc</Dependency>
+            <Dependency release="145">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mtrace</Path>
@@ -8377,8 +8377,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="144">
-            <Date>2026-08-12</Date>
+        <Update release="145">
+            <Date>2026-08-19</Date>
             <Version>2.43</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- m68k: Fix fmod/fmodf infinite recursion
- malloc: Show hugetlb tunable default in --list-tunables

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild `nano`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
