### PR TITLE
python-lxml: Update to 6.1.2

### DIFF
--- a/packages/py/python-lxml/package.yml
+++ b/packages/py/python-lxml/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-lxml
-version    : 6.1.1
-release    : 29
+version    : 6.1.2
+release    : 30
 source     :
-    - https://github.com/lxml/lxml/archive/refs/tags/lxml-6.1.1.tar.gz : 624d1f5a50862c1bd5280f6997898c5a334e26d3a58bc2bbfec1efd8f98135fa
+    - https://github.com/lxml/lxml/archive/refs/tags/lxml-6.1.2-1.tar.gz : 41959b6aa08e182db200b94ae66429369e028e6328a36c54cdc697e213e0f7ac
 homepage   : https://lxml.de/
 license    :
     - BSD-3-Clause
@@ -27,7 +27,7 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
     %python3_install
 #check      : |

--- a/packages/py/python-lxml/pspec_x86_64.xml
+++ b/packages/py/python-lxml/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-lxml</Name>
         <Homepage>https://lxml.de/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>MIT</License>
@@ -23,12 +23,12 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.1.dist-info/licenses/LICENSE.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.1.dist-info/licenses/LICENSES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.2.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.2.dist-info/licenses/LICENSES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/lxml-6.1.2.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/lxml/ElementInclude.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/lxml/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/lxml/__pycache__/ElementInclude.cpython-314.opt-1.pyc</Path>
@@ -173,12 +173,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2026-07-11</Date>
-            <Version>6.1.1</Version>
+        <Update release="30">
+            <Date>2026-08-22</Date>
+            <Version>6.1.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- [Change Log](https://github.com/lxml/lxml/releases#release-lxml-6.1.2-1)
- Add test

**Test Plan**
- Ensure the ElementTree API initializes and can parse a dummy XML string


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
