### PR TITLE
stress-ng: Update to 0.22.00

### DIFF
--- a/packages/s/stress-ng/package.yml
+++ b/packages/s/stress-ng/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : stress-ng
-version    : 0.21.04
-release    : 19
+version    : 0.22.00
+release    : 20
 source     :
-    - https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.21.04.tar.gz : a328ba050bd3014f07a3265fb6c1aab071ae942dfad75c7459cce45a987869e1
+    - https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.22.00.tar.gz : 4dab6440b81a05468c256e3540285d167f4b8b35f48788723f46fada3b7b71a9
 license    : GPL-2.0-or-later
 component  : system.utils
 homepage   : https://github.com/ColinIanKing/stress-ng

--- a/packages/s/stress-ng/pspec_x86_64.xml
+++ b/packages/s/stress-ng/pspec_x86_64.xml
@@ -42,9 +42,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-07-21</Date>
-            <Version>0.21.04</Version>
+        <Update release="20">
+            <Date>2026-08-27</Date>
+            <Version>0.22.00</Version>
             <Comment>Packaging update</Comment>
             <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**
- [Change Log](https://github.com/ColinIanKing/stress-ng/releases/tag/V0.22.00)

**Test Plan**
- Test with s-tui

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
