### PR TITLE
libgit2: Update to v1.9.7

### DIFF
--- a/packages/l/libgit2/package.yml
+++ b/packages/l/libgit2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libgit2
-version    : 1.9.4
-release    : 41
+version    : 1.9.7
+release    : 42
 source     :
-    - https://github.com/libgit2/libgit2/archive/refs/tags/v1.9.4.tar.gz : 824b73bd13647800fe4b566a1008ae77fea0e3e3424edab632fcfd8c0b14ba8b
+    - https://github.com/libgit2/libgit2/archive/refs/tags/v1.9.7.tar.gz : 1a4fbe7589e814777ae76b64734ad80f4ecad22cd33a22682a2aaea4ae5375e7
 homepage   : https://libgit2.org/
 license    : GPL-2.0-or-later
 component  : programming.library
@@ -20,9 +20,9 @@ rundeps    :
         - libssh2-devel
 setup      : |
     %cmake_ninja \
-                 -DREGEX_BACKEND=pcre2 \
-                 -DUSE_SSH:BOOL=ON \
-                 -DUSE_THREADS:BOOL=ON
+        -DREGEX_BACKEND=pcre2 \
+        -DUSE_SSH:BOOL=ON \
+        -DUSE_THREADS:BOOL=ON
 build      : |
     %ninja_build
 install    : |

--- a/packages/l/libgit2/pspec_x86_64.xml
+++ b/packages/l/libgit2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libgit2</Name>
         <Homepage>https://libgit2.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -22,7 +22,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/git2</Path>
             <Path fileType="library">/usr/lib64/libgit2.so.1.9</Path>
-            <Path fileType="library">/usr/lib64/libgit2.so.1.9.4</Path>
+            <Path fileType="library">/usr/lib64/libgit2.so.1.9.7</Path>
             <Path fileType="data">/usr/share/licenses/libgit2/COPYING</Path>
         </Files>
     </Package>
@@ -33,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="41">libgit2</Dependency>
+            <Dependency release="42">libgit2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/git2.h</Path>
@@ -138,12 +138,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2026-06-12</Date>
-            <Version>1.9.4</Version>
+        <Update release="42">
+            <Date>2026-08-20</Date>
+            <Version>1.9.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/libgit2/libgit2/releases/tag/v1.9.7).

**Security**
- CVE-2026-5917
- CVE-2026-53586
- CVE-2026-53587
- CVE-2026-53585
- CVE-2026-53584
- CVE-2026-53583

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild a reverse dependency.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
