### PR TITLE
python-bidict: Update to v0.24.1

### DIFF
--- a/packages/py/python-bidict/package.yml
+++ b/packages/py/python-bidict/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-bidict
-version    : 0.23.1
-release    : 8
+version    : 0.24.1
+release    : 9
 source     :
-    - https://pypi.io/packages/source/b/bidict/bidict-0.23.1.tar.gz : 03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71
+    - https://pypi.io/packages/source/b/bidict/bidict-0.24.1.tar.gz : 4dca6c17f0b01700e9f24359daa5ebabf7be022d99f4cb2a257b6af2a5076c88
 homepage   : https://github.com/jab/bidict
 license    : MPL-2.0
 component  : programming.python
@@ -14,9 +14,22 @@ builddeps  :
     - python-build
     - python-installer
     - python-packaging
-    - python-setuptools
-    - python-wheel
+    - python-uv-build
+#checkdeps  :
+#    - python-hypothesis
+#    - python-pytest
+#    - python-pytest-benchmark
+#    - python-pytest-examples
+#    - python-pytest-xdist
+#    - python-pytokens
+#    - python-ruff
+setup      : |
+    # Raise uv_build upper bound
+    sed -i 's|uv_build>=0.8.13,<0.12|uv_build>=0.8.13,<0.13|' pyproject.toml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
+# Possibly missing test deps, not entirely sure
+#check      : |
+#    %pytest -v

--- a/packages/py/python-bidict/pspec_x86_64.xml
+++ b/packages/py/python-bidict/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-bidict</Name>
         <Homepage>https://github.com/jab/bidict</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict-0.23.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict-0.23.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict-0.23.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict-0.23.1.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict-0.23.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict-0.24.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict-0.24.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict-0.24.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict-0.24.1.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/__pycache__/__init__.cpython-314.pyc</Path>
@@ -48,8 +47,6 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/__pycache__/_orderedbidict.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/__pycache__/_typing.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/__pycache__/_typing.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/__pycache__/metadata.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/__pycache__/metadata.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/_abc.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/_base.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/_bidict.py</Path>
@@ -60,17 +57,16 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/_orderedbase.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/_orderedbidict.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/_typing.py</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/metadata.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/bidict/py.typed</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2026-06-05</Date>
-            <Version>0.23.1</Version>
+        <Update release="9">
+            <Date>2026-09-01</Date>
+            <Version>0.24.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/jab/bidict/blob/v0.24.1/CHANGELOG.rst).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Test with `onionshare-cli`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
