### PR TITLE
nfs-utils: Update to v2.9.2

### DIFF
--- a/packages/n/nfs-utils/abi_used_symbols
+++ b/packages/n/nfs-utils/abi_used_symbols
@@ -181,6 +181,7 @@ libc.so.6:perror
 libc.so.6:pipe
 libc.so.6:poll
 libc.so.6:prctl
+libc.so.6:pthread_attr_destroy
 libc.so.6:pthread_attr_init
 libc.so.6:pthread_attr_setdetachstate
 libc.so.6:pthread_cancel

--- a/packages/n/nfs-utils/package.yml
+++ b/packages/n/nfs-utils/package.yml
@@ -1,14 +1,14 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nfs-utils
-version    : 2.9.1
-release    : 27
+version    : 2.9.2
+release    : 28
 source     :
-    - https://mirrors.edge.kernel.org/pub/linux/utils/nfs-utils/2.9.1/nfs-utils-2.9.1.tar.gz : 384c91a563fb1a36c040ff9d2783bf755d52d927d1635363ff75a54f73018f0d
+    - https://mirrors.edge.kernel.org/pub/linux/utils/nfs-utils/2.9.2/nfs-utils-2.9.2.tar.gz : 56c4fbd273688b1983390703b234a84094505a78048d77be8709b3077973fb0f
 homepage   : https://nfs.sourceforge.net/
 license    :
     - GPL-2.0-only
     - GPL-2.0-or-later
-component  : network.utils
+component  : network.util
 summary    : Network File System Utilities
 description: |
     Network File System Utilities
@@ -31,6 +31,7 @@ setup      : |
     sed -i "s|/sbin|/usr/sbin|" systemd/60-nfs.rules
     sed -i "s|/sbin|/usr/sbin|" systemd/auth-rpcgss-module.service
     sed -i "s|/bin|/usr/bin|" systemd/nfs-server.service
+    sed -i "s|libexec|lib%LIBSUFFIX%/${package}|" tools/nfsrahead/99-nfs.rules
 
     %configure \
         --disable-static \
@@ -41,6 +42,7 @@ setup      : |
         --disable-sbin-override \
         --enable-libmount-mount \
         --enable-ipv6 \
+        --enable-junction \
         --enable-svcgss # Required if gssproxy is not available
 build      : |
     %make
@@ -48,13 +50,13 @@ install    : |
     %make_install
     %install_license COPYING
 
-    install -Dm00644 utils/nfsidmap/id_resolver.conf $installdir/usr/share/defaults/etc/request-key.d/id_resolver.conf
-    install -m00644 nfs.conf $installdir/usr/share/defaults/etc/nfs.conf
-    install -m00644 support/nfsidmap/idmapd.conf $installdir/usr/share/defaults/etc/idmapd.conf
-    install -m00644 utils/mount/nfsmount.conf $installdir/usr/share/defaults/etc/nfsmount.conf
+    %install_file -t ${installdir}/usr/share/defaults/etc/request-key.d utils/nfsidmap/id_resolver.conf
+    %install_file -t ${installdir}/usr/share/defaults/etc nfs.conf
+    %install_file -t ${installdir}/usr/share/defaults/etc support/nfsidmap/idmapd.conf
+    %install_file -t ${installdir}/usr/share/defaults/etc utils/mount/nfsmount.conf
 
-    install -Dm00644 ${pkgfiles}/${package}.preset ${installdir}/%libdir%/systemd/system-preset/60-${package}.preset
-    install -Dm00644 ${pkgfiles}/${package}.tmpfiles $installdir/%libdir%/tmpfiles.d/${package}.conf
+    %install_file ${pkgfiles}/${package}.preset ${installdir}/%libdir%/systemd/system-preset/60-${package}.preset
+    %install_file ${pkgfiles}/${package}.tmpfiles $installdir/%libdir%/tmpfiles.d/${package}.conf
 
     # Stateless
     rm -v $installdir/run/nfs/etab \

--- a/packages/n/nfs-utils/pspec_x86_64.xml
+++ b/packages/n/nfs-utils/pspec_x86_64.xml
@@ -8,7 +8,7 @@
         </Packager>
         <License>GPL-2.0-only</License>
         <License>GPL-2.0-or-later</License>
-        <PartOf>network.utils</PartOf>
+        <PartOf>network.util</PartOf>
         <Summary xml:lang="en">Network File System Utilities</Summary>
         <Description xml:lang="en">Network File System Utilities
 </Description>
@@ -19,7 +19,7 @@
         <Summary xml:lang="en">Network File System Utilities</Summary>
         <Description xml:lang="en">Network File System Utilities
 </Description>
-        <PartOf>network.utils</PartOf>
+        <PartOf>network.util</PartOf>
         <Files>
             <Path fileType="library">/usr/lib/systemd/system-generators/nfs-server-generator</Path>
             <Path fileType="library">/usr/lib/systemd/system-generators/nfsroot-generator</Path>
@@ -131,7 +131,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">nfs-utils</Dependency>
+            <Dependency release="28">nfs-utils</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/nfsidmap.h</Path>
@@ -145,9 +145,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2026-04-10</Date>
-            <Version>2.9.1</Version>
+        <Update release="28">
+            <Date>2026-08-28</Date>
+            <Version>2.9.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://mirrors.edge.kernel.org/pub/linux/utils/nfs-utils/2.9.2/2.9.2-Changelog).
Fix incorrect libexecdir path in `99-nfs.rules`.

Fixes https://github.com/getsolus/packages/issues/10401

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Extract the `eopkg` file and see that the path is correct in `99-nfs.rules`. Someone else who actually uses `nfs-utils` should probably test this.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
