### PR TITLE
wofi: Update to v1.5.3 & add license

### DIFF
--- a/packages/w/wofi/abi_symbols
+++ b/packages/w/wofi/abi_symbols
@@ -52,6 +52,7 @@ wofi:wofi_insert_widgets
 wofi:wofi_load_css
 wofi:wofi_mod_control
 wofi:wofi_mod_shift
+wofi:wofi_no_custom_entry
 wofi:wofi_parse_image_escapes
 wofi:wofi_property_box_add_property
 wofi:wofi_property_box_get_property

--- a/packages/w/wofi/abi_used_symbols
+++ b/packages/w/wofi/abi_used_symbols
@@ -1,7 +1,5 @@
 libc.so.6:__asprintf_chk
 libc.so.6:__ctype_b_loc
-libc.so.6:__ctype_tolower_loc
-libc.so.6:__ctype_toupper_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
@@ -42,7 +40,11 @@ libc.so.6:getenv
 libc.so.6:getopt_long
 libc.so.6:gettimeofday
 libc.so.6:isatty
+libc.so.6:iswalnum
+libc.so.6:iswlower
+libc.so.6:iswupper
 libc.so.6:malloc
+libc.so.6:mbstowcs
 libc.so.6:memcpy
 libc.so.6:memset
 libc.so.6:mkdir
@@ -65,7 +67,6 @@ libc.so.6:stderr
 libc.so.6:stdin
 libc.so.6:stdout
 libc.so.6:strcasecmp
-libc.so.6:strcasestr
 libc.so.6:strcat
 libc.so.6:strchr
 libc.so.6:strcmp
@@ -75,12 +76,19 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncat
 libc.so.6:strncmp
-libc.so.6:strncpy
-libc.so.6:strpbrk
 libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtok_r
+libc.so.6:towlower
+libc.so.6:towupper
 libc.so.6:waitpid
+libc.so.6:wcschr
+libc.so.6:wcscmp
+libc.so.6:wcslen
+libc.so.6:wcsncpy
+libc.so.6:wcspbrk
+libc.so.6:wcsstr
+libc.so.6:wcstok
 libc.so.6:write
 libcairo.so.2:cairo_surface_destroy
 libgdk-3.so.0:gdk_cairo_surface_create_from_pixbuf
@@ -133,8 +141,8 @@ libglib-2.0.so.0:g_error_free
 libglib-2.0.so.0:g_free
 libglib-2.0.so.0:g_intern_static_string
 libglib-2.0.so.0:g_list_free
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_tree_destroy
 libglib-2.0.so.0:g_tree_insert
 libglib-2.0.so.0:g_tree_lookup
@@ -162,6 +170,7 @@ libgtk-3.so.0:gtk_css_provider_load_from_data
 libgtk-3.so.0:gtk_css_provider_new
 libgtk-3.so.0:gtk_entry_get_text
 libgtk-3.so.0:gtk_entry_grab_focus_without_selecting
+libgtk-3.so.0:gtk_entry_new
 libgtk-3.so.0:gtk_entry_set_invisible_char
 libgtk-3.so.0:gtk_entry_set_placeholder_text
 libgtk-3.so.0:gtk_entry_set_text
@@ -208,6 +217,7 @@ libgtk-3.so.0:gtk_settings_get_default
 libgtk-3.so.0:gtk_style_context_add_class
 libgtk-3.so.0:gtk_style_context_add_provider_for_screen
 libgtk-3.so.0:gtk_widget_child_focus
+libgtk-3.so.0:gtk_widget_destroy
 libgtk-3.so.0:gtk_widget_get_allocated_size
 libgtk-3.so.0:gtk_widget_get_style_context
 libgtk-3.so.0:gtk_widget_get_visible
@@ -215,9 +225,9 @@ libgtk-3.so.0:gtk_widget_get_window
 libgtk-3.so.0:gtk_widget_grab_focus
 libgtk-3.so.0:gtk_widget_has_focus
 libgtk-3.so.0:gtk_widget_realize
-libgtk-3.so.0:gtk_widget_set_child_visible
 libgtk-3.so.0:gtk_widget_set_halign
 libgtk-3.so.0:gtk_widget_set_name
+libgtk-3.so.0:gtk_widget_set_sensitive
 libgtk-3.so.0:gtk_widget_set_size_request
 libgtk-3.so.0:gtk_widget_set_state_flags
 libgtk-3.so.0:gtk_widget_set_valign

--- a/packages/w/wofi/package.yml
+++ b/packages/w/wofi/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : wofi
-version    : 1.4.1
-release    : 1
+version    : 1.5.3
+release    : 2
 source     :
-    - https://hg.sr.ht/~scoopta/wofi/archive/v1.4.1.tar.gz : e95e35c03551c39178c16ad6213a88e3883a236e942d7f2666c780d934c270bb
+    - https://hg.sr.ht/~scoopta/wofi/archive/v1.5.3.tar.gz : 6216dc14d93cdb6170f89c1ca3aaacdeaa44862fbc9be947d614be266a9c49f6
 homepage   : https://hg.sr.ht/~scoopta/wofi
 license    : GPL-3.0-or-later
 component  : system.utils
@@ -11,11 +11,14 @@ summary    : Wofi is a rofi-like alternative for wlroots-based wayland composito
 description: |
     Wofi is a rofi-like alternative for wlroots-based wayland compositors.
 builddeps  :
+    - pkgconfig(gio-unix-2.0)
     - pkgconfig(gtk+-3.0)
-    - pkgconfig(wayland-server)
+    - pkgconfig(wayland-client)
+    - pkgconfig(wayland-protocols)
 setup      : |
     %meson_configure
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING.md

--- a/packages/w/wofi/pspec_x86_64.xml
+++ b/packages/w/wofi/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wofi</Name>
         <Homepage>https://hg.sr.ht/~scoopta/wofi</Homepage>
         <Packager>
-            <Name>Facundo Ciruzzi</Name>
-            <Email>ciruzzifacundo@gmail.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -21,10 +21,11 @@
         <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/wofi</Path>
-            <Path fileType="man">/usr/share/man/man1/wofi.1</Path>
-            <Path fileType="man">/usr/share/man/man5/wofi.5</Path>
-            <Path fileType="man">/usr/share/man/man7/wofi-keys.7</Path>
-            <Path fileType="man">/usr/share/man/man7/wofi.7</Path>
+            <Path fileType="data">/usr/share/licenses/wofi/COPYING.md</Path>
+            <Path fileType="man">/usr/share/man/man1/wofi.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/wofi.5.zst</Path>
+            <Path fileType="man">/usr/share/man/man7/wofi-keys.7.zst</Path>
+            <Path fileType="man">/usr/share/man/man7/wofi.7.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -34,7 +35,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">wofi</Dependency>
+            <Dependency release="2">wofi</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wofi-1/config.h</Path>
@@ -44,21 +45,21 @@
             <Path fileType="header">/usr/include/wofi-1/widget_builder_api.h</Path>
             <Path fileType="header">/usr/include/wofi-1/wofi_api.h</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/wofi.pc</Path>
-            <Path fileType="man">/usr/share/man/man3/wofi-api.3</Path>
-            <Path fileType="man">/usr/share/man/man3/wofi-config.3</Path>
-            <Path fileType="man">/usr/share/man/man3/wofi-map.3</Path>
-            <Path fileType="man">/usr/share/man/man3/wofi-utils.3</Path>
-            <Path fileType="man">/usr/share/man/man3/wofi-widget-builder.3</Path>
-            <Path fileType="man">/usr/share/man/man3/wofi.3</Path>
+            <Path fileType="man">/usr/share/man/man3/wofi-api.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/wofi-config.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/wofi-map.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/wofi-utils.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/wofi-widget-builder.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/wofi.3.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-03-11</Date>
-            <Version>1.4.1</Version>
+        <Update release="2">
+            <Date>2026-08-25</Date>
+            <Version>1.5.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Facundo Ciruzzi</Name>
-            <Email>ciruzzifacundo@gmail.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Part of #7294

Changelog:

- update_surface_size() no longer performs a resize if width or height is 0
- Added the API function wofi_no_custom_entry()
- dmenu mode will now auto-close with status 0 if no entries are provided and custom entry is not allowed
- Backed out changeset a40edf527046
- The size of the scrolled window is now handled correctly while preserving the behavior of --lines
- Fixed --lines when using a horizontal layout
- Added support for loading configs and styling from /usr/etc/wofi and /etc/wofi, plugins can now be loaded from /usr/lib/wofi and /lib/wofi

**Test Plan**
- run wofi and see that it works.
- See that the license file was installed.

**Checklist**
- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes
once merged <!-- Write an appropriate message in the Summary section,
then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous
contributions under the licensing terms in
[LICENSE.md](../blob/main/LICENSE.md) and have the power and authority
to grant those licenses.