### PR TITLE
docker-compose: Update to v5.5.0

### DIFF
--- a/packages/d/docker-compose/package.yml
+++ b/packages/d/docker-compose/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker-compose
-version    : 5.4.0
-release    : 66
+version    : 5.5.0
+release    : 67
 source     :
-    - https://github.com/docker/compose/archive/refs/tags/v5.4.0.tar.gz : 142f895ba74715ea0018a20b7f93fa96e36fb6c91ea66f856a61c6e3716c4ef8
+    - https://github.com/docker/compose/archive/refs/tags/v5.5.0.tar.gz : 504ed1541f4bc5c301dc9cf7b86ae8e2d26b57a558a248d9b832af188b298bba
 homepage   : https://docs.docker.com/compose/
 license    : Apache-2.0
 component  : virt

--- a/packages/d/docker-compose/pspec_x86_64.xml
+++ b/packages/d/docker-compose/pspec_x86_64.xml
@@ -28,9 +28,9 @@ With Compose, you use a Compose file to configure your application&#x2019;s serv
         </Files>
     </Package>
     <History>
-        <Update release="66">
-            <Date>2026-08-04</Date>
-            <Version>5.4.0</Version>
+        <Update release="67">
+            <Date>2026-08-19</Date>
+            <Version>5.5.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/docker/compose/releases/tag/v5.5.0).

**Test Plan**

Open container with compose

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
