### PR TITLE
cloc: Update to v2.10

### DIFF
--- a/packages/c/cloc/package.yml
+++ b/packages/c/cloc/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : cloc
-version    : '2.08'
-release    : 6
+version    : '2.10'
+release    : 7
 source     :
-    - https://github.com/AlDanial/cloc/archive/refs/tags/v2.08.tar.gz : 8099b6275c124f662690f2db3581cd2ad4e9ad4e08332288719838ded00d1da5
+    - https://github.com/AlDanial/cloc/archive/refs/tags/v2.10.tar.gz : a8fac35f4cf42728765580ba11afc2568ad205509a22204663f526169548436d
 license    : GPL-2.0-or-later
 component  : programming.tools
 homepage   : https://github.com/AlDanial/cloc/
@@ -21,5 +21,5 @@ rundeps    :
     - perl-parallel-forkmanager
     - perl-regexp-common
 install    : |
-    cd Unix
-    %make_install
+    %make_install -C Unix
+    %install_license Unix/COPYING

--- a/packages/c/cloc/pspec_x86_64.xml
+++ b/packages/c/cloc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>cloc</Name>
         <Homepage>https://github.com/AlDanial/cloc/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming.tools</PartOf>
@@ -21,16 +21,17 @@
         <PartOf>programming.tools</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/cloc</Path>
+            <Path fileType="data">/usr/share/licenses/cloc/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/cloc.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-01-26</Date>
-            <Version>2.08</Version>
+        <Update release="7">
+            <Date>2026-08-19</Date>
+            <Version>2.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/AlDanial/cloc/blob/v2.10/Unix/NEWS).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `cloc --vcs=git` on the Budgie Desktop repo.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
