### PR TITLE
zellij: Update to v0.45.1

### DIFF
--- a/packages/z/zellij/package.yml
+++ b/packages/z/zellij/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : zellij
-version    : 0.45.0
-release    : 21
+version    : 0.45.1
+release    : 22
 source     :
-    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.45.0.tar.gz : fba81ade9d3fd93869338553dce394a889e6f28e0e91f98896eb77533bab599b
+    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.45.1.tar.gz : 5cbe711437d2a61afd9287165f6aca0bcccb9ab1473633665a5b11ed55467852
 homepage   : https://zellij.dev
 license    : MIT
 component  : system.utils

--- a/packages/z/zellij/pspec_x86_64.xml
+++ b/packages/z/zellij/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2026-08-20</Date>
-            <Version>0.45.0</Version>
+        <Update release="22">
+            <Date>2026-09-01</Date>
+            <Version>0.45.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/zellij-org/zellij/releases/tag/v0.45.1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new zellij session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
