### PR TITLE
python-charset-normalizer: Update to v3.5.1

### DIFF
--- a/packages/py/python-charset-normalizer/package.yml
+++ b/packages/py/python-charset-normalizer/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-charset-normalizer
-version    : 3.4.7
-release    : 13
+version    : 3.5.1
+release    : 14
 source     :
-    - https://pypi.io/packages/source/c/charset_normalizer/charset_normalizer-3.4.7.tar.gz : ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5
+    - https://pypi.io/packages/source/c/charset_normalizer/charset_normalizer-3.5.1.tar.gz : 6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3
 homepage   : https://github.com/ousret/charset_normalizer
 license    : MIT
 component  : programming.python
@@ -15,12 +15,12 @@ builddeps  :
     - python-installer
     - python-mypy
     - python-setuptools
-    - python-setuptools-scm
 checkdeps  :
+    - python-pytest
     - python-pytest-cov
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
-    %python3_test pytest -v
+    %pytest -v

--- a/packages/py/python-charset-normalizer/pspec_x86_64.xml
+++ b/packages/py/python-charset-normalizer/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-charset-normalizer</Name>
         <Homepage>https://github.com/ousret/charset_normalizer</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -21,12 +21,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/normalizer</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.4.7.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.4.7.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.4.7.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.4.7.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.4.7.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.4.7.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.5.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.5.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.5.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.5.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.5.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer-3.5.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/charset_normalizer/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -67,12 +67,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-06-05</Date>
-            <Version>3.4.7</Version>
+        <Update release="14">
+            <Date>2026-09-01</Date>
+            <Version>3.5.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/jawah/charset_normalizer/blob/3.5.1/CHANGELOG.md).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
