### PR TITLE
pcre2: Update to v10.48

### DIFF
--- a/packages/p/pcre2/abi_used_symbols
+++ b/packages/p/pcre2/abi_used_symbols
@@ -20,3 +20,4 @@ libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
 libc.so.6:strlen
 libc.so.6:sysconf
+libc.so.6:wcslen

--- a/packages/p/pcre2/abi_used_symbols32
+++ b/packages/p/pcre2/abi_used_symbols32
@@ -20,3 +20,4 @@ libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
 libc.so.6:strlen
 libc.so.6:sysconf
+libc.so.6:wcslen

--- a/packages/p/pcre2/package.yml
+++ b/packages/p/pcre2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : pcre2
-version    : '10.47'
-release    : 16
+version    : '10.48'
+release    : 17
 source     :
-    - https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.bz2 : 47fe8c99461250d42f89e6e8fdaeba9da057855d06eb7fc08d9ca03fd08d7bc7
+    - https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.48/pcre2-10.48.tar.bz2 : b6c68fdf6f3ac31388b50aa89ff0fc49c00c987c16e7b5146491d12003f2c8ed
 homepage   : https://github.com/PCRE2Project/pcre2
 license    : BSD-3-Clause
 component  : system.base

--- a/packages/p/pcre2/pspec_x86_64.xml
+++ b/packages/p/pcre2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pcre2</Name>
         <Homepage>https://github.com/PCRE2Project/pcre2</Homepage>
         <Packager>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>system.base</PartOf>
@@ -21,13 +21,13 @@
         <PartOf>system.base</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libpcre2-16.so.0</Path>
-            <Path fileType="library">/usr/lib64/libpcre2-16.so.0.15.0</Path>
+            <Path fileType="library">/usr/lib64/libpcre2-16.so.0.16.0</Path>
             <Path fileType="library">/usr/lib64/libpcre2-32.so.0</Path>
-            <Path fileType="library">/usr/lib64/libpcre2-32.so.0.15.0</Path>
+            <Path fileType="library">/usr/lib64/libpcre2-32.so.0.16.0</Path>
             <Path fileType="library">/usr/lib64/libpcre2-8.so.0</Path>
-            <Path fileType="library">/usr/lib64/libpcre2-8.so.0.15.0</Path>
+            <Path fileType="library">/usr/lib64/libpcre2-8.so.0.16.0</Path>
             <Path fileType="library">/usr/lib64/libpcre2-posix.so.3</Path>
-            <Path fileType="library">/usr/lib64/libpcre2-posix.so.3.0.7</Path>
+            <Path fileType="library">/usr/lib64/libpcre2-posix.so.3.0.8</Path>
             <Path fileType="data">/usr/share/licenses/pcre2/LICENCE.md</Path>
             <Path fileType="data">/usr/share/licenses/pcre2/sljit/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/pcre2-config.1.zst</Path>
@@ -40,17 +40,17 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="16">pcre2</Dependency>
+            <Dependency release="17">pcre2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpcre2-16.so.0</Path>
-            <Path fileType="library">/usr/lib32/libpcre2-16.so.0.15.0</Path>
+            <Path fileType="library">/usr/lib32/libpcre2-16.so.0.16.0</Path>
             <Path fileType="library">/usr/lib32/libpcre2-32.so.0</Path>
-            <Path fileType="library">/usr/lib32/libpcre2-32.so.0.15.0</Path>
+            <Path fileType="library">/usr/lib32/libpcre2-32.so.0.16.0</Path>
             <Path fileType="library">/usr/lib32/libpcre2-8.so.0</Path>
-            <Path fileType="library">/usr/lib32/libpcre2-8.so.0.15.0</Path>
+            <Path fileType="library">/usr/lib32/libpcre2-8.so.0.16.0</Path>
             <Path fileType="library">/usr/lib32/libpcre2-posix.so.3</Path>
-            <Path fileType="library">/usr/lib32/libpcre2-posix.so.3.0.7</Path>
+            <Path fileType="library">/usr/lib32/libpcre2-posix.so.3.0.8</Path>
         </Files>
     </Package>
     <Package>
@@ -60,8 +60,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="16">pcre2-devel</Dependency>
-            <Dependency release="16">pcre2-32bit</Dependency>
+            <Dependency release="17">pcre2-32bit</Dependency>
+            <Dependency release="17">pcre2-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpcre2-16.so</Path>
@@ -81,7 +81,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="16">pcre2</Dependency>
+            <Dependency release="17">pcre2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/pcre2-config</Path>
@@ -111,6 +111,7 @@
             <Path fileType="doc">/usr/share/doc/pcre2/NEWS</Path>
             <Path fileType="doc">/usr/share/doc/pcre2/README</Path>
             <Path fileType="doc">/usr/share/doc/pcre2/SECURITY.md</Path>
+            <Path fileType="doc">/usr/share/doc/pcre2/SUPPORT-LIFECYCLE.md</Path>
             <Path fileType="doc">/usr/share/doc/pcre2/html/NON-AUTOTOOLS-BUILD.txt</Path>
             <Path fileType="doc">/usr/share/doc/pcre2/html/README.txt</Path>
             <Path fileType="doc">/usr/share/doc/pcre2/html/index.html</Path>
@@ -318,12 +319,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2026-04-26</Date>
-            <Version>10.47</Version>
+        <Update release="17">
+            <Date>2026-09-01</Date>
+            <Version>10.48</Version>
             <Comment>Packaging update</Comment>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/PCRE2Project/pcre2/releases/tag/pcre2-10.48)

**Security**

- GHSA-2p8c-ff85-vh9x
- GHSA-q8g2-wprr-34m9
- GHSA-3r4p-g7gg-ppmf
- GHSA-fmgr-6ggq-9859
- GHSA-9qww-pwc4-77qq
- GHSA-q7rw-r7qq-2hx6

**Test Plan**

- Built some revdeps, see no change

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
