### PR TITLE
netbird: Update to v0.77.1

### DIFF
--- a/packages/n/netbird/package.yml
+++ b/packages/n/netbird/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : netbird
-version    : 0.77.0
-release    : 3
+version    : 0.77.1
+release    : 4
 source     :
-    - https://github.com/netbirdio/netbird/archive/refs/tags/v0.77.0.tar.gz : f27f5f5f853b74891838a781eb7a18ba7475375cbf69e9f3bf5c3721a7f0a4c2
+    - https://github.com/netbirdio/netbird/archive/refs/tags/v0.77.1.tar.gz : a02b6e788e1c428c8b7473c6530235ecdb4d16732b06674c05dd650a89960237
 homepage   : https://netbird.io/
 license    :
     - BSD-3-Clause

--- a/packages/n/netbird/pspec_x86_64.xml
+++ b/packages/n/netbird/pspec_x86_64.xml
@@ -38,7 +38,7 @@
         <Description xml:lang="en">NetBird combines a configuration-free peer-to-peer private network and a centralized access control system in a single platform, making it easy to create secure private networks for your organization or home.
 </Description>
         <RuntimeDependencies>
-            <Dependency releaseFrom="3">netbird</Dependency>
+            <Dependency releaseFrom="4">netbird</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/netbird-ui</Path>
@@ -48,9 +48,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-08-19</Date>
-            <Version>0.77.0</Version>
+        <Update release="4">
+            <Date>2026-08-25</Date>
+            <Version>0.77.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**
- Changelog available [here](https://github.com/netbirdio/netbird/releases/tag/v0.77.1)

**Test Plan**
- Build and install from this PR.
- `sudo systemctl restart netbird`.
- Connect to a self-hosted NetBird and see that it still works. 
- See that NetBird no longer says it has an update available.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
