### PR TITLE
python-stevedore: Update to 5.6.0

### DIFF
--- a/packages/py/python-stevedore/package.yml
+++ b/packages/py/python-stevedore/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-stevedore
-version    : 5.4.1
-release    : 14
+version    : 5.6.0
+release    : 15
 source     :
-    - https://files.pythonhosted.org/packages/source/s/stevedore/stevedore-5.4.1.tar.gz : 3135b5ae50fe12816ef291baff420acb727fcd356106e3e9cbfa9e5985cd6f4b
+    - https://files.pythonhosted.org/packages/source/s/stevedore/stevedore-5.6.0.tar.gz : f22d15c6ead40c5bbfa9ca54aa7e7b4a07d59b36ae03ed12ced1a54cf0b51945
 homepage   : https://opendev.org/openstack/stevedore
 license    : Apache-2.0
 component  : programming.python
@@ -24,10 +24,10 @@ rundeps    :
     - pbr
     - python-six
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
-#check      : |
+    %pyproject_install
+check      : |
     #need testtools packaged
-#    rm $workdir/stevedore/tests/test_callback.py
-#    %python3_test pytest3
+    rm $workdir/stevedore/tests/test_callback.py
+    %pytest

--- a/packages/py/python-stevedore/pspec_x86_64.xml
+++ b/packages/py/python-stevedore/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-stevedore</Name>
         <Homepage>https://opendev.org/openstack/stevedore</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,14 +20,14 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.4.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.4.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.4.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.4.1.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.4.1.dist-info/licenses/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.4.1.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.4.1.dist-info/pbr.json</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.4.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.6.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.6.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.6.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.6.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.6.0.dist-info/licenses/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.6.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.6.0.dist-info/pbr.json</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore-5.6.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/__pycache__/__init__.cpython-314.pyc</Path>
@@ -69,6 +69,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example/base.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example/load_as_driver.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example/load_as_extension.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example/pyproject.toml</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example/setup.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example/simple.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example2/__init__.py</Path>
@@ -79,11 +80,13 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example2/__pycache__/setup.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example2/__pycache__/setup.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example2/fields.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example2/pyproject.toml</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/example2/setup.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/exception.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/extension.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/hook.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/named.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/py.typed</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/sphinxext.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/tests/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/stevedore/tests/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -136,12 +139,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2026-06-06</Date>
-            <Version>5.4.1</Version>
+        <Update release="15">
+            <Date>2026-08-20</Date>
+            <Version>5.6.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- [Change Log](https://docs.openstack.org/releasenotes/stevedore/2026.1.html)
- Re-enabled test as it now works

**Test Plan**
- Pass test suite

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
