### PR TITLE
gnome-sudoku: Update to v50.3 & add license

### DIFF
--- a/packages/g/gnome-sudoku/abi_used_symbols
+++ b/packages/g/gnome-sudoku/abi_used_symbols
@@ -382,6 +382,7 @@ libgtk-4.so.1:gtk_widget_init_template
 libgtk-4.so.1:gtk_widget_insert_action_group
 libgtk-4.so.1:gtk_widget_measure
 libgtk-4.so.1:gtk_widget_queue_allocate
+libgtk-4.so.1:gtk_widget_queue_resize
 libgtk-4.so.1:gtk_widget_remove_css_class
 libgtk-4.so.1:gtk_widget_set_can_focus
 libgtk-4.so.1:gtk_widget_set_css_classes

--- a/packages/g/gnome-sudoku/package.yml
+++ b/packages/g/gnome-sudoku/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-sudoku
-version    : 50.2.1
-release    : 32
+version    : '50.3'
+release    : 33
 source     :
-    - https://download.gnome.org/sources/gnome-sudoku/50/gnome-sudoku-50.2.1.tar.xz : 64ab4610083e78c895e13e02fe95078f97f8e03c0a8fa87cdc4285bf72b33b9f
+    - https://download.gnome.org/sources/gnome-sudoku/50/gnome-sudoku-50.3.tar.xz : fd8ff1fa32b3341642ac21b1a9ae63fa8d312993e028ce96623a875c04913354
 homepage   : https://gitlab.gnome.org/GNOME/gnome-sudoku/-/wikis/home
 license    : GPL-3.0-or-later
 component  : games.puzzle
@@ -26,3 +26,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/g/gnome-sudoku/pspec_x86_64.xml
+++ b/packages/g/gnome-sudoku/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-sudoku</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/gnome-sudoku/-/wikis/home</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games.puzzle</PartOf>
@@ -406,6 +406,7 @@
             <Path fileType="doc">/usr/share/help/uk/gnome-sudoku/translate.page</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.gnome.Sudoku.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/symbolic/apps/org.gnome.Sudoku-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/licenses/gnome-sudoku/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/gnome-sudoku.mo</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/gnome-sudoku.mo</Path>
             <Path fileType="localedata">/usr/share/locale/am/LC_MESSAGES/gnome-sudoku.mo</Path>
@@ -503,12 +504,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2026-07-07</Date>
-            <Version>50.2.1</Version>
+        <Update release="33">
+            <Date>2026-08-25</Date>
+            <Version>50.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Part of #7294
[Changelog](https://gitlab.gnome.org/GNOME/gnome-sudoku/-/raw/50.3/NEWS?ref_type=tags)

**Test Plan**
- run gnome-sudoku and see that it works.
- See that the license file was installed.

**Checklist**
- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes
once merged <!-- Write an appropriate message in the Summary section,
then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous
contributions under the licensing terms in
[LICENSE.md](../blob/main/LICENSE.md) and have the power and authority
to grant those licenses.