### PR TITLE
lact: Update to v0.10.1

### DIFF
--- a/packages/l/lact/abi_used_symbols
+++ b/packages/l/lact/abi_used_symbols
@@ -366,6 +366,7 @@ libgobject-2.0.so.0:g_object_unref
 libgobject-2.0.so.0:g_param_spec_boolean
 libgobject-2.0.so.0:g_param_spec_double
 libgobject-2.0.so.0:g_param_spec_get_name
+libgobject-2.0.so.0:g_param_spec_int
 libgobject-2.0.so.0:g_param_spec_int64
 libgobject-2.0.so.0:g_param_spec_ref_sink
 libgobject-2.0.so.0:g_param_spec_string

--- a/packages/l/lact/package.yml
+++ b/packages/l/lact/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : lact
-version    : 0.10.0
-release    : 18
+version    : 0.10.1
+release    : 19
 source     :
-    - git|https://github.com/ilya-zlobintsev/LACT.git : v0.10.0
+    - git|https://github.com/ilya-zlobintsev/LACT.git : v0.10.1
 homepage   : https://github.com/ilya-zlobintsev/LACT
 license    : MIT
 component  : system.utils

--- a/packages/l/lact/pspec_x86_64.xml
+++ b/packages/l/lact/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>lact</Name>
         <Homepage>https://github.com/ilya-zlobintsev/LACT</Homepage>
         <Packager>
-            <Name>Clint Eschberger</Name>
-            <Email>clint@eschberger.info</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -33,12 +33,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2026-08-13</Date>
-            <Version>0.10.0</Version>
+        <Update release="19">
+            <Date>2026-09-01</Date>
+            <Version>0.10.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Clint Eschberger</Name>
-            <Email>clint@eschberger.info</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/ilya-zlobintsev/LACT/releases/tag/v0.10.1).

**Security**
- CVE-2026-75037
- CVE-2026-75038

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start LACT, start the service, view information about my GPU.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
