### PR TITLE
libgcrypt: Update to v1.12.3

### DIFF
--- a/packages/l/libgcrypt/package.yml
+++ b/packages/l/libgcrypt/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libgcrypt
-version    : 1.12.2
-release    : 32
+version    : 1.12.3
+release    : 33
 source     :
-    - https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.12.2.tar.bz2 : 7ce33c2492221a0436f96a8500215e9f3e3dcb5fd26a757cd415e7a843babd5e
+    - https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.12.3.tar.bz2 : 98d1b0b3202d2b03fa754a35aa3cbbfcf526a3260d8d2ee213748001b1043006
 license    :
     - GPL-2.0-or-later
     - LGPL-2.1-or-later

--- a/packages/l/libgcrypt/pspec_x86_64.xml
+++ b/packages/l/libgcrypt/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libgcrypt</Name>
         <Homepage>https://gnupg.org/software/libgcrypt/index.html</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -26,7 +26,7 @@
             <Path fileType="executable">/usr/bin/libgcrypt-config</Path>
             <Path fileType="executable">/usr/bin/mpicalc</Path>
             <Path fileType="library">/usr/lib64/libgcrypt.so.20</Path>
-            <Path fileType="library">/usr/lib64/libgcrypt.so.20.7.2</Path>
+            <Path fileType="library">/usr/lib64/libgcrypt.so.20.8.8</Path>
             <Path fileType="info">/usr/share/info/gcrypt.info-1.zst</Path>
             <Path fileType="info">/usr/share/info/gcrypt.info-2.zst</Path>
             <Path fileType="info">/usr/share/info/gcrypt.info.zst</Path>
@@ -43,11 +43,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">libgcrypt</Dependency>
+            <Dependency release="33">libgcrypt</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgcrypt.so.20</Path>
-            <Path fileType="library">/usr/lib32/libgcrypt.so.20.7.2</Path>
+            <Path fileType="library">/usr/lib32/libgcrypt.so.20.8.8</Path>
         </Files>
     </Package>
     <Package>
@@ -57,8 +57,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">libgcrypt-devel</Dependency>
-            <Dependency release="32">libgcrypt-32bit</Dependency>
+            <Dependency release="33">libgcrypt-devel</Dependency>
+            <Dependency release="33">libgcrypt-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgcrypt.so</Path>
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">libgcrypt</Dependency>
+            <Dependency release="33">libgcrypt</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gcrypt.h</Path>
@@ -82,12 +82,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2026-04-21</Date>
-            <Version>1.12.2</Version>
+        <Update release="33">
+            <Date>2026-09-01</Date>
+            <Version>1.12.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/gpg/libgcrypt/blob/libgcrypt-1.12.3/NEWS)
- gcrypt doesn't consider this a security release: "...the real world attack severity is not critical.
Thus we don't consider 1.12.3 a security fix release."

**Test Plan**

- Built some revdeps, no change

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
