### PR TITLE
pandoc: Update to 3.10.2

### DIFF
--- a/packages/p/pandoc-crossref/package.yml
+++ b/packages/p/pandoc-crossref/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : pandoc-crossref
-version    : 0.3.24
-release    : 14
+version    : 0.3.25
+release    : 15
 source     :
-    - https://github.com/lierdakil/pandoc-crossref/archive/refs/tags/v0.3.24a.tar.gz : 5b478c94b67d5b972c7b3d867a345be982d3af12475e2261dd9b37fc17e225d1
+    - https://github.com/lierdakil/pandoc-crossref/archive/refs/tags/v0.3.25.tar.gz : cb42b8319a59f258fea191e4660b62bdd9a90a9099322ae0f17203bc5986498a
 homepage   : https://lierdakil.github.io/pandoc-crossref/
 license    : GPL-2.0-only
 component  : office
@@ -18,7 +18,7 @@ rundeps    :
 networking : true
 setup      : |
     rm $workdir/cabal.project.freeze
-    %cabal_configure --enable-tests --constraint="pandoc == 3.9.0.2"
+    %cabal_configure --enable-tests --constraint="pandoc == 3.10.2"
 build      : |
     %haskell_build
 install    : |

--- a/packages/p/pandoc-crossref/pspec_x86_64.xml
+++ b/packages/p/pandoc-crossref/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pandoc-crossref</Name>
         <Homepage>https://lierdakil.github.io/pandoc-crossref/</Homepage>
         <Packager>
-            <Name>Ivan Trepakov</Name>
-            <Email>liontiger23@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>office</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2026-05-24</Date>
-            <Version>0.3.24</Version>
+        <Update release="15">
+            <Date>2026-08-27</Date>
+            <Version>0.3.25</Version>
             <Comment>Packaging update</Comment>
-            <Name>Ivan Trepakov</Name>
-            <Email>liontiger23@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/p/pandoc/abi_used_symbols
+++ b/packages/p/pandoc/abi_used_symbols
@@ -388,6 +388,7 @@ libm.so.6:cos
 libm.so.6:cosf
 libm.so.6:cosh
 libm.so.6:coshf
+libm.so.6:erf
 libm.so.6:exp
 libm.so.6:expf
 libm.so.6:expm1

--- a/packages/p/pandoc/package.yml
+++ b/packages/p/pandoc/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : pandoc
-version    : 3.9.0.2
-release    : 16
+version    : 3.10.2
+release    : 17
 source     :
-    - https://github.com/jgm/pandoc/archive/refs/tags/3.9.0.2.tar.gz : c300c60ae4d47da6e5d265e93f89b896324cdc84ccbb504b88a9855bacd6b5d7
+    - https://github.com/jgm/pandoc/archive/refs/tags/3.10.2.tar.gz : ec4c5d36e355785802601986637369ada24079ac20af6c0ee85c79502d77b3f0
 homepage   : https://pandoc.org
 license    : GPL-2.0-or-later
 component  : office

--- a/packages/p/pandoc/pspec_x86_64.xml
+++ b/packages/p/pandoc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pandoc</Name>
         <Homepage>https://pandoc.org</Homepage>
         <Packager>
-            <Name>Ivan Trepakov</Name>
-            <Email>liontiger23@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2026-05-09</Date>
-            <Version>3.9.0.2</Version>
+        <Update release="17">
+            <Date>2026-08-27</Date>
+            <Version>3.10.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Ivan Trepakov</Name>
-            <Email>liontiger23@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION

**Summary**
- [pandoc change log](https://github.com/jgm/pandoc/releases/tag/3.10.2)
- [pandoc-crossref change log](https://github.com/lierdakil/pandoc-crossref/releases/tag/v0.3.25)
- pandoc-crossref is tightly coupled with pandoc, needs to update to supported version
- Resolves getsolus/packages#9275

**Test Plan**
- Passed both test suites
- Run demo test verify output

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
