### PR TITLE
snapd: Update to v2.76.3

### DIFF
--- a/packages/d/dbus-broker/abi_used_libs
+++ b/packages/d/dbus-broker/abi_used_libs
@@ -1,3 +1,4 @@
+libapparmor.so.1
 libaudit.so.1
 libc.so.6
 libcap-ng.so.0

--- a/packages/d/dbus-broker/abi_used_symbols
+++ b/packages/d/dbus-broker/abi_used_symbols
@@ -1,3 +1,5 @@
+libapparmor.so.1:aa_query_label
+libapparmor.so.1:aa_splitcon
 libaudit.so.1:audit_close
 libaudit.so.1:audit_log_user_avc_message
 libaudit.so.1:audit_log_user_message
@@ -18,6 +20,7 @@ libc.so.6:__progname_full
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
+libc.so.6:__vasprintf_chk
 libc.so.6:__vsnprintf_chk
 libc.so.6:_exit
 libc.so.6:accept4
@@ -35,8 +38,10 @@ libc.so.6:execve
 libc.so.6:fchmod
 libc.so.6:fclose
 libc.so.6:fcntl64
+libc.so.6:ferror
 libc.so.6:fgetgrent
 libc.so.6:fgetpwent
+libc.so.6:fgets
 libc.so.6:fopen64
 libc.so.6:fork
 libc.so.6:free
@@ -102,6 +107,7 @@ libc.so.6:strncmp
 libc.so.6:strnlen
 libc.so.6:strrchr
 libc.so.6:strspn
+libc.so.6:strstr
 libc.so.6:syscall
 libcap-ng.so.0:capng_change_id
 libcap-ng.so.0:capng_clear

--- a/packages/d/dbus-broker/package.yml
+++ b/packages/d/dbus-broker/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dbus-broker
 version    : '37'
-release    : 12
+release    : 13
 source     :
     - https://github.com/bus1/dbus-broker/releases/download/v37/dbus-broker-37.tar.xz : f819a8db8795fa08c767612e3823fd594694a0990f2543ecf35d6a1a6bf2ab5b
 homepage   : https://github.com/bus1/dbus-broker/wiki
@@ -12,10 +12,12 @@ description: |
     The dbus-broker project is an implementation of a message bus as defined by the D-Bus specification. Its aim is to provide high performance and reliability, while keeping compatibility to the D-Bus reference implementation. It is exclusively written for Linux systems, and makes use of many modern features provided by recent linux kernel releases.
 builddeps  :
     - pkgconfig(audit)
+    - pkgconfig(libapparmor)
     - pkgconfig(libcap-ng)
     - python-docutils
 setup      : |
-    %meson_configure -Daudit=true \
+    %meson_configure -Dapparmor=true \
+                     -Daudit=true \
                      -Ddocs=true
 build      : |
     %ninja_build

--- a/packages/d/dbus-broker/pspec_x86_64.xml
+++ b/packages/d/dbus-broker/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>dbus-broker</Name>
         <Homepage>https://github.com/bus1/dbus-broker/wiki</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>system.base</PartOf>
@@ -28,17 +28,17 @@
             <Path fileType="library">/usr/lib/systemd/system/dbus.service</Path>
             <Path fileType="library">/usr/lib/systemd/user/dbus-broker.service</Path>
             <Path fileType="library">/usr/lib/systemd/user/dbus.service</Path>
-            <Path fileType="man">/usr/share/man/man1/dbus-broker-launch.1</Path>
-            <Path fileType="man">/usr/share/man/man1/dbus-broker.1</Path>
+            <Path fileType="man">/usr/share/man/man1/dbus-broker-launch.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/dbus-broker.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-09-06</Date>
+        <Update release="13">
+            <Date>2026-08-12</Date>
             <Version>37</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/s/snapd/files/20-snap.preset
+++ b/packages/s/snapd/files/20-snap.preset
@@ -1,1 +1,0 @@
-enable snapd.socket

--- a/packages/s/snapd/files/60-snap.preset
+++ b/packages/s/snapd/files/60-snap.preset
@@ -1,0 +1,2 @@
+enable snapd.socket
+enable snapd.apparmor.service

--- a/packages/s/snapd/files/wrapper.sh
+++ b/packages/s/snapd/files/wrapper.sh
@@ -36,15 +36,15 @@ if [[ "${CONFINEMENT}" != "strict" ]] && [[ "${DISABLE_CONFINEMENT_WARNING:-n}" 
   # https://specifications.freedesktop.org/notification-spec/latest/
   # Keep it short and test on all DEs
   # Also, we can't use any HTML tags, they are only optionally supported
-      notify-send \
-          --app-name Snap \
-          --urgency critical \
-          --icon dialog-warning \
-          "Snap has ${CONFINEMENT} confinement" \
-          "See ${URL}"
+  notify-send \
+    --app-name Snap \
+    --urgency critical \
+    --icon dialog-warning \
+    "Snap has ${CONFINEMENT} confinement" \
+    "See ${URL}"
   else
       echo -e "${YELLOW}WARNING:${NC} snap is running with ${CONFINEMENT} confinement." \
-        "See ${URL} for details."
+        "See ${URL} for details." >/dev/stderr
   fi
 fi
 

--- a/packages/s/snapd/package.yml
+++ b/packages/s/snapd/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : snapd
-version    : '2.76'
+version    : 2.76.3
 homepage   : https://snapcraft.io/
-release    : 96
+release    : 97
 source     :
-    - https://github.com/canonical/snapd/releases/download/2.76/snapd_2.76.vendor.tar.xz : 78ad358dc685ab5a40b9ca0b3fc283ae7c8fbbabb4612182d512bde7efeef605
+    - https://github.com/canonical/snapd/releases/download/2.76.3/snapd_2.76.3.vendor.tar.xz : d97627913cbe4ec0a72b507e561f7c9da87c4be5c59412a3e1a94bdc079fa838
 license    : GPL-3.0-only
 component  : desktop
 summary    : The snapd and snap tools enable systems to work with .snap files
@@ -37,6 +37,8 @@ environment: |
     export bincommands=(snap)
     export dcommands=(snapctl snapd snap-exec snap-update-ns snap-seccomp snap-failure snapd-apparmor)
 setup      : |
+    go mod vendor
+
     mkdir -p src/github.com/snapcore
     ln -s `pwd` src/github.com/snapcore/snapd
 
@@ -86,7 +88,7 @@ install    : |
     # satisfy bindmounts in confinement
     install -Ddm00755 $installdir/usr/src
 
-    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-snap.preset
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/60-snap.preset
 
     install -Dm00644 data/info $installdir/%libdir%/$package/info
     install -Dm00644 data/polkit/io.snapcraft.snapd.policy $installdir/usr/share/polkit-1/actions/io.snapcraft.snapd.policy

--- a/packages/s/snapd/pspec_x86_64.xml
+++ b/packages/s/snapd/pspec_x86_64.xml
@@ -48,7 +48,7 @@
             <Path fileType="library">/usr/lib64/snapd/snapd</Path>
             <Path fileType="library">/usr/lib64/snapd/snapd-apparmor</Path>
             <Path fileType="library">/usr/lib64/snapd/snapd.run-from-snap</Path>
-            <Path fileType="library">/usr/lib64/systemd/system-preset/20-snap.preset</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/60-snap.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/snapd.apparmor.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/snapd.failure.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/snapd.gpio-chardev-setup.target</Path>
@@ -81,9 +81,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="96">
-            <Date>2026-07-15</Date>
-            <Version>2.76</Version>
+        <Update release="97">
+            <Date>2026-08-26</Date>
+            <Version>2.76.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Silke Hofstra</Name>
             <Email>silke@slxh.eu</Email>

--- a/packages/s/systemd/abi_symbols
+++ b/packages/s/systemd/abi_symbols
@@ -3761,6 +3761,7 @@ libsystemd-shared-261.so:luo_retrieve_session
 libsystemd-shared-261.so:luo_session_finish
 libsystemd-shared-261.so:luo_session_preserve_fd
 libsystemd-shared-261.so:luo_session_retrieve_fd
+libsystemd-shared-261.so:mac_apparmor_use
 libsystemd-shared-261.so:mac_init
 libsystemd-shared-261.so:mac_init_lazy
 libsystemd-shared-261.so:mac_selinux_apply
@@ -6597,6 +6598,14 @@ libsystemd-shared-261.so:sym_X509_free
 libsystemd-shared-261.so:sym_X509_get_pubkey
 libsystemd-shared-261.so:sym_X509_get_subject_name
 libsystemd-shared-261.so:sym_X509_gmtime_adj
+libsystemd-shared-261.so:sym_aa_change_onexec
+libsystemd-shared-261.so:sym_aa_change_profile
+libsystemd-shared-261.so:sym_aa_features_new_from_kernel
+libsystemd-shared-261.so:sym_aa_features_unref
+libsystemd-shared-261.so:sym_aa_policy_cache_dir_path_preview
+libsystemd-shared-261.so:sym_aa_policy_cache_new
+libsystemd-shared-261.so:sym_aa_policy_cache_replace_all
+libsystemd-shared-261.so:sym_aa_policy_cache_unref
 libsystemd-shared-261.so:sym_acl_add_perm
 libsystemd-shared-261.so:sym_acl_calc_mask
 libsystemd-shared-261.so:sym_acl_copy_entry

--- a/packages/s/systemd/package.yml
+++ b/packages/s/systemd/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : systemd
 version    : '261.2'
-release    : 190
+release    : 191
 source     :
     - https://github.com/systemd/systemd/archive/refs/tags/v261.2.tar.gz : ed1059ff964f5df35b6056434cc17cc83f86dc913f10489948a0b19b6081c5ec
 license    :
@@ -33,6 +33,7 @@ builddeps  :
     - pkgconfig(glib-2.0)
     - pkgconfig(gpg-error)
     - pkgconfig(libacl)
+    - pkgconfig(libapparmor)
     - pkgconfig(libarchive)
     - pkgconfig(libattr)
     - pkgconfig(libbpf)
@@ -118,6 +119,7 @@ setup      : |
         -Dacl=${_IS_64BIT_FEAT} \
         -Dadm-group=true \
         -Danalyze=${_IS_64BIT_BOOL} \
+        -Dapparmor=${_IS_64BIT_BOOL} \
         -Dbacklight=${_IS_64BIT_BOOL} \
         -Dbinfmt=${_IS_64BIT_BOOL} \
         -Dblkid=${_IS_64BIT_FEAT} \

--- a/packages/s/systemd/pspec_x86_64.xml
+++ b/packages/s/systemd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>systemd</Name>
         <Homepage>https://www.github.com/systemd/systemd</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <License>GPL-2.0-or-later</License>
@@ -1657,7 +1657,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="190">systemd</Dependency>
+            <Dependency release="191">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnss_myhostname.so.2</Path>
@@ -1680,8 +1680,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="190">systemd-32bit</Dependency>
-            <Dependency release="190">systemd-devel</Dependency>
+            <Dependency release="191">systemd-devel</Dependency>
+            <Dependency release="191">systemd-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib32/pkgconfig/libsystemd.pc</Path>
@@ -1695,7 +1695,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="190">systemd</Dependency>
+            <Dependency release="191">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libudev.h</Path>
@@ -2598,12 +2598,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="190">
-            <Date>2026-08-15</Date>
+        <Update release="191">
+            <Date>2026-08-26</Date>
             <Version>261.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update snap to v2.76.3 and enable AppArmor support in DBus and Systemd.

**Test Plan**

- Install updated packages.
- Verify that snaps work:
  ```
  $ snap run hello-world
  WARNING: snap is running with partial confinement. See https://help.getsol.us/docs/user/software/third-party/snap for details.
  Hello World!
  ```

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
