### PR TITLE
yt-dlp: Update to v2026.08.19

### DIFF
--- a/packages/y/yt-dlp/package.yml
+++ b/packages/y/yt-dlp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : yt-dlp
-version    : 2026.07.04
-release    : 273
+version    : 2026.08.19
+release    : 274
 source     :
-    - https://github.com/yt-dlp/yt-dlp/archive/refs/tags/2026.07.04.tar.gz : 7fb7ca0509dd8f21263246d3d749a346e049fa9d3cfdef072e05c7bbd88d6fc0
+    - https://github.com/yt-dlp/yt-dlp/archive/refs/tags/2026.08.19.tar.gz : a0779c45179a846986a852bce31bddbe9259b594574f75c0ec146d0567058f7e
 license    : Unlicense
 component  : network.download
 homepage   : https://github.com/yt-dlp/yt-dlp

--- a/packages/y/yt-dlp/pspec_x86_64.xml
+++ b/packages/y/yt-dlp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>yt-dlp</Name>
         <Homepage>https://github.com/yt-dlp/yt-dlp</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>Unlicense</License>
         <PartOf>network.download</PartOf>
@@ -23,11 +23,11 @@
             <Path fileType="executable">/usr/bin/youtube-dl</Path>
             <Path fileType="executable">/usr/bin/yt-dlc</Path>
             <Path fileType="executable">/usr/bin/yt-dlp</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp-2026.7.4.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp-2026.7.4.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp-2026.7.4.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp-2026.7.4.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp-2026.7.4.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp-2026.8.19.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp-2026.8.19.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp-2026.8.19.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp-2026.8.19.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp-2026.8.19.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp/YoutubeDL.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/yt_dlp/__main__.py</Path>
@@ -3177,12 +3177,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="273">
-            <Date>2026-07-04</Date>
-            <Version>2026.07.04</Version>
+        <Update release="274">
+            <Date>2026-08-20</Date>
+            <Version>2026.08.19</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/yt-dlp/yt-dlp/releases/tag/2026.08.19)

**Test Plan**

- Download a YT live video that was throwing an error with the prior release

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
