### PR TITLE
github-cli: Update to v2.98.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : github-cli
-version    : 2.96.0
-release    : 97
+version    : 2.98.0
+release    : 98
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.96.0.tar.gz : 8d80d0aeccea7bec8024f8c30365bbfa76852901f2b2cb0afb7ab2cbf6d317c2
+    - https://github.com/cli/cli/archive/refs/tags/v2.98.0.tar.gz : abada9e8b550547ac93f99250f3ad4d90ad623fa245cb54cb058f78030a6a5f6
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils
@@ -26,13 +26,15 @@ environment: |
 setup      : |
     # As-yet unmerged telemetry patch, see https://github.com/cli/cli/issues/13260
     %patch -p1 -i ${pkgfiles}/cb2509cb612cf9111a12a7960afd10b0c9d2dede.patch
+
+    go mod vendor
 build      : |
-    make GH_VERSION="v$version" bin/gh manpages
+    %make GH_VERSION="v${version}" bin/gh manpages
     bin/gh completion -s bash | install -Dm644 /dev/stdin share/bash-completion/completions/gh
     bin/gh completion -s zsh | install -Dm644 /dev/stdin share/zsh/site-functions/_gh
     bin/gh completion -s fish | install -Dm644 /dev/stdin share/fish/vendor_completions.d/gh.fish
 install    : |
-    install -Dm00755 $workdir/bin/gh $installdir/usr/bin/gh
-    cp -r $workdir/share/ $installdir/usr
+    %install_bin ${workdir}/bin/gh
+    cp -av --no-preserve=ownership ${workdir}/share/ ${installdir}/usr
 
     %install_license LICENSE

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -257,9 +257,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="97">
-            <Date>2026-07-03</Date>
-            <Version>2.96.0</Version>
+        <Update release="98">
+            <Date>2026-09-01</Date>
+            <Version>2.98.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/cli/cli/releases/tag/v2.98.0).

**Security**
- GHSA-vfhh-p7hm-pxfh

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
