### PR TITLE
exiv2: Update to v0.28.9

### DIFF
--- a/packages/e/exiv2/abi_used_symbols
+++ b/packages/e/exiv2/abi_used_symbols
@@ -136,7 +136,10 @@ libexpat.so.1:XML_StopParser
 libgcc_s.so.1:_Unwind_Resume
 libm.so.6:exp
 libm.so.6:expf
+libm.so.6:feclearexcept
+libm.so.6:fetestexcept
 libm.so.6:fmod
+libm.so.6:llround
 libm.so.6:logf
 libm.so.6:lround
 libm.so.6:lroundf
@@ -256,6 +259,7 @@ libstdc++.so.6:_ZTINSt10filesystem7__cxx1116filesystem_errorE
 libstdc++.so.6:_ZTINSt7__cxx117collateIcEE
 libstdc++.so.6:_ZTISt11regex_error
 libstdc++.so.6:_ZTISt12out_of_range
+libstdc++.so.6:_ZTISt12system_error
 libstdc++.so.6:_ZTISt14overflow_error
 libstdc++.so.6:_ZTISt16invalid_argument
 libstdc++.so.6:_ZTISt9exception
@@ -277,7 +281,6 @@ libstdc++.so.6:_ZTVSt14basic_ofstreamIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTVSt15basic_streambufIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTVSt9basic_iosIcSt11char_traitsIcEE
 libstdc++.so.6:_ZdaPv
-libstdc++.so.6:_ZdaPvm
 libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm

--- a/packages/e/exiv2/package.yml
+++ b/packages/e/exiv2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : exiv2
-version    : 0.28.8
-release    : 20
+version    : 0.28.9
+release    : 21
 source     :
-    - https://github.com/Exiv2/exiv2/archive/v0.28.8.tar.gz : ea51b0609f58a9afa063b60daa1539948b62247721e154f4fff0ad3aec9f9756
+    - https://github.com/Exiv2/exiv2/archive/v0.28.9.tar.gz : 700b76b97695b2fab4ef8c79619c68ae57d09e0c130724791cafbd39e0eb4aef
 license    : GPL-2.0-or-later
 component  : desktop.library
 homepage   : https://exiv2.org/

--- a/packages/e/exiv2/pspec_x86_64.xml
+++ b/packages/e/exiv2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>exiv2</Name>
         <Homepage>https://exiv2.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.library</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>desktop.library</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/exiv2</Path>
-            <Path fileType="library">/usr/lib64/libexiv2.so.0.28.8</Path>
+            <Path fileType="library">/usr/lib64/libexiv2.so.0.28.9</Path>
             <Path fileType="library">/usr/lib64/libexiv2.so.28</Path>
             <Path fileType="data">/usr/share/licenses/exiv2/COPYING</Path>
             <Path fileType="data">/usr/share/licenses/exiv2/LICENSE.txt</Path>
@@ -56,7 +56,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">exiv2</Dependency>
+            <Dependency release="21">exiv2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/exiv2/asfvideo.hpp</Path>
@@ -116,12 +116,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-03-02</Date>
-            <Version>0.28.8</Version>
+        <Update release="21">
+            <Date>2026-09-01</Date>
+            <Version>0.28.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/Exiv2/exiv2/releases/tag/v0.28.9).

- CVE-2026-68546
- CVE-2026-68547
- CVE-2026-49275

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild a reverse dependency.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
