### PR TITLE
libheif: Update to v1.23.3

### DIFF
--- a/packages/l/libheif/abi_used_symbols
+++ b/packages/l/libheif/abi_used_symbols
@@ -44,6 +44,9 @@ libavcodec.so.63:avcodec_receive_frame
 libavcodec.so.63:avcodec_send_packet
 libavutil.so.61:av_frame_alloc
 libavutil.so.61:av_frame_free
+libavutil.so.61:av_get_pix_fmt_name
+libavutil.so.61:av_pix_fmt_desc_get
+libavutil.so.61:av_pix_fmt_swap_endianness
 libavutil.so.61:av_strerror
 libavutil.so.61:av_version_info
 libc.so.6:__cxa_atexit
@@ -260,7 +263,6 @@ libstdc++.so.6:_ZNSo9_M_insertIbEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertIdEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertIlEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertImEERSoT_
-libstdc++.so.6:_ZNSoC2Ev
 libstdc++.so.6:_ZNSolsEi
 libstdc++.so.6:_ZNSolsEs
 libstdc++.so.6:_ZNSt10filesystem6statusERKNS_7__cxx114pathE

--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libheif
-version    : 1.23.2
-release    : 66
+version    : 1.23.3
+release    : 67
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.23.2/libheif-1.23.2.tar.gz : 8bd5d41d19dc84536d118b04774709f244df6104ef66d623dad5fa4650143405
+    - https://github.com/strukturag/libheif/releases/download/v1.23.3/libheif-1.23.3.tar.gz : 11c1179e0e4bec33624b87f22ec42c1e993a40d946d44d26f9c431cf1456a863
 homepage   : https://github.com/strukturag/libheif
 license    :
     - LGPL-3.0-or-later

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libheif</Name>
         <Homepage>https://github.com/strukturag/libheif</Homepage>
         <Packager>
-            <Name>Clint Eschberger</Name>
-            <Email>clint@eschberger.info</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <License>MIT</License>
@@ -47,15 +47,15 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>multimedia.codecs</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="66">libheif-plugin-dav1d</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-ffmpeg</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-jpeg</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-rav1e</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-x265</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-dav1d</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-ffmpeg</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-jpeg</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-rav1e</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-x265</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.23.2</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.23.3</Path>
             <Path fileType="data">/usr/share/licenses/libheif/COPYING</Path>
         </Files>
     </Package>
@@ -79,18 +79,18 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="66">libheif</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-aom</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-dav1d</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-ffmpeg</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-j2k</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-jpeg</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-libde265</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-openh264</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-rav1e</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-svtav1</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-x264</Dependency>
-            <Dependency releaseFrom="66">libheif-plugin-x265</Dependency>
+            <Dependency release="67">libheif</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-aom</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-dav1d</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-ffmpeg</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-j2k</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-jpeg</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-libde265</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-openh264</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-rav1e</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-svtav1</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-x264</Dependency>
+            <Dependency releaseFrom="67">libheif-plugin-x265</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -403,7 +403,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>multimedia.codecs</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="66">libheif</Dependency>
+            <Dependency releaseFrom="67">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/heif-convert</Path>
@@ -419,12 +419,12 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="66">
-            <Date>2026-08-27</Date>
-            <Version>1.23.2</Version>
+        <Update release="67">
+            <Date>2026-09-02</Date>
+            <Version>1.23.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Clint Eschberger</Name>
-            <Email>clint@eschberger.info</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/strukturag/libheif/releases/tag/v1.23.3)

**Security**

- GHSA-x8r2-mggj-j6wr
- GHSA-8fmq-r4pf-7m57
- GHSA-w7mc-p8jc-p853
- GHSA-4jqm-2x34-6f6r
- GHSA-hh47-fhqr-cj2r
- GHSA-4h82-g446-83fm
- GHSA-9rj8-5mp5-26c9
- GHSA-gh5q-69gg-c964
- GHSA-8857-r8x5-7499

**Test Plan**

- Built

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
