### PR TITLE
fastfetch: Update to v2.68.1

### DIFF
--- a/packages/f/fastfetch/abi_used_symbols
+++ b/packages/f/fastfetch/abi_used_symbols
@@ -117,6 +117,7 @@ libc.so.6:qsort
 libc.so.6:read
 libc.so.6:readdir64
 libc.so.6:readlink
+libc.so.6:readlinkat
 libc.so.6:realloc
 libc.so.6:realpath
 libc.so.6:recv

--- a/packages/f/fastfetch/package.yml
+++ b/packages/f/fastfetch/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fastfetch
-version    : 2.67.1
-release    : 81
+version    : 2.68.1
+release    : 82
 source     :
-    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.67.1.tar.gz : 52489550d1fdeac8bde8b3442064e3bc78d28fda752a171dc46a6cd97454f237
+    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.68.1.tar.gz : c268cfcd230cc7ed5447fb34ed21bf4977315c7104356a39388b6ba784ad11b0
 homepage   : https://github.com/fastfetch-cli/fastfetch
 license    : MIT
 component  : system.utils

--- a/packages/f/fastfetch/pspec_x86_64.xml
+++ b/packages/f/fastfetch/pspec_x86_64.xml
@@ -67,9 +67,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="81">
-            <Date>2026-08-14</Date>
-            <Version>2.67.1</Version>
+        <Update release="82">
+            <Date>2026-09-02</Date>
+            <Version>2.68.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.68.1).

**Test Plan**

run `fastfetch`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
