### PR TITLE
wlroots: Update to v0.20.2

### DIFF
--- a/packages/w/wlroots/abi_used_symbols
+++ b/packages/w/wlroots/abi_used_symbols
@@ -662,6 +662,7 @@ libwayland-server.so.0:wl_resource_from_link
 libwayland-server.so.0:wl_resource_get_class
 libwayland-server.so.0:wl_resource_get_client
 libwayland-server.so.0:wl_resource_get_id
+libwayland-server.so.0:wl_resource_get_interface
 libwayland-server.so.0:wl_resource_get_link
 libwayland-server.so.0:wl_resource_get_user_data
 libwayland-server.so.0:wl_resource_get_version

--- a/packages/w/wlroots/package.yml
+++ b/packages/w/wlroots/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : wlroots
-version    : 0.20.1
-release    : 28
+version    : 0.20.2
+release    : 29
 source     :
-    - https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/0.20.1/wlroots-0.20.1.tar.bz2 : b5fadef7f5ce5c14917fdd24f3c009399923d12b5b29b062cbb300bc504d0458
+    - https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/0.20.2/wlroots-0.20.2.tar.bz2 : 20c37b521dc3054b6e9627b79bdd45fc716db9ebc58bdf97e57e84d04b04610f
 license    : MIT
 component  : desktop.library
 homepage   : https://gitlab.freedesktop.org/wlroots/wlroots

--- a/packages/w/wlroots/pspec_x86_64.xml
+++ b/packages/w/wlroots/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wlroots</Name>
         <Homepage>https://gitlab.freedesktop.org/wlroots/wlroots</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.library</PartOf>
@@ -31,7 +31,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">wlroots</Dependency>
+            <Dependency release="29">wlroots</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wlroots-0.20/wlr/backend.h</Path>
@@ -161,12 +161,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2026-05-26</Date>
-            <Version>0.20.1</Version>
+        <Update release="29">
+            <Date>2026-08-28</Date>
+            <Version>0.20.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://gitlab.freedesktop.org/wlroots/wlroots/-/tags/0.20.2).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `labwc` against this version and start a Budgie Wayland session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
