### PR TITLE
xpad: Update to v5.9.0 & add license

### DIFF
--- a/packages/x/xpad/abi_used_symbols
+++ b/packages/x/xpad/abi_used_symbols
@@ -65,6 +65,7 @@ libgdk-3.so.0:gdk_rgba_free
 libgdk-3.so.0:gdk_rgba_get_type
 libgdk-3.so.0:gdk_rgba_parse
 libgdk-3.so.0:gdk_rgba_to_string
+libgdk-3.so.0:gdk_screen_get_rgba_visual
 libgdk-3.so.0:gdk_set_program_class
 libgdk-3.so.0:gdk_window_freeze_updates
 libgdk-3.so.0:gdk_window_get_display
@@ -202,6 +203,7 @@ libgobject-2.0.so.0:g_value_get_pointer
 libgobject-2.0.so.0:g_value_get_string
 libgobject-2.0.so.0:g_value_get_uint
 libgobject-2.0.so.0:g_value_set_boolean
+libgobject-2.0.so.0:g_value_set_boxed
 libgobject-2.0.so.0:g_value_set_pointer
 libgobject-2.0.so.0:g_value_set_static_boxed
 libgobject-2.0.so.0:g_value_set_string
@@ -371,6 +373,7 @@ libgtk-3.so.0:gtk_widget_get_allocated_width
 libgtk-3.so.0:gtk_widget_get_direction
 libgtk-3.so.0:gtk_widget_get_display
 libgtk-3.so.0:gtk_widget_get_preferred_size
+libgtk-3.so.0:gtk_widget_get_screen
 libgtk-3.so.0:gtk_widget_get_style_context
 libgtk-3.so.0:gtk_widget_get_toplevel
 libgtk-3.so.0:gtk_widget_get_type
@@ -379,6 +382,7 @@ libgtk-3.so.0:gtk_widget_get_window
 libgtk-3.so.0:gtk_widget_grab_focus
 libgtk-3.so.0:gtk_widget_hide
 libgtk-3.so.0:gtk_widget_intersect
+libgtk-3.so.0:gtk_widget_set_app_paintable
 libgtk-3.so.0:gtk_widget_set_halign
 libgtk-3.so.0:gtk_widget_set_margin_bottom
 libgtk-3.so.0:gtk_widget_set_margin_end
@@ -388,6 +392,7 @@ libgtk-3.so.0:gtk_widget_set_name
 libgtk-3.so.0:gtk_widget_set_sensitive
 libgtk-3.so.0:gtk_widget_set_size_request
 libgtk-3.so.0:gtk_widget_set_valign
+libgtk-3.so.0:gtk_widget_set_visual
 libgtk-3.so.0:gtk_widget_show
 libgtk-3.so.0:gtk_widget_show_all
 libgtk-3.so.0:gtk_widget_translate_coordinates

--- a/packages/x/xpad/package.yml
+++ b/packages/x/xpad/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xpad
-version    : 5.8.0
-release    : 4
+version    : 5.9.0
+release    : 5
 source     :
-    - https://launchpad.net/xpad/trunk/5.8.0/+download/xpad-5.8.0.tar.bz2 : f26052308850c406b15adb8d86acd3962ef10af22b427bb1a5cff4eec96f82e9
+    - https://launchpad.net/xpad/trunk/5.9.0/+download/xpad-5.9.0.tar.bz2 : 16c35f52cd550a7bf920a57aa07ed7bfda6fa9eec50a98024e93acb7fe16dca3
 homepage   : https://launchpad.net/xpad
-license    : GPL-2.0-only
+license    : GPL-3.0-or-later
 component  : office.notes
 summary    : A basic sticky note application
 description: |
@@ -21,3 +21,4 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING

--- a/packages/x/xpad/pspec_x86_64.xml
+++ b/packages/x/xpad/pspec_x86_64.xml
@@ -3,10 +3,10 @@
         <Name>xpad</Name>
         <Homepage>https://launchpad.net/xpad</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Packager>
-        <License>GPL-2.0-only</License>
+        <License>GPL-3.0-or-later</License>
         <PartOf>office.notes</PartOf>
         <Summary xml:lang="en">A basic sticky note application</Summary>
         <Description xml:lang="en">A sticky note application for jotting down things to remember
@@ -23,6 +23,7 @@
             <Path fileType="executable">/usr/bin/xpad</Path>
             <Path fileType="data">/usr/share/applications/xpad.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/xpad.svg</Path>
+            <Path fileType="data">/usr/share/licenses/xpad/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/xpad.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/xpad.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/xpad.mo</Path>
@@ -51,18 +52,18 @@
             <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/xpad.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/xpad.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/xpad.mo</Path>
-            <Path fileType="man">/usr/share/man/man1/xpad.1</Path>
+            <Path fileType="man">/usr/share/man/man1/xpad.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/xpad.appdata.xml</Path>
             <Path fileType="data">/usr/share/xpad/help/xpad-user-help.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-06-30</Date>
-            <Version>5.8.0</Version>
+        <Update release="5">
+            <Date>2026-08-27</Date>
+            <Version>5.9.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Part of #7294

Changelog:

- New: Ability to activate transparency of a pad by Evaldas Granickas
- Fix: prevent irrelevant CLI warning about a failed toolbar height calculation.
- Fix: Xpad help: extend the help by explaining that shortcuts are either being set by Xpad, GTK or the window manager.
- Fix: CLI command: when hiding the pads from the CLI, do not quit the application if there is no notification icon enabled/available.
- Fix: Pad size was lost after app restart
- Fix: Individual pad colors were lost after app restart.
- Fix: Add AC_CONFIG_MACRO_DIRS to squash autogen errors by neil.mayhew

**Test Plan**
- launch xpad & edit notes
- See that the license file was installed.

**Checklist**
- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes
once merged <!-- Write an appropriate message in the Summary section,
then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous
contributions under the licensing terms in
[LICENSE.md](../blob/main/LICENSE.md) and have the power and authority
to grant those licenses.
