### PR TITLE
libheif: Update to 1.23.2

### DIFF
--- a/packages/l/libheif/abi_used_symbols
+++ b/packages/l/libheif/abi_used_symbols
@@ -349,7 +349,9 @@ libstdc++.so.6:_ZTINSt13__future_base12_Result_baseE
 libstdc++.so.6:_ZTINSt6thread6_StateE
 libstdc++.so.6:_ZTISt12bad_weak_ptr
 libstdc++.so.6:_ZTISt12future_error
+libstdc++.so.6:_ZTISt12length_error
 libstdc++.so.6:_ZTISt12system_error
+libstdc++.so.6:_ZTISt9bad_alloc
 libstdc++.so.6:_ZTISt9exception
 libstdc++.so.6:_ZTTNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTTNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEEE

--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libheif
-version    : 1.23.1
-release    : 65
+version    : 1.23.2
+release    : 66
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.23.1/libheif-1.23.1.tar.gz : 0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a
+    - https://github.com/strukturag/libheif/releases/download/v1.23.2/libheif-1.23.2.tar.gz : 8bd5d41d19dc84536d118b04774709f244df6104ef66d623dad5fa4650143405
 homepage   : https://github.com/strukturag/libheif
 license    :
     - LGPL-3.0-or-later

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libheif</Name>
         <Homepage>https://github.com/strukturag/libheif</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <License>MIT</License>
@@ -47,15 +47,15 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>multimedia.codecs</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="65">libheif-plugin-dav1d</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-ffmpeg</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-jpeg</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-rav1e</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-x265</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-dav1d</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-ffmpeg</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-jpeg</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-rav1e</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-x265</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.23.1</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.23.2</Path>
             <Path fileType="data">/usr/share/licenses/libheif/COPYING</Path>
         </Files>
     </Package>
@@ -79,18 +79,18 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="65">libheif</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-aom</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-dav1d</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-ffmpeg</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-j2k</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-jpeg</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-libde265</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-openh264</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-rav1e</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-svtav1</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-x264</Dependency>
-            <Dependency releaseFrom="65">libheif-plugin-x265</Dependency>
+            <Dependency release="66">libheif</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-aom</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-dav1d</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-ffmpeg</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-j2k</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-jpeg</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-libde265</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-openh264</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-rav1e</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-svtav1</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-x264</Dependency>
+            <Dependency releaseFrom="66">libheif-plugin-x265</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -403,7 +403,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>multimedia.codecs</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="65">libheif</Dependency>
+            <Dependency releaseFrom="66">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/heif-convert</Path>
@@ -419,12 +419,12 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="65">
-            <Date>2026-08-16</Date>
-            <Version>1.23.1</Version>
+        <Update release="66">
+            <Date>2026-08-27</Date>
+            <Version>1.23.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security
- [Change Log](https://github.com/strukturag/libheif/releases/tag/v1.23.2)

**Security**
- GHSA-g89c-p67h-r497
- GHSA-2jg2-4ch7-h545
- GHSA-24wx-9w62-c96w
- GHSA-x8xm-cm2c-cfc8
- GHSA-xw34-mjcp-jqh8
- GHSA-j264-xvrp-5v7q
- GHSA-p58j-h3vm-3fp5

**Test Plan**
- Test command line
- Test rebuild imagemagik


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
