### PR TITLE
xfce4-panel: Backport patch for systray crash with Electron apps

### DIFF
--- a/packages/x/xfce4-panel/files/avoid-systray-crash.patch
+++ b/packages/x/xfce4-panel/files/avoid-systray-crash.patch
@@ -1,0 +1,31 @@
+From 72c6cc88ee2eb48a9d99203b440b66562c9ba45c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ga=C3=ABl=20Bonithon?= <gael@xfce.org>
+Date: Fri, 21 Aug 2026 20:00:58 +0200
+Subject: [PATCH] systray: Avoid crash when bus_name contains garbage
+
+We should return TRUE in this case as well, as we actually handle the
+invocation, although by returning an error. Otherwise it makes glib
+crash.
+
+Related: #992
+(cherry picked from commit 1c9220f8eeb7aa093a9b107116705ed2ac3c28d4)
+---
+ plugins/systray/sn-backend.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/systray/sn-backend.c b/plugins/systray/sn-backend.c
+index fd8c851af..0a3b4a817 100644
+--- a/plugins/systray/sn-backend.c
++++ b/plugins/systray/sn-backend.c
+@@ -375,7 +375,7 @@ sn_backend_watcher_register_item (SnWatcher *watcher_skeleton,
+                                                      G_IO_ERROR,
+                                                      G_IO_ERROR_INVALID_ARGUMENT,
+                                                      "Invalid bus name");
+-      return FALSE;
++      return TRUE;
+     }
+ 
+   key = g_strdup_printf ("%s%s", bus_name, object_path);
+-- 
+GitLab
+

--- a/packages/x/xfce4-panel/package.yml
+++ b/packages/x/xfce4-panel/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xfce4-panel
 version    : 4.20.8
-release    : 23
+release    : 24
 source     :
     - https://archive.xfce.org/src/xfce/xfce4-panel/4.20/xfce4-panel-4.20.8.tar.bz2 : d69cb1f377953aeb1fb9bdbcef12c246bea66586e3f2868f3b758e0e8ce3d3fe
 homepage   : https://docs.xfce.org/xfce/xfce4-panel/start
@@ -25,6 +25,7 @@ rundeps    :
 setup      : |
     %patch -p1 -i ${pkgfiles}/0001-Use-Solus-defaults.patch
     %patch -p1 -i ${pkgfiles}/wayland-wrapper-Prevent-plugin-allocation-blocking.patch
+    %patch -p1 -i ${pkgfiles}/avoid-systray-crash.patch
 
     %meson_configure \
         --sysconfdir=/usr/share

--- a/packages/x/xfce4-panel/pspec_x86_64.xml
+++ b/packages/x/xfce4-panel/pspec_x86_64.xml
@@ -228,7 +228,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="23">xfce4-panel</Dependency>
+            <Dependency release="24">xfce4-panel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xfce4/libxfce4panel-2.0/libxfce4panel/libxfce4panel-config.h</Path>
@@ -248,8 +248,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2026-07-29</Date>
+        <Update release="24">
+            <Date>2026-08-28</Date>
             <Version>4.20.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
Backport a patch to avoid crashes with Electron apps when they create a system tray icon.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new Xfce4 session and launch Discord.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
