### PR TITLE
python-argon2-cffi-bindings: Update to v26.1.0

### DIFF
--- a/packages/py/python-argon2-cffi-bindings/abi_used_symbols
+++ b/packages/py/python-argon2-cffi-bindings/abi_used_symbols
@@ -14,6 +14,5 @@ libargon2.so.1:argon2_encodedlen
 libargon2.so.1:argon2_error_message
 libargon2.so.1:argon2_hash
 libargon2.so.1:argon2_verify
-libc.so.6:__assert_fail
 libc.so.6:__stack_chk_fail
 libc.so.6:memset

--- a/packages/py/python-argon2-cffi-bindings/package.yml
+++ b/packages/py/python-argon2-cffi-bindings/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-argon2-cffi-bindings
-version    : 25.1.0
-release    : 5
+version    : 26.1.0
+release    : 6
 source     :
-    - https://github.com/hynek/argon2-cffi-bindings/archive/refs/tags/25.1.0.tar.gz : 204ac0e36e4f4fe97c7fa07b2ce1e5587633999786b055d1372cb27bb0402d4c
+    - https://github.com/hynek/argon2-cffi-bindings/archive/refs/tags/26.1.0.tar.gz : 5555dd98c57e3f8c3e8f7b7607c0e6bdad53b9310eff9f4a23e39cb70a52dd2e
 homepage   : https://github.com/hynek/argon2-cffi-bindings
 license    : MIT
 component  : programming.python
@@ -16,6 +16,7 @@ builddeps  :
     - python-build
     - python-cffi
     - python-installer
+    - python-scikit-build-core
     - python-setuptools-scm
     - python-wheel
 checkdeps  :

--- a/packages/py/python-argon2-cffi-bindings/pspec_x86_64.xml
+++ b/packages/py/python-argon2-cffi-bindings/pspec_x86_64.xml
@@ -23,21 +23,17 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/_argon2_cffi_bindings/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/_argon2_cffi_bindings/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/_argon2_cffi_bindings/__pycache__/__init__.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/_argon2_cffi_bindings/__pycache__/_ffi_build.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/_argon2_cffi_bindings/__pycache__/_ffi_build.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/_argon2_cffi_bindings/_ffi.abi3.so</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/_argon2_cffi_bindings/_ffi_build.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argon2_cffi_bindings-25.1.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argon2_cffi_bindings-25.1.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argon2_cffi_bindings-25.1.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argon2_cffi_bindings-25.1.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/argon2_cffi_bindings-25.1.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/argon2_cffi_bindings-26.1.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/argon2_cffi_bindings-26.1.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/argon2_cffi_bindings-26.1.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/argon2_cffi_bindings-26.1.0.dist-info/licenses/LICENSE</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-07-30</Date>
-            <Version>25.1.0</Version>
+        <Update release="6">
+            <Date>2026-09-01</Date>
+            <Version>26.1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/hynek/argon2-cffi-bindings/blob/26.1.0/CHANGELOG.md).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
