### PR TITLE
rhythmbox-alternative-toolbar: Update to v0.21.0 & add license

### DIFF
--- a/packages/r/rhythmbox-alternative-toolbar/files/0001-Apply-Solus-Defaults.patch
+++ b/packages/r/rhythmbox-alternative-toolbar/files/0001-Apply-Solus-Defaults.patch
@@ -12,10 +12,10 @@ diff --git a/alternative-toolbar.plugin.in b/alternative-toolbar.plugin.in
 index ff565be..7c67337 100644
 --- a/alternative-toolbar.plugin.in
 +++ b/alternative-toolbar.plugin.in
-@@ -10,3 +10,6 @@ Copyright=© 2016-2022 David Mohammed
+@@ -10,3 +10,6 @@ Copyright=© 2016-2025 David Mohammed
  Website=http://github.com/fossfreedom/alternative-toolbar
  Help=https://github.com/fossfreedom/alternative-toolbar/blob/master/README.md
- Version=0.20.4
+ Version=0.21.0
 +
 +[RB]
 +InitiallyEnabled=true

--- a/packages/r/rhythmbox-alternative-toolbar/package.yml
+++ b/packages/r/rhythmbox-alternative-toolbar/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : rhythmbox-alternative-toolbar
-version    : 0.20.4
-release    : 19
+version    : 0.21.0
+release    : 20
 source     :
-    - https://github.com/fossfreedom/alternative-toolbar/releases/download/v0.20.4/alternative-toolbar-0.20.4.tar.xz : a036bc9bec34c5e4bfadde5f9a67a4777ef293d966a57819960aa6ac1d53a102
+    - https://github.com/fossfreedom/alternative-toolbar/releases/download/v0.21.0/alternative-toolbar-0.21.0.tar.xz : d2beaa901a9419948a247966332f56fe6f053b28371932a7b05089cefe7e0b9b
 homepage   : https://github.com/fossfreedom/alternative-toolbar/
 license    : GPL-3.0-or-later
 component  : desktop
@@ -23,3 +23,4 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license LICENSE

--- a/packages/r/rhythmbox-alternative-toolbar/pspec_x86_64.xml
+++ b/packages/r/rhythmbox-alternative-toolbar/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>rhythmbox-alternative-toolbar</Name>
         <Homepage>https://github.com/fossfreedom/alternative-toolbar/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop</PartOf>
@@ -31,9 +31,11 @@
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/alternative-toolbar/alttoolbar_type.py</Path>
             <Path fileType="library">/usr/lib64/rhythmbox/plugins/alternative-toolbar/alttoolbar_widget.py</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.rhythmbox.plugins.alternative_toolbar.gschema.xml</Path>
+            <Path fileType="data">/usr/share/licenses/rhythmbox-alternative-toolbar/LICENSE</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/am/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/alternative-toolbar.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/az/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bs/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/alternative-toolbar.mo</Path>
@@ -46,7 +48,6 @@
             <Path fileType="localedata">/usr/share/locale/en_CA/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/en_GB/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/en_US/LC_MESSAGES/alternative-toolbar.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/eu/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/alternative-toolbar.mo</Path>
@@ -56,6 +57,7 @@
             <Path fileType="localedata">/usr/share/locale/he/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hr/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/alternative-toolbar.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ia/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/alternative-toolbar.mo</Path>
@@ -77,6 +79,7 @@
             <Path fileType="localedata">/usr/share/locale/sr@latin/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/szl/LC_MESSAGES/alternative-toolbar.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/te/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/th/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/alternative-toolbar.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ug/LC_MESSAGES/alternative-toolbar.mo</Path>
@@ -99,12 +102,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2025-11-01</Date>
-            <Version>0.20.4</Version>
+        <Update release="20">
+            <Date>2026-08-27</Date>
+            <Version>0.21.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Part of #7294

Changelog:

- Fix syntax warning
- Translation updates
- Bump version and copyright year for the plugin

**Test Plan**
- launch rhythmbox, select rhythmbox-alternative-toolbar plugin and see that it works.
- See that the license file was installed.

**Checklist**
- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes
once merged <!-- Write an appropriate message in the Summary section,
then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous
contributions under the licensing terms in
[LICENSE.md](../blob/main/LICENSE.md) and have the power and authority
to grant those licenses.
