### PR TITLE
python-cssselect2: Update to v0.10.1

### DIFF
--- a/packages/py/python-cssselect2/package.yml
+++ b/packages/py/python-cssselect2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-cssselect2
-version    : 0.9.0
-release    : 7
+version    : 0.10.1
+release    : 8
 source     :
-    - https://files.pythonhosted.org/packages/source/c/cssselect2/cssselect2-0.9.0.tar.gz : 759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb
+    - https://files.pythonhosted.org/packages/source/c/cssselect2/cssselect2-0.10.1.tar.gz : 83b0d820ef589dabaf693289b647c2f5b410f76d285f56deba911ffa75a7b9d1
 homepage   : https://doc.courtbouillon.org/cssselect2/stable/
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-cssselect2/pspec_x86_64.xml
+++ b/packages/py/python-cssselect2/pspec_x86_64.xml
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.9.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.9.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.9.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.9.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.10.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.10.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.10.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2-0.10.1.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/cssselect2/__pycache__/__init__.cpython-314.pyc</Path>
@@ -39,9 +39,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2026-08-01</Date>
-            <Version>0.9.0</Version>
+        <Update release="8">
+            <Date>2026-09-01</Date>
+            <Version>0.10.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://doc.courtbouillon.org/cssselect2/stable/changelog.html#version-0-10-1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
