### PR TITLE
dust: Update to v1.2.5

### DIFF
--- a/packages/d/dust/package.yml
+++ b/packages/d/dust/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dust
-version    : 1.2.4
-release    : 3
+version    : 1.2.5
+release    : 4
 source     :
-    - https://github.com/bootandy/dust/archive/refs/tags/v1.2.4.tar.gz : 2f6768534bd01727234e67f1dd3754c9547aa18c715f6ee52094e881ebac50e3
+    - https://github.com/bootandy/dust/archive/refs/tags/v1.2.5.tar.gz : 4445e61f1341ea567e9e49367f275a1f4b026a60526e60048265f7af4a4943fd
 homepage   : https://github.com/bootandy/dust
 license    : Apache-2.0
 component  : system.utils

--- a/packages/d/dust/pspec_x86_64.xml
+++ b/packages/d/dust/pspec_x86_64.xml
@@ -29,9 +29,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-01-09</Date>
-            <Version>1.2.4</Version>
+        <Update release="4">
+            <Date>2026-08-19</Date>
+            <Version>1.2.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/bootandy/dust/releases/tag/v1.2.5).

**Test Plan**

See file sizes. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
