### PR TITLE
libssh: Update to 0.12.2

### DIFF
--- a/packages/l/libssh/abi_symbols
+++ b/packages/l/libssh/abi_symbols
@@ -1,5 +1,6 @@
 libssh.so.4:LIBSSH_4_10_0
 libssh.so.4:LIBSSH_4_11_0
+libssh.so.4:LIBSSH_4_12_0
 libssh.so.4:LIBSSH_4_5_0
 libssh.so.4:LIBSSH_4_6_0
 libssh.so.4:LIBSSH_4_7_0
@@ -395,6 +396,7 @@ libssh.so.4:ssh_session_export_known_hosts_entry
 libssh.so.4:ssh_session_get_known_hosts_entry
 libssh.so.4:ssh_session_has_known_hosts_entry
 libssh.so.4:ssh_session_is_known_server
+libssh.so.4:ssh_session_kex_is_gss
 libssh.so.4:ssh_session_set_disconnect_message
 libssh.so.4:ssh_session_update_known_hosts
 libssh.so.4:ssh_set_agent_channel
@@ -436,6 +438,7 @@ libssh.so.4:ssh_userauth_agent
 libssh.so.4:ssh_userauth_agent_pubkey
 libssh.so.4:ssh_userauth_autopubkey
 libssh.so.4:ssh_userauth_gssapi
+libssh.so.4:ssh_userauth_gssapi_keyex
 libssh.so.4:ssh_userauth_kbdint
 libssh.so.4:ssh_userauth_kbdint_getanswer
 libssh.so.4:ssh_userauth_kbdint_getinstruction

--- a/packages/l/libssh/abi_used_symbols
+++ b/packages/l/libssh/abi_used_symbols
@@ -217,6 +217,8 @@ libcrypto.so.3:EVP_KDF_CTX_new
 libcrypto.so.3:EVP_KDF_derive
 libcrypto.so.3:EVP_KDF_fetch
 libcrypto.so.3:EVP_KDF_free
+libcrypto.so.3:EVP_KEM_fetch
+libcrypto.so.3:EVP_KEM_free
 libcrypto.so.3:EVP_MAC_CTX_free
 libcrypto.so.3:EVP_MAC_CTX_new
 libcrypto.so.3:EVP_MAC_fetch

--- a/packages/l/libssh/package.yml
+++ b/packages/l/libssh/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libssh
-version    : 0.12.1
-release    : 21
+version    : 0.12.2
+release    : 22
 source     :
-    - https://www.libssh.org/files/0.12/libssh-0.12.1.tar.xz : d3941af0a2d78d5d82ed7a36988e9133994312f035b9659a6e43f8db3968784c
+    - https://www.libssh.org/files/0.12/libssh-0.12.2.tar.xz : 49560f677d96e3706a904ac2de1116e25f3680937d51e5c92198fcba4a1c1e9f
 homepage   : https://www.libssh.org/
 license    : LGPL-2.1-or-later
 component  : programming.library

--- a/packages/l/libssh/pspec_x86_64.xml
+++ b/packages/l/libssh/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libssh</Name>
         <Homepage>https://www.libssh.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libssh.so.4</Path>
-            <Path fileType="library">/usr/lib64/libssh.so.4.11.1</Path>
+            <Path fileType="library">/usr/lib64/libssh.so.4.12.0</Path>
             <Path fileType="data">/usr/share/licenses/libssh/COPYING</Path>
         </Files>
     </Package>
@@ -32,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">libssh</Dependency>
+            <Dependency release="22">libssh</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libssh/callbacks.h</Path>
@@ -52,12 +52,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2026-07-21</Date>
-            <Version>0.12.1</Version>
+        <Update release="22">
+            <Date>2026-08-27</Date>
+            <Version>0.12.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security release
- [Change Log](https://www.libssh.org/2026/07/28/libssh-0-12-2-security-release/)
- No breaking changes

**Security**
- CVE-2026-59843

**Test Plan**
- Test ffmpeg and remmina

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
