### PR TITLE
freerdp: Update to 3.31.0

### DIFF
--- a/packages/f/freerdp/abi_symbols
+++ b/packages/f/freerdp/abi_symbols
@@ -10,6 +10,7 @@ libfreerdp-client3.so.3:client_cli_verify_certificate_ex
 libfreerdp-client3.so.3:client_cli_verify_changed_certificate_ex
 libfreerdp-client3.so.3:client_common_get_access_token
 libfreerdp-client3.so.3:client_common_retry_dialog
+libfreerdp-client3.so.3:client_common_save_session_info
 libfreerdp-client3.so.3:client_rail_server_start_cmd
 libfreerdp-client3.so.3:cliprdr_file_context_clear
 libfreerdp-client3.so.3:cliprdr_file_context_current_flags
@@ -760,6 +761,7 @@ libfreerdp3.so.3:freerdp_register_addin_provider
 libfreerdp3.so.3:freerdp_send_error_info
 libfreerdp3.so.3:freerdp_server_license_issuers_copy
 libfreerdp3.so.3:freerdp_server_license_issuers_free
+libfreerdp3.so.3:freerdp_session_logon_type_data_str
 libfreerdp3.so.3:freerdp_session_logon_type_str
 libfreerdp3.so.3:freerdp_setApplicationDetails
 libfreerdp3.so.3:freerdp_set_common_access_token
@@ -1505,6 +1507,7 @@ libwinpr3.so.3:DefineCommDevice
 libwinpr3.so.3:DeleteCriticalSection
 libwinpr3.so.3:DeleteFileA
 libwinpr3.so.3:DeleteFileW
+libwinpr3.so.3:DeleteProcThreadAttributeList
 libwinpr3.so.3:DeleteTimerQueue
 libwinpr3.so.3:DeleteTimerQueueEx
 libwinpr3.so.3:DeleteTimerQueueTimer
@@ -1693,6 +1696,7 @@ libwinpr3.so.3:InitializeCriticalSection
 libwinpr3.so.3:InitializeCriticalSectionAndSpinCount
 libwinpr3.so.3:InitializeCriticalSectionEx
 libwinpr3.so.3:InitializeListHead
+libwinpr3.so.3:InitializeProcThreadAttributeList
 libwinpr3.so.3:InitializeSListHead
 libwinpr3.so.3:InitializeSecurityDescriptor
 libwinpr3.so.3:InsertHeadList
@@ -2279,6 +2283,7 @@ libwinpr3.so.3:Stream_Read_UTF16_String_As_UTF8
 libwinpr3.so.3:Stream_Read_UTF16_String_As_UTF8_Buffer
 libwinpr3.so.3:Stream_Release
 libwinpr3.so.3:Stream_SafeSeekEx
+libwinpr3.so.3:Stream_SafeZeroEx
 libwinpr3.so.3:Stream_SealLength
 libwinpr3.so.3:Stream_SetLength
 libwinpr3.so.3:Stream_SetPosition
@@ -2314,6 +2319,7 @@ libwinpr3.so.3:UnixPathCchAppendW
 libwinpr3.so.3:UnlockFile
 libwinpr3.so.3:UnlockFileEx
 libwinpr3.so.3:UnmapViewOfFile
+libwinpr3.so.3:UpdateProcThreadAttribute
 libwinpr3.so.3:UuidCompare
 libwinpr3.so.3:UuidCreate
 libwinpr3.so.3:UuidCreateNil
@@ -2606,11 +2612,16 @@ libwinpr3.so.3:g_rgSCardRawPci
 libwinpr3.so.3:g_rgSCardT0Pci
 libwinpr3.so.3:g_rgSCardT1Pci
 libwinpr3.so.3:memmove_s
+libwinpr3.so.3:sspi_AllocSecKerberosSettings
+libwinpr3.so.3:sspi_AllocSecNtlmSettings
+libwinpr3.so.3:sspi_CloneSecSettingsString
 libwinpr3.so.3:sspi_CopyAuthIdentity
 libwinpr3.so.3:sspi_CopyAuthIdentityFieldsA
 libwinpr3.so.3:sspi_CopyAuthIdentityFieldsW
 libwinpr3.so.3:sspi_CopyAuthPackageListA
 libwinpr3.so.3:sspi_FreeAuthIdentity
+libwinpr3.so.3:sspi_FreeSecKerberosSettings
+libwinpr3.so.3:sspi_FreeSecNtlmSettings
 libwinpr3.so.3:sspi_GetAuthIdentityFlags
 libwinpr3.so.3:sspi_GetAuthIdentityPasswordA
 libwinpr3.so.3:sspi_GetAuthIdentityPasswordW

--- a/packages/f/freerdp/abi_used_symbols
+++ b/packages/f/freerdp/abi_used_symbols
@@ -377,6 +377,7 @@ libc.so.6:__xpg_strerror_r
 libc.so.6:_exit
 libc.so.6:abort
 libc.so.6:accept
+libc.so.6:accept4
 libc.so.6:access
 libc.so.6:bind
 libc.so.6:calloc
@@ -396,7 +397,6 @@ libc.so.6:dlclose
 libc.so.6:dlerror
 libc.so.6:dlopen
 libc.so.6:dlsym
-libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:epoll_create
@@ -454,6 +454,7 @@ libc.so.6:getservbyport
 libc.so.6:getsockname
 libc.so.6:getsockopt
 libc.so.6:getuid
+libc.so.6:getxattr
 libc.so.6:gmtime_r
 libc.so.6:inet_addr
 libc.so.6:inet_ntoa
@@ -471,7 +472,7 @@ libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:mkfifo
-libc.so.6:mkstemp64
+libc.so.6:mkostemp64
 libc.so.6:mktime
 libc.so.6:mmap64
 libc.so.6:munmap
@@ -479,6 +480,7 @@ libc.so.6:open64
 libc.so.6:opendir
 libc.so.6:pclose
 libc.so.6:pipe
+libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:popen
 libc.so.6:posix_memalign
@@ -526,6 +528,7 @@ libc.so.6:recvfrom
 libc.so.6:regcomp
 libc.so.6:regexec
 libc.so.6:regfree
+libc.so.6:removexattr
 libc.so.6:rename
 libc.so.6:rmdir
 libc.so.6:sched_get_priority_max
@@ -543,6 +546,7 @@ libc.so.6:setlocale
 libc.so.6:setsockopt
 libc.so.6:setuid
 libc.so.6:setvbuf
+libc.so.6:setxattr
 libc.so.6:shm_open
 libc.so.6:shm_unlink
 libc.so.6:shmat
@@ -594,7 +598,6 @@ libc.so.6:time
 libc.so.6:timerfd_create
 libc.so.6:timerfd_settime
 libc.so.6:tzset
-libc.so.6:umask
 libc.so.6:unlink
 libc.so.6:unsetenv
 libc.so.6:usleep

--- a/packages/f/freerdp/package.yml
+++ b/packages/f/freerdp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : freerdp
-version    : 3.30.0
-release    : 56
+version    : 3.31.0
+release    : 57
 source     :
-    - https://pub.freerdp.com/releases/freerdp-3.30.0.tar.xz : 1a1df431fd35ec85706fb6c1729cda4ce82379ed87a4c880f8dd570c5625583a
+    - https://pub.freerdp.com/releases/freerdp-3.31.0.tar.xz : 8538da2f75cfde313808916943c31071b91869b2c616a94441639c7331f56dbc
 homepage   : https://www.freerdp.com/
 license    : Apache-2.0
 component  :

--- a/packages/f/freerdp/pspec_x86_64.xml
+++ b/packages/f/freerdp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>freerdp</Name>
         <Homepage>https://www.freerdp.com/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>network.util</PartOf>
@@ -20,7 +20,7 @@
 </Description>
         <PartOf>network.util</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">freerdp-libs</Dependency>
+            <Dependency release="57">freerdp-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/freerdp-proxy</Path>
@@ -54,8 +54,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">freerdp</Dependency>
-            <Dependency releaseFrom="56">freerdp-libs</Dependency>
+            <Dependency release="57">freerdp</Dependency>
+            <Dependency releaseFrom="57">freerdp-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/freerdp3/freerdp/addin.h</Path>
@@ -252,6 +252,7 @@
             <Path fileType="header">/usr/include/uwac0/uwac/uwac-tools.h</Path>
             <Path fileType="header">/usr/include/uwac0/uwac/uwac.h</Path>
             <Path fileType="header">/usr/include/uwac0/uwac/version.h</Path>
+            <Path fileType="header">/usr/include/winpr3/winpr/Pathcch.h</Path>
             <Path fileType="header">/usr/include/winpr3/winpr/asn1.h</Path>
             <Path fileType="header">/usr/include/winpr3/winpr/assert-api.h</Path>
             <Path fileType="header">/usr/include/winpr3/winpr/assert.h</Path>
@@ -387,32 +388,32 @@
             <Path fileType="library">/usr/lib64/freerdp3/proxy/libproxy-demo-plugin.so</Path>
             <Path fileType="library">/usr/lib64/freerdp3/proxy/libproxy-dyn-channel-dump-plugin.so</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.30.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.31.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.30.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.31.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.30.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.31.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.30.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.31.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.30.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.31.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.30.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.31.0</Path>
             <Path fileType="library">/usr/lib64/libuwac0.so.0</Path>
             <Path fileType="library">/usr/lib64/libuwac0.so.0.2.0</Path>
             <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.30.0</Path>
+            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.31.0</Path>
             <Path fileType="library">/usr/lib64/libwinpr3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr3.so.3.30.0</Path>
+            <Path fileType="library">/usr/lib64/libwinpr3.so.3.31.0</Path>
         </Files>
     </Package>
     <History>
-        <Update release="56">
-            <Date>2026-08-11</Date>
-            <Version>3.30.0</Version>
+        <Update release="57">
+            <Date>2026-08-26</Date>
+            <Version>3.31.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security
- [change Log](https://www.freerdp.com/2026/08/26/3_31_0-release)

**Security**
- GHSA-c5gr-hmqp-pwj4
- GHSA-h5w2-q35j-443h
- GHSA-m85m-3qxv-63h5
- GHSA-r9pv-ffph-6gg6
- GHSA-ffjr-p229-hpch
- GHSA-4464-r7qj-pgrx
- GHSA-2vf2-grvj-6g8x
- GHSA-hg4r-vv53-vwf8
- GHSA-57h7-vw2f-2f9x
- GHSA-v649-94v2-p72q
- GHSA-j5mq-3349-gwmm
- GHSA-23pf-q83q-x45r
- GHSA-pj8w-fh79-f438
- GHSA-vccg-35r5-8jrf
- GHSA-w9qg-g24r-77f6
- GHSA-f5p6-88mh-59vg
- GHSA-hw7p-5h2r-83gq
- GHSA-r7jx-j9h7-j4xj
- GHSA-6mpx-c8rj-whj5
- GHSA-x7v6-xfx3-52j6
- GHSA-9jcm-x588-gh26
- GHSA-q65v-4w7q-hx3r

**Test Plan**
- Connect to system

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
