### PR TITLE
xev: Update to v1.2.7 & add license

### DIFF
--- a/packages/x/xev/abi_used_symbols
+++ b/packages/x/xev/abi_used_symbols
@@ -18,9 +18,11 @@ libX11.so.6:XOpenIM
 libX11.so.6:XParseGeometry
 libX11.so.6:XRefreshKeyboardMapping
 libX11.so.6:XSelectInput
+libX11.so.6:XSetErrorHandler
 libX11.so.6:XSetLocaleModifiers
 libX11.so.6:XSetStandardProperties
 libX11.so.6:XSetWMProtocols
+libX11.so.6:XSync
 libX11.so.6:XmbLookupString
 libXrandr.so.2:XRRFreeOutputInfo
 libXrandr.so.2:XRRFreeScreenResources

--- a/packages/x/xev/package.yml
+++ b/packages/x/xev/package.yml
@@ -1,11 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xev
-version    : 1.2.6
-release    : 7
+version    : 1.2.7
+release    : 8
 source     :
-    - https://www.x.org/releases/individual/app/xev-1.2.6.tar.xz : 61e1c5e008ac9973aca7cdddf36e9df7410e77083b030eb04f4dc737c51807d7
+    - https://xorg.freedesktop.org/archive/individual/app/xev-1.2.7.tar.xz : 95167895924de58e34b1013b2b0c8476e90d0888c6c39e7ae9bc35e3a19dba04
 license    :
-    - GPL-3.0-only
     - MIT
 component  : xorg.apps
 homepage   : https://www.x.org/
@@ -15,8 +14,9 @@ description: |
 builddeps  :
     - pkgconfig(xrandr)
 setup      : |
-    %configure --disable-static
+    %meson_configure
 build      : |
-    %make
+    %ninja_build
 install    : |
-    %make_install
+    %ninja_install
+    %install_license COPYING

--- a/packages/x/xev/pspec_x86_64.xml
+++ b/packages/x/xev/pspec_x86_64.xml
@@ -3,10 +3,9 @@
         <Name>xev</Name>
         <Homepage>https://www.x.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Packager>
-        <License>GPL-3.0-only</License>
         <License>MIT</License>
         <PartOf>xorg.apps</PartOf>
         <Summary xml:lang="en">Print contents of X events</Summary>
@@ -22,16 +21,17 @@
         <PartOf>xorg.apps</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/xev</Path>
-            <Path fileType="man">/usr/share/man/man1/xev.1</Path>
+            <Path fileType="data">/usr/share/licenses/xev/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/xev.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-03-05</Date>
-            <Version>1.2.6</Version>
+        <Update release="8">
+            <Date>2026-08-25</Date>
+            <Version>1.2.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Part of #7294
Release notes available [here](https://lists.x.org/archives/xorg-announce/2026-May/003699.html)

**Test Plan**
- run xev and see that it works.
- See that the license file was installed.

**Checklist**
- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes
once merged <!-- Write an appropriate message in the Summary section,
then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous
contributions under the licensing terms in
[LICENSE.md](../blob/main/LICENSE.md) and have the power and authority
to grant those licenses.
