### PR TITLE
zellij: Update to v0.45.0

### DIFF
--- a/packages/z/zellij/abi_used_symbols
+++ b/packages/z/zellij/abi_used_symbols
@@ -29,6 +29,7 @@ libc.so.6:chmod
 libc.so.6:chown
 libc.so.6:chroot
 libc.so.6:clock_gettime
+libc.so.6:clock_nanosleep
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:connect
@@ -96,7 +97,7 @@ libc.so.6:getuid
 libc.so.6:gmtime
 libc.so.6:gnu_get_libc_version
 libc.so.6:inotify_add_watch
-libc.so.6:inotify_init
+libc.so.6:inotify_init1
 libc.so.6:inotify_rm_watch
 libc.so.6:ioctl
 libc.so.6:isatty
@@ -229,8 +230,10 @@ libc.so.6:strstr
 libc.so.6:strtol
 libc.so.6:syscall
 libc.so.6:sysconf
+libc.so.6:sysinfo
 libc.so.6:tcdrain
 libc.so.6:tcgetattr
+libc.so.6:tcgetpgrp
 libc.so.6:tcsetattr
 libc.so.6:time
 libc.so.6:umask

--- a/packages/z/zellij/package.yml
+++ b/packages/z/zellij/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : zellij
-version    : 0.44.3
-release    : 20
+version    : 0.45.0
+release    : 21
 source     :
-    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.44.3.tar.gz : 33ae61fc802b59462fed49b424893596d3aa819646bdce53d5602f714c1264fe
+    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.45.0.tar.gz : fba81ade9d3fd93869338553dce394a889e6f28e0e91f98896eb77533bab599b
 homepage   : https://zellij.dev
 license    : MIT
 component  : system.utils
@@ -21,29 +21,23 @@ build      : |
     %cargo_build --no-default-features --features "plugins_from_target web_server_capability"
 
     # Build completions
-    ./target/release/zellij setup --generate-completion bash > target/zellij.bash
+    ./target/release/zellij setup --generate-completion bash > target/zellij
     ./target/release/zellij setup --generate-completion fish > target/zellij.fish
-    ./target/release/zellij setup --generate-completion zsh > target/zellij.zsh
-
-    # Build manpage
-    mandown docs/MANPAGE.md > assets/zellij.1
+    ./target/release/zellij setup --generate-completion zsh > target/_zellij
 install    : |
     %cargo_install
     %install_license LICENSE.md
 
     # Install completions
-    install -Dm00644 target/zellij.bash "${installdir}/usr/share/bash-completion/completions/zellij"
-    install -Dm00644 target/zellij.fish "${installdir}/usr/share/fish/vendor_completions.d/zellij.fish"
-    install -Dm00644 target/zellij.zsh "${installdir}/usr/share/zsh/site-functions/_zellij"
-
-    # Install manpage
-    install -Dm00644 assets/zellij.1 "${installdir}/usr/share/man/man1/zellij.1"
+    %install_file -t ${installdir}/usr/share/bash-completion/completions target/zellij
+    %install_file -t ${installdir}/usr/share/fish/vendor_completions.d target/zellij.fish
+    %install_file -t ${installdir}/usr/share/zsh/site-functions target/_zellij
 
     # Install desktop file
-    install -Dm00644 assets/zellij.desktop "${installdir}/usr/share/applications/zellij.desktop"
+    %install_file -t ${installdir}/usr/share/applications assets/zellij.desktop
 
     # Install app icon
-    install -Dm00644 assets/logo.svg "${installdir}/usr/share/icons/hicolor/scalable/apps/zellij.svg"
+    %install_file assets/logo.svg ${installdir}/usr/share/icons/hicolor/scalable/apps/zellij.svg
 
     # Install AppStream Metainfo
-    install -Dm00644 ${pkgfiles}/dev.zellij.Zellij.metainfo.xml "${installdir}/usr/share/metainfo/dev.zellij.Zellij.metainfo.xml"
+    %install_file -t ${installdir}/usr/share/metainfo ${pkgfiles}/dev.zellij.Zellij.metainfo.xml

--- a/packages/z/zellij/pspec_x86_64.xml
+++ b/packages/z/zellij/pspec_x86_64.xml
@@ -26,15 +26,14 @@
             <Path fileType="data">/usr/share/fish/vendor_completions.d/zellij.fish</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/zellij.svg</Path>
             <Path fileType="data">/usr/share/licenses/zellij/LICENSE.md</Path>
-            <Path fileType="man">/usr/share/man/man1/zellij.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/dev.zellij.Zellij.metainfo.xml</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_zellij</Path>
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-05-14</Date>
-            <Version>0.44.3</Version>
+        <Update release="21">
+            <Date>2026-08-20</Date>
+            <Version>0.45.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/zellij-org/zellij/releases/tag/v0.45.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Launch a Zellij session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
