### PR TITLE
openssl: Update to v3.6.4

### DIFF
--- a/packages/o/openssl/abi_used_symbols32
+++ b/packages/o/openssl/abi_used_symbols32
@@ -68,6 +68,7 @@ libc.so.6:gmtime_r
 libc.so.6:ioctl
 libc.so.6:listen
 libc.so.6:lseek
+libc.so.6:lstat
 libc.so.6:madvise
 libc.so.6:makecontext
 libc.so.6:malloc

--- a/packages/o/openssl/package.yml
+++ b/packages/o/openssl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openssl
-version    : 3.6.3
-release    : 59
+version    : 3.6.4
+release    : 60
 source     :
-    - https://github.com/openssl/openssl/releases/download/openssl-3.6.3/openssl-3.6.3.tar.gz : 243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1
+    - https://github.com/openssl/openssl/releases/download/openssl-3.6.4/openssl-3.6.4.tar.gz : 9bffaa1ad1e07b354c21bd3324ec02fa15579f45a7d0494b3e74bc449b7333ef
 homepage   : https://www.openssl.org/
 license    : OpenSSL
 summary    : Cryptographic tools required by many packages
@@ -19,9 +19,9 @@ builddeps  :
     - glibc-32bit-devel
     - libgcc-32bit
 setup      : |
-    %patch -p1 -i $pkgfiles/0001-Use-OS-provided-copy-of-openssl.cnf-as-fallback.patch
-    %patch -p1 -i $pkgfiles/0001-Fix-soname-dynamic-loading.patch
-    %patch -p1 -i $pkgfiles/ca-dir.patch
+    %patch -p1 -i ${pkgfiles}/0001-Use-OS-provided-copy-of-openssl.cnf-as-fallback.patch
+    %patch -p1 -i ${pkgfiles}/0001-Fix-soname-dynamic-loading.patch
+    %patch -p1 -i ${pkgfiles}/ca-dir.patch
 
     if [[ -z "${EMUL32BUILD}" ]]; then
         ./Configure --prefix=/usr --openssldir=/etc/ssl --libdir=lib64 shared zlib-dynamic enable-ktls enable-ec_nistp_64_gcc_128 linux-x86_64
@@ -31,10 +31,12 @@ setup      : |
 build      : |
     %make
 install    : |
-    %make install_sw install_ssldirs install_man_docs DESTDIR="$installdir" INSTALL_PREFIX="$installdir"
+    %make install_sw install_ssldirs install_man_docs \
+        DESTDIR="${installdir}" \
+        INSTALL_PREFIX="${installdir}"
     %install_license LICENSE.txt
 
     # Stateless (kinda)
-    install -dm755 $installdir/usr/share/defaults/etc/ssl
-    mv $installdir/etc/ssl/openssl.cnf $installdir/usr/share/defaults/etc/ssl/openssl.cnf
-    rm -v $installdir/etc/ssl/openssl.cnf.dist
+    %install_dir ${installdir}/usr/share/defaults/etc/ssl
+    mv ${installdir}/etc/ssl/openssl.cnf ${installdir}/usr/share/defaults/etc/ssl/openssl.cnf
+    rm -v ${installdir}/etc/ssl/openssl.cnf.dist

--- a/packages/o/openssl/pspec_x86_64.xml
+++ b/packages/o/openssl/pspec_x86_64.xml
@@ -415,7 +415,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="59">openssl</Dependency>
+            <Dependency release="60">openssl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/engines-3/afalg.so</Path>
@@ -434,8 +434,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="59">openssl-devel</Dependency>
-            <Dependency release="59">openssl-32bit</Dependency>
+            <Dependency release="60">openssl-32bit</Dependency>
+            <Dependency release="60">openssl-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/cmake/OpenSSL/OpenSSLConfig.cmake</Path>
@@ -456,7 +456,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="59">openssl</Dependency>
+            <Dependency release="60">openssl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openssl/aes.h</Path>
@@ -3028,6 +3028,8 @@
             <Path fileType="man">/usr/share/man/man3/MDC2_Final.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/MDC2_Init.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/MDC2_Update.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/NAME_CONSTRAINTS_check.3ossl.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/NAME_CONSTRAINTS_check_CN.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/NAME_CONSTRAINTS_free.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/NAME_CONSTRAINTS_new.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/NAMING_AUTHORITY.3ossl</Path>
@@ -3198,6 +3200,7 @@
             <Path fileType="man">/usr/share/man/man3/OPENSSL_VERSION_TEXT.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/OPENSSL_aligned_alloc.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/OPENSSL_aligned_alloc_array.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/OPENSSL_armcap.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/OPENSSL_atexit.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/OPENSSL_buf2hexstr.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/OPENSSL_buf2hexstr_ex.3ossl</Path>
@@ -5084,6 +5087,7 @@
             <Path fileType="man">/usr/share/man/man3/SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/SSL_VALUE_EVENT_HANDLING_MODE_INHERIT.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/SSL_VALUE_QUIC_IDLE_TIMEOUT.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/SSL_VALUE_QUIC_MAX_PENDING_CONNS.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/SSL_VALUE_QUIC_STREAM_BIDI_LOCAL_AVAIL.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/SSL_VALUE_QUIC_STREAM_BIDI_REMOTE_AVAIL.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/SSL_VALUE_QUIC_STREAM_UNI_LOCAL_AVAIL.3ossl</Path>
@@ -6811,9 +6815,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="59">
-            <Date>2026-06-09</Date>
-            <Version>3.6.3</Version>
+        <Update release="60">
+            <Date>2026-08-25</Date>
+            <Version>3.6.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/openssl/openssl/releases/tag/openssl-3.6.4).

**Security**
- CVE-2026-18798
- CVE-2026-63072
- CVE-2026-63076
- CVE-2026-14456
- CVE-2026-14457
- CVE-2026-54874
- CVE-2026-54876
- CVE-2026-63073
- CVE-2026-63074
- CVE-2026-63075
- CVE-2026-75803

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install the updates and see that the internet still works.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
