### PR TITLE
[NFC] repo-wide: Use pyproject macros where appropriate

### DIFF
--- a/packages/a/alabaster/package.yml
+++ b/packages/a/alabaster/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-flit-core
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/a/ansible/package.yml
+++ b/packages/a/ansible/package.yml
@@ -26,7 +26,7 @@ rundeps    :
     - python-resolvelib
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license COPYING

--- a/packages/a/autopep8/package.yml
+++ b/packages/a/autopep8/package.yml
@@ -22,8 +22,8 @@ checkdeps  :
 rundeps    :
     - pycodestyle
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v -k 'not io_error' # two io_error tests fail only in solbuild

--- a/packages/b/beeref/package.yml
+++ b/packages/b/beeref/package.yml
@@ -23,9 +23,9 @@ rundeps    :
     - python-qt6
     - python-rectangle-packer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     install -Dm00644 $pkgfiles/org.beeref.BeeRef.desktop -t $installdir/usr/share/applications/
     install -Dm00644 beeref/assets/logo.svg $installdir/usr/share/icons/hicolor/scalable/apps/beeref.svg
     install -Dm00644 $pkgfiles/org.beeref.BeeRef.appdata.xml -t $installdir/usr/share/metainfo/

--- a/packages/b/beets/package.yml
+++ b/packages/b/beets/package.yml
@@ -28,7 +28,7 @@ rundeps    :
     - python-unidecode
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     ln -s /usr/bin/beet ${installdir}/usr/bin/beets

--- a/packages/b/borg/package.yml
+++ b/packages/b/borg/package.yml
@@ -38,9 +38,9 @@ rundeps    :
     - python-msgpack
     - python-packaging
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     install -D -m00644 scripts/shell_completions/bash/borg $installdir/usr/share/bash-completion/completions/borg
     install -D -m00644 scripts/shell_completions/fish/borg.fish $installdir/usr/share/fish/vendor_completions.d/borg.fish

--- a/packages/b/brotli/package.yml
+++ b/packages/b/brotli/package.yml
@@ -30,13 +30,13 @@ build      : |
     %ninja_build
 
     if [ -z "${EMUL32BUILD+set}" ]; then
-        %python3_setup
+        %pyproject_build
     fi
 install    : |
     if [ -z "${EMUL32BUILD+set}" ]; then
         %ninja_install
         install -Dm00644 docs/brotli.1 $installdir/usr/share/man/man1/brotli.1
-        %python3_install
+        %pyproject_install
     else
         %ninja_install
     fi

--- a/packages/b/bumpversion/package.yml
+++ b/packages/b/bumpversion/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/c/clustershell/package.yml
+++ b/packages/c/clustershell/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/c/codespell/package.yml
+++ b/packages/c/codespell/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools-scm
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/c/cython/package.yml
+++ b/packages/c/cython/package.yml
@@ -23,9 +23,9 @@ checkdeps  :
 rundeps    :
     - python3-devel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    # The checks last like... forever. Feel free to uncomment them to check the package
 #    %python3_test runtests.py -v

--- a/packages/d/devedeng/package.yml
+++ b/packages/d/devedeng/package.yml
@@ -23,6 +23,6 @@ rundeps    :
     - python-urllib3
     - vcdimager
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/d/diffoscope/package.yml
+++ b/packages/d/diffoscope/package.yml
@@ -39,10 +39,10 @@ rundeps    :
     - xz
     - zstd
 build      : |
-    %python3_setup
+    %pyproject_build
     make -C doc
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license COPYING
     install -Dm00644 debian/zsh-completion/_diffoscope -t $installdir/usr/share/zsh/site-functions/
     install -Dm00644 doc/diffoscope.1 -t $installdir/usr/share/man/man1

--- a/packages/d/dnspython/package.yml
+++ b/packages/d/dnspython/package.yml
@@ -19,8 +19,8 @@ checkdeps  :
     - python-pytest
     - python-trio
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/d/dogtail/package.yml
+++ b/packages/d/dogtail/package.yml
@@ -19,7 +19,7 @@ rundeps    :
     - pyatspi2
     - python-gobject
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     install -Dm00644 $pkgfiles/com.gitlab.dogtail.metainfo.xml $installdir/usr/share/metainfo/com.gitlab.dogtail.metainfo.xml

--- a/packages/d/duplicity/package.yml
+++ b/packages/d/duplicity/package.yml
@@ -24,5 +24,5 @@ rundeps    :
 build      : |
     %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install
     rm -rf $installdir/usr/share/doc

--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -60,7 +60,7 @@ setup      : |
     %patch -p1 -i $pkgfiles/packagekit/0002-backends-eopkg-Mark-security-updates-with-critical-s.patch
     popd
 
-    %python3_setup
+    %pyproject_build
 build      : |
     # Note: we need to ensure that ca-certs, libmagic, openssl, and zlib are included
     #       in the standalone package (all are part of system.base, so not listed in
@@ -108,7 +108,7 @@ build      : |
         --report=pk-nuitka-report.xml \
         $sources/PackageKit.git/backends/eopkg/eopkgBackend.py
 install    : |
-    %python3_install
+    %pyproject_install
 
     # Add .py extension
     for exe in eopkg lseopkg uneopkg; do

--- a/packages/f/flake8/package.yml
+++ b/packages/f/flake8/package.yml
@@ -25,8 +25,8 @@ rundeps    :
     - pycodestyle
     - pyflakes
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/f/flask-cors/package.yml
+++ b/packages/f/flask-cors/package.yml
@@ -22,8 +22,8 @@ checkdeps  :
 rundeps    :
     - flask
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/f/flask-httpauth/package.yml
+++ b/packages/f/flask-httpauth/package.yml
@@ -22,8 +22,8 @@ checkdeps  :
 rundeps    :
     - flask
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/f/flask-sqlalchemy/package.yml
+++ b/packages/f/flask-sqlalchemy/package.yml
@@ -26,8 +26,8 @@ setup      : |
     # https://github.com/pallets-eco/flask-sqlalchemy/pull/1384
     %patch -p1 -i $pkgfiles/1384.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v -Wdefault

--- a/packages/f/flask/package.yml
+++ b/packages/f/flask/package.yml
@@ -30,9 +30,9 @@ rundeps    :
     - python-jinja
     - python-werkzeug
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # https://github.com/pallets/flask/issues/5961
     %python3_test pytest -k 'not test_environ_for_valid_idna_completes'

--- a/packages/g/gajim/package.yml
+++ b/packages/g/gajim/package.yml
@@ -40,9 +40,9 @@ rundeps    :
 setup      : |
     ./make.py build --dist unix
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     $workdir/make.py install --dist unix --prefix=$installdir/usr
 
     # Move locales to the system path

--- a/packages/g/gcovr/package.yml
+++ b/packages/g/gcovr/package.yml
@@ -27,7 +27,7 @@ setup      : |
 build      : |
     # Provide the version explicitly
     export SETUPTOOLS_SCM_PRETEND_VERSION="$version"
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE.txt

--- a/packages/g/gem/package.yml
+++ b/packages/g/gem/package.yml
@@ -20,9 +20,9 @@ rundeps    :
     - python-setuptools
     - pyxdg
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     sed -i '/Exec=geode-gem/a StartupWMClass=geode-gem' geode_gem/data/desktop/gem.desktop
     install -Dm644 geode_gem/data/desktop/gem.desktop $installdir/usr/share/applications/gem.desktop
     install -Dm644 geode_gem/data/desktop/gem.svg $installdir/usr/share/icons/hicolor/scalable/apps/gem.svg

--- a/packages/g/gi-docgen/package.yml
+++ b/packages/g/gi-docgen/package.yml
@@ -33,6 +33,6 @@ rundeps    :
 patterns   :
     - /*
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/g/glances/package.yml
+++ b/packages/g/glances/package.yml
@@ -27,8 +27,8 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/no-check-update.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license COPYING
     rm -rf $installdir/usr/share/doc/glances/{AUTHORS,CONTRIBUTING.md,COPYING,NEWS.rst,README.rst}

--- a/packages/h/httpie/package.yml
+++ b/packages/h/httpie/package.yml
@@ -22,6 +22,6 @@ rundeps    :
     - python-requests-toolbelt
     - python-rich
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/i/icdiff/package.yml
+++ b/packages/i/icdiff/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/i/iksemel/package.yml
+++ b/packages/i/iksemel/package.yml
@@ -29,8 +29,8 @@ build      : |
     %ninja_build
 install    : |
     # need pypi source for metadata
-    %python3_setup
-    %python3_install
+    %pyproject_build
+    %pyproject_install
 
     cd $workdir
     %ninja_install

--- a/packages/i/img2pdf/package.yml
+++ b/packages/i/img2pdf/package.yml
@@ -18,7 +18,7 @@ builddeps  :
 rundeps    :
     - python-pikepdf
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     rm -f $installdir/usr/bin/img2pdf-gui

--- a/packages/i/input-remapper/package.yml
+++ b/packages/i/input-remapper/package.yml
@@ -29,9 +29,9 @@ setup      : |
     # don't install twice
     sed -i '/build_input_remapper_module/d' install/__main__.py
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     # install non-python files
     python3 -m install --root ${installdir}
 

--- a/packages/l/lector/package.yml
+++ b/packages/l/lector/package.yml
@@ -24,8 +24,8 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/Bug-fixed-when-self.adjisted_size-is-float.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     # Install AppStream metainfo
     install -Dm00644 $pkgfiles/io.github.basiomeuspuga.lector.metainfo.xml -t $installdir/usr/share/metainfo

--- a/packages/l/lenovo-legion-linux/package.yml
+++ b/packages/l/lenovo-legion-linux/package.yml
@@ -55,7 +55,7 @@ build      : |
     %make -C lts/kernel_module KERNELVERSION=%kernel_version_lts% KSRC=%libdir%/modules/%kernel_version_lts%/build
 
     cd current/python/legion_linux
-    python3 -m build --wheel --no-isolation
+    %pyproject_build
 install    : |
     install -Dm00644 current/kernel_module/legion-laptop.ko -t $installdir/%libdir%/modules/%kernel_version_current%/extra/drivers/platform/x86/
     install -Dm00644 lts/kernel_module/legion-laptop.ko -t $installdir/%libdir%/modules/%kernel_version_lts%/extra/drivers/platform/x86/
@@ -63,4 +63,4 @@ install    : |
     find "$installdir" -name '*.ko' -exec strip --strip-debug {} \; -exec zstd {} \; -exec rm -v {} \;
 
     cd current/python/legion_linux
-    python3 -m installer --destdir=%installroot% dist/*.whl
+    %pyproject_install

--- a/packages/l/lensfun/package.yml
+++ b/packages/l/lensfun/package.yml
@@ -25,7 +25,7 @@ build      : |
     %ninja_build
 
     cd solusBuildDir/apps
-    python3 -m build --wheel --no-isolation
+    %pyproject_build
 
 install    : |
     %ninja_install
@@ -33,5 +33,5 @@ install    : |
     rm $installdir/usr/bin/g-lensfun*
 
     cd solusBuildDir/apps
-    python3 -m installer --destdir="$installdir" dist/*.whl
+    %pyproject_install
 

--- a/packages/l/liblouis/package.yml
+++ b/packages/l/liblouis/package.yml
@@ -24,7 +24,7 @@ build      : |
     %make -j1
     cd python
     LD_PRELOAD+=":$workdir/liblouis/.libs/liblouis.so"
-    %python3_setup
+    %pyproject_build
 install    : |
     %make_install
     %install_license COPYING AUTHORS

--- a/packages/l/libpillowfight/package.yml
+++ b/packages/l/libpillowfight/package.yml
@@ -23,7 +23,7 @@ setup      : |
     %cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .
 build      : |
     %make
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
     %make_install
-    %python3_install
+    %pyproject_install

--- a/packages/l/libvirt-python/package.yml
+++ b/packages/l/libvirt-python/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-lxml
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/m/m64py/package.yml
+++ b/packages/m/m64py/package.yml
@@ -31,6 +31,6 @@ environment: |
     # Help the build script find Qt6 rcc
     export PATH="$PATH:/usr/lib64/qt6"
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/m/magic-wormhole/package.yml
+++ b/packages/m/magic-wormhole/package.yml
@@ -30,9 +30,9 @@ rundeps    :
     - python-txtorcon
     - python-zipstream-ng
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE
 
     # install completions

--- a/packages/m/mako/package.yml
+++ b/packages/m/mako/package.yml
@@ -22,8 +22,8 @@ checkdeps  :
 rundeps    :
     - python-markupsafe
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3

--- a/packages/m/material-color-utilities-python/package.yml
+++ b/packages/m/material-color-utilities-python/package.yml
@@ -21,6 +21,6 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Allow-pillow-10.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/m/mcomix/package.yml
+++ b/packages/m/mcomix/package.yml
@@ -21,6 +21,6 @@ rundeps    :
     - python-pillow
     - unrar
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/m/menulibre/package.yml
+++ b/packages/m/menulibre/package.yml
@@ -29,9 +29,9 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/0002-Should-only-be-visible-on-Gnome-and-Budgie.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     rm -rv $installdir/usr/share/doc
 
     # Don't need uninstall script

--- a/packages/m/mercurial/package.yml
+++ b/packages/m/mercurial/package.yml
@@ -18,9 +18,9 @@ builddeps  :
     - python-setuptools-scm
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license COPYING
 
     # Docs

--- a/packages/m/meson-python/package.yml
+++ b/packages/m/meson-python/package.yml
@@ -33,13 +33,13 @@ build      : |
     if [[ ${BOOTSTRAP} == "1" ]]; then
         python3 -m pip wheel --no-deps .
     else
-        %python3_setup
+        %pyproject_build
     fi
 install    : |
     if [[ ${BOOTSTRAP} == "1" ]]; then
         python3 -m pip install --root=%installroot% --no-deps --ignore-installed .
     else
-        %python3_install
+        %pyproject_install
     fi
 check      : |
     # test_use_ansi_escapes[True-env1-True] failed on build server

--- a/packages/m/meson/package.yml
+++ b/packages/m/meson/package.yml
@@ -20,9 +20,9 @@ builddeps  :
 rundeps    :
     - ninja
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     # install autocompletions
     install -Dm 00644 $workdir/data/shell-completions/bash/meson $installdir/usr/share/bash-completion/completions/meson

--- a/packages/m/minigalaxy/package.yml
+++ b/packages/m/minigalaxy/package.yml
@@ -20,6 +20,6 @@ rundeps    :
     - python-gobject
     - python-requests
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/m/mkdocs/package.yml
+++ b/packages/m/mkdocs/package.yml
@@ -28,6 +28,6 @@ rundeps    :
     - python-watchdog
 build      : |
     rm setup.py
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/m/mutagen/package.yml
+++ b/packages/m/mutagen/package.yml
@@ -18,8 +18,8 @@ checkdeps  :
     - python-hypothesis
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/n/nanobind/package.yml
+++ b/packages/n/nanobind/package.yml
@@ -20,9 +20,9 @@ builddeps  :
     - robin-map
 build      : |
     SKBUILD_CMAKE_ARGS="-DNB_USE_SUBMODULE_DEPS=OFF"
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     python_version=$(python -c "import sys; print(sys.version[:4])")
     install -dm 00755 ${installdir}/usr/include ${installdir}/%libdir%/cmake

--- a/packages/n/nautilus-open-any-terminal/package.yml
+++ b/packages/n/nautilus-open-any-terminal/package.yml
@@ -18,6 +18,6 @@ builddeps  :
 rundeps    :
     - nautilus-python
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/n/nemo-extensions/package.yml
+++ b/packages/n/nemo-extensions/package.yml
@@ -130,6 +130,8 @@ build      : |
 
       if [[ -f meson.build ]]; then
         %ninja_build
+      elif [[ -f pyproject.toml || -f setup.cfg ]]; then
+        %pyproject_build
       elif [[ -f setup.py ]]; then
         %python3_setup
       fi
@@ -154,6 +156,8 @@ install    : |
 
       if [[ -f meson.build ]]; then
         %ninja_install
+      elif [[ -f pyproject.toml || -f setup.cfg ]]; then
+        %pyproject_install
       elif [[ -f setup.py ]]; then
         %python3_install
       fi

--- a/packages/n/networkx/package.yml
+++ b/packages/n/networkx/package.yml
@@ -27,8 +27,8 @@ rundeps    :
     - pyyaml
     - scipy
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/n/nftables/package.yml
+++ b/packages/n/nftables/package.yml
@@ -39,11 +39,13 @@ build      : |
     %make
 
     cd py
-    python3 -m build --wheel --no-isolation
+    %pyproject_build
 install    : |
     %make_install
 
-    python3 -m installer --destdir="$installdir" py/dist/*.whl
+    cd py
+    %pyproject_install
+    cd -
 
     install -Dm00644 $pkgfiles/nftables.conf $installdir/usr/share/defaults/etc/nftables.conf
     install -Dm00644 $pkgfiles/nftables.service $installdir/usr/lib/systemd/system/nftables.service

--- a/packages/n/nicotine-plus/package.yml
+++ b/packages/n/nicotine-plus/package.yml
@@ -22,9 +22,9 @@ rundeps    :
     - libgtk-3
     - python-gobject
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     rm -rf $installdir/usr/share/doc
     find $installdir \
         -name "README*" -prune -exec rm -r '{}' + \

--- a/packages/n/nuitka/package.yml
+++ b/packages/n/nuitka/package.yml
@@ -25,6 +25,6 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Allow-patchelf-0.18.0-on-Solus.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/n/numpy/package.yml
+++ b/packages/n/numpy/package.yml
@@ -28,9 +28,9 @@ checkdeps  :
 clang      : true
 build      : |
     # SSE+SSE2 corresponds to the x86_64 baseline
-    %python3_setup -Csetup-args=-Dcpu-baseline="SSE+SSE2"
+    %pyproject_build -Csetup-args=-Dcpu-baseline="SSE+SSE2"
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE.txt
 check      : |
     export PATH="${installdir}/usr/bin:$PATH"

--- a/packages/o/onedrive-gui/package.yml
+++ b/packages/o/onedrive-gui/package.yml
@@ -28,9 +28,9 @@ setup      : |
     install -D -m00644 $pkgfiles/pyproject.toml $workdir/pyproject.toml
     desktop-file-edit --set-key=Exec --set-value="onedrive-gui" $workdir/src/onedrive_gui/resources/OneDriveGUI.desktop
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     install -D -m00644 src/onedrive_gui/resources/OneDriveGUI.desktop $installdir/usr/share/applications/OneDriveGUI.desktop
     install -D -m00644 $pkgfiles/io.github.bpozdena.onedrivegui.metainfo.xml $installdir/usr/share/metainfo/io.github.com.bpozdena.onedrivegui.metainfo.xml
     install -D -m00644 src/onedrive_gui/resources/images/OneDriveGUI.png $installdir/usr/share/icons/hicolor/80x80/apps/OneDriveGUI.png

--- a/packages/o/onionshare-cli/package.yml
+++ b/packages/o/onionshare-cli/package.yml
@@ -45,11 +45,11 @@ rundeps    :
     - tor
 build      : |
     pushd cli
-        %python3_setup
+        %pyproject_build
     popd
 install    : |
     pushd cli
-        %python3_install
+        %pyproject_install
     popd
 # TODO 3.14
 #check      : |

--- a/packages/o/opencollective-export/package.yml
+++ b/packages/o/opencollective-export/package.yml
@@ -21,7 +21,7 @@ rundeps    :
     - python-keyring
     - python-rich
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE

--- a/packages/o/openpaperwork-core/package.yml
+++ b/packages/o/openpaperwork-core/package.yml
@@ -26,8 +26,8 @@ rundeps    :
     - python-distro
     - python-psutil
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest

--- a/packages/o/openpaperwork-gtk/package.yml
+++ b/packages/o/openpaperwork-gtk/package.yml
@@ -21,8 +21,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/p/paperwork-backend/package.yml
+++ b/packages/p/paperwork-backend/package.yml
@@ -42,6 +42,6 @@ rundeps    :
     - python-whoosh
     - scikit-learn
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/p/paperwork-shell/package.yml
+++ b/packages/p/paperwork-shell/package.yml
@@ -22,6 +22,6 @@ rundeps    :
     - paperwork-backend
     - python-fabulous
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/p/paperwork/package.yml
+++ b/packages/p/paperwork/package.yml
@@ -44,12 +44,11 @@ setup      : |
 build      : |
     make l10n_compile
     pushd paperwork-gtk
-      # our python macros don´t work well when using pushd
-      python3 -m build --wheel --no-isolation
+      %pyproject_build
     popd
 install    : |
     pushd paperwork-gtk
-      python3 -m installer --destdir=$installdir dist/*.whl
+      %pyproject_install
     popd
 
     # install icons and desktop file

--- a/packages/p/pbr/package.yml
+++ b/packages/p/pbr/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/p/pep8/package.yml
+++ b/packages/p/pep8/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/p/picard/package.yml
+++ b/packages/p/picard/package.yml
@@ -33,9 +33,9 @@ rundeps    :
     - python3-qt5
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license COPYING.txt
 check      : |
     sed -i "s/\\\\Z'/\\\\z'/g" test/test_file.py

--- a/packages/p/pipenv/package.yml
+++ b/packages/p/pipenv/package.yml
@@ -20,6 +20,6 @@ rundeps    :
     - virtualenv
     - virtualenv-clone
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/p/pipx/package.yml
+++ b/packages/p/pipx/package.yml
@@ -22,9 +22,9 @@ rundeps    :
     - python-platformdirs
     - python-userpath
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     mkdir -p $workdir/completions
     register-python-argcomplete --shell bash pipx > $workdir/completions/pipx.bash

--- a/packages/p/printrun/package.yml
+++ b/packages/p/printrun/package.yml
@@ -31,7 +31,7 @@ rundeps    :
 build      : |
     # Let the macro do its job, but we want different build options.
     # https://github.com/kliment/Printrun#cython-based-g-code-parser
-    %python3_setup
+    %pyproject_build
     python3 setup.py build_ext --inplace
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/p/proton-vpn-cli/package.yml
+++ b/packages/p/proton-vpn-cli/package.yml
@@ -23,7 +23,7 @@ rundeps    :
     - python-proton-vpn-local-agent
     - python-tabulate
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |-
-    %python3_install
+    %pyproject_install
     %install_license COPYING.md LICENSE

--- a/packages/p/proton-vpn-daemon/package.yml
+++ b/packages/p/proton-vpn-daemon/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - bcc
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/p/proton-vpn-gtk-app/package.yml
+++ b/packages/p/proton-vpn-gtk-app/package.yml
@@ -42,9 +42,9 @@ setup      : |
     #patch -p1 -i ${pkgfiles}/0003-clean-up-tray-menu-state.patch
     %patch -p1 -i ${pkgfiles}/0004-re-register-tray-item-when-tray-host-restarts.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     # Install desktop file, app icon and appstream metainfo
     install -Dm00644 rpmbuild/SOURCES/proton.vpn.app.gtk.desktop -t $installdir/usr/share/applications

--- a/packages/p/protontricks/package.yml
+++ b/packages/p/protontricks/package.yml
@@ -30,9 +30,9 @@ setup      : |
     %patch -Rp1 -i $pkgfiles/drop-vendored-vdf.patch
     rm -rf ./src/protontricks/_vdf
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest
     # Install AppStream metainfo

--- a/packages/p/psycopg2/package.yml
+++ b/packages/p/psycopg2/package.yml
@@ -17,7 +17,7 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE

--- a/packages/p/ptyprocess/package.yml
+++ b/packages/p/ptyprocess/package.yml
@@ -21,8 +21,8 @@ checkdeps  :
 setup      : |
     # unittest.makeSuite() was removed in Python 3.14
     sed -i '/unittest.makeSuite/d' tests/test_invalid_binary.py
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/p/puddletag/package.yml
+++ b/packages/p/puddletag/package.yml
@@ -27,9 +27,9 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/puddletag-2.5.0-req.patch # patch from Fedora
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE
     # Install AppStream metainfo
     install -Dm00644 $pkgfiles/net.puddletag.puddletag.appdata.xml -t $installdir/usr/share/metainfo

--- a/packages/py/PyAudio/package.yml
+++ b/packages/py/PyAudio/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/py/package.yml
+++ b/packages/py/py/package.yml
@@ -27,8 +27,8 @@ checkdeps  :
 setup      : |
     %patch -p1 -i $pkgfiles/fix-pytest4-compatibility-errors.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     #python3_test pytest3 -k"-test_warning" # testing/code/test_excinfo.py

--- a/packages/py/pychromecast/package.yml
+++ b/packages/py/pychromecast/package.yml
@@ -21,6 +21,6 @@ rundeps    :
     - python-six
     - python-zeroconf
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/pycodestyle/package.yml
+++ b/packages/py/pycodestyle/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/pycups/package.yml
+++ b/packages/py/pycups/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-setuptools
 clang      : true
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/pydocstyle/package.yml
+++ b/packages/py/pydocstyle/package.yml
@@ -21,6 +21,6 @@ setup      : |
     # Fix version number in metadata
     sed -e "s|^version = .*|version = \"$version\"|" -i pyproject.toml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/pyenchant/package.yml
+++ b/packages/py/pyenchant/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 rundeps    :
     - enchant16
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/pyflakes/package.yml
+++ b/packages/py/pyflakes/package.yml
@@ -15,8 +15,8 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test

--- a/packages/py/pyg3t/package.yml
+++ b/packages/py/pyg3t/package.yml
@@ -18,6 +18,6 @@ builddeps  :
 rundeps    :
     - python-dateutil
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/pygraphviz/package.yml
+++ b/packages/py/pygraphviz/package.yml
@@ -23,8 +23,8 @@ setup      : |
     # Skip the code coverage tests
     sed -i -e '/codecov/d' -e '/pytest-cov/d' requirements/test.txt
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -vk "not test_layout_prog_arg and not TestExperimentalGraphvizLibInterface" $installdir/%PREFIX%/lib/python%python3_version%/site-packages/pygraphviz/tests

--- a/packages/py/pyicu/package.yml
+++ b/packages/py/pyicu/package.yml
@@ -21,8 +21,8 @@ builddeps  :
 checkdeps  :
     - python-six
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test

--- a/packages/py/pylint/package.yml
+++ b/packages/py/pylint/package.yml
@@ -35,9 +35,9 @@ rundeps    :
     - python-platformdirs
     - python-tomlkit
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # Need to undeprecate and update python-gitpython and deps
     rm tests/testutils/_primer/{test_package_to_lint.py,test_primer.py}

--- a/packages/py/pymarkups/package.yml
+++ b/packages/py/pymarkups/package.yml
@@ -23,8 +23,8 @@ checkdeps  :
 rundeps    :
     - python-markdown-math
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v --deselect tests/test_public_api.py::APITest::test_get_pygments_stylesheet

--- a/packages/py/pyparsing/package.yml
+++ b/packages/py/pyparsing/package.yml
@@ -15,9 +15,9 @@ builddeps  :
     - python-flit-core
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # require python-railroad-diagrams for chekc and as optional dependency
 #    %python3_test pytest -v

--- a/packages/py/pyprind/package.yml
+++ b/packages/py/pyprind/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
 rundeps    :
     - python-psutil
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/pyqt-builder/package.yml
+++ b/packages/py/pyqt-builder/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools-scm
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/pysolfc/package.yml
+++ b/packages/py/pysolfc/package.yml
@@ -25,4 +25,4 @@ build      : |
     %pyproject_build
 install    : |
     %pyproject_install
-    %install_file $pkgfiles/io.sourceforge.pysolfc.PySolFC.metainfo.xml -t $installdir/usr/share/metainfo/
+    install -Dm00644 $pkgfiles/io.sourceforge.pysolfc.PySolFC.metainfo.xml -t $installdir/usr/share/metainfo/

--- a/packages/py/python-aiohappyeyeballs/package.yml
+++ b/packages/py/python-aiohappyeyeballs/package.yml
@@ -19,8 +19,8 @@ checkdeps  :
     - python-pytest-asyncio
     - python-pytest-cov
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v --no-cov

--- a/packages/py/python-aiohttp/package.yml
+++ b/packages/py/python-aiohttp/package.yml
@@ -39,9 +39,9 @@ rundeps    :
     - python-propcache
     - python-yarl
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     export PYTEST_ADDOPTS="-o asyncio_default_fixture_loop_scope=function -W ignore::pytest.PytestDeprecationWarning"
     %python3_test pytest -m "not dev_mode and not autobahn and not internal and not network" \

--- a/packages/py/python-aiosignal/package.yml
+++ b/packages/py/python-aiosignal/package.yml
@@ -24,8 +24,8 @@ checkdeps  :
 rundeps    :
     - python-frozenlist
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v --no-cov

--- a/packages/py/python-ajsonrpc/package.yml
+++ b/packages/py/python-ajsonrpc/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/python-anyascii/package.yml
+++ b/packages/py/python-anyascii/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-packaging
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-arrow/package.yml
+++ b/packages/py/python-arrow/package.yml
@@ -25,8 +25,8 @@ rundeps    :
     - python-six
     - types-python-dateutil
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -k "not test_init_dateutil_timezone"

--- a/packages/py/python-asn1-modules/package.yml
+++ b/packages/py/python-asn1-modules/package.yml
@@ -19,8 +19,8 @@ rundeps    :
     - python-asn1
     - python-openssl
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    %python3_test

--- a/packages/py/python-asn1crypto/package.yml
+++ b/packages/py/python-asn1crypto/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-async-generator/package.yml
+++ b/packages/py/python-async-generator/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3

--- a/packages/py/python-async_timeout/package.yml
+++ b/packages/py/python-async_timeout/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-atomicwrites/package.yml
+++ b/packages/py/python-atomicwrites/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test py.test3

--- a/packages/py/python-attrs/package.yml
+++ b/packages/py/python-attrs/package.yml
@@ -21,8 +21,8 @@ checkdeps  :
     - python-pytest
     - python-zope.interface
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-autocommand/package.yml
+++ b/packages/py/python-autocommand/package.yml
@@ -19,8 +19,8 @@ setup      : |
     # From https://github.com/Lucretiel/autocommand/pull/33
     %patch -p1 -i $pkgfiles/remove-license-declaration.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v --ignore=test/test_autoasync.py

--- a/packages/py/python-automat/package.yml
+++ b/packages/py/python-automat/package.yml
@@ -22,8 +22,8 @@ rundeps    :
     - python-attrs
     - python-six
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v ${installdir}/%PREFIX%/lib/python%python3_version%/site-packages/automat/_test

--- a/packages/py/python-babelfish/package.yml
+++ b/packages/py/python-babelfish/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-poetry-core
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-backoff/package.yml
+++ b/packages/py/python-backoff/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-poetry-core
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-backports.tarfile/package.yml
+++ b/packages/py/python-backports.tarfile/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    %python3_test pytest -v

--- a/packages/py/python-bcrypt/package.yml
+++ b/packages/py/python-bcrypt/package.yml
@@ -23,8 +23,8 @@ checkdeps  :
 rundeps    :
     - python-cffi
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-betamax/package.yml
+++ b/packages/py/python-betamax/package.yml
@@ -20,9 +20,9 @@ checkdeps  :
 rundeps    :
     - python-requests
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    # tests require networking
 #    %python3_test

--- a/packages/py/python-binaryornot/package.yml
+++ b/packages/py/python-binaryornot/package.yml
@@ -22,8 +22,8 @@ checkdeps  :
 rundeps    :
     - python-chardet
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -k 'not test_sdist and not test_unreadable_file_raises'

--- a/packages/py/python-black/package.yml
+++ b/packages/py/python-black/package.yml
@@ -23,6 +23,6 @@ rundeps    :
     - python-platformdirs
     - python-typing-extensions
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-blinker/package.yml
+++ b/packages/py/python-blinker/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest-asyncio
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-boolean.py/package.yml
+++ b/packages/py/python-boolean.py/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-bottle/package.yml
+++ b/packages/py/python-bottle/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -k 'not test_sendfile'

--- a/packages/py/python-bottleneck/package.yml
+++ b/packages/py/python-bottleneck/package.yml
@@ -23,9 +23,9 @@ checkdeps  :
 rundeps    :
     - numpy
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # TODO 3.14
 #check      : |
 #    export PYTHONSRC=$workdir

--- a/packages/py/python-bsddb3/package.yml
+++ b/packages/py/python-bsddb3/package.yml
@@ -17,9 +17,9 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install --no-compile
+    %pyproject_install --no-compile
 replaces   :
     - python3-bsddb3
     - devel : python3-bsddb3-devel

--- a/packages/py/python-cachecontrol/package.yml
+++ b/packages/py/python-cachecontrol/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - python-msgpack
     - python-requests
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-cachy/package.yml
+++ b/packages/py/python-cachy/package.yml
@@ -15,8 +15,8 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     # ...
     rm -r $installdir/usr/lib/python%python3_version%/site-packages/tests/

--- a/packages/py/python-calver/package.yml
+++ b/packages/py/python-calver/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-casttube/package.yml
+++ b/packages/py/python-casttube/package.yml
@@ -17,7 +17,7 @@ builddeps  :
 rundeps    :
     - python-requests
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     rm $installdir/usr/LICENSE

--- a/packages/py/python-cepa/package.yml
+++ b/packages/py/python-cepa/package.yml
@@ -24,8 +24,8 @@ rundeps    :
 setup      : |
     %apply_patches
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # python3_test run_tests.py --all

--- a/packages/py/python-chardet/package.yml
+++ b/packages/py/python-chardet/package.yml
@@ -22,9 +22,9 @@ builddeps  :
 #     - python-pytest
 #     - python-pytest-timeout
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # Upstream tests require additional data files with problematic
 # license status.
 # check      : |

--- a/packages/py/python-cheetah/package.yml
+++ b/packages/py/python-cheetah/package.yml
@@ -18,6 +18,6 @@ builddeps  :
 rundeps    :
     - python3
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-cleo/package.yml
+++ b/packages/py/python-cleo/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - python-crashtest
     - python-rapidfuzz
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-clickgen/package.yml
+++ b/packages/py/python-clickgen/package.yml
@@ -32,8 +32,8 @@ rundeps    :
     - python-toml
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # check      : |
 #     %python3_test pytest -v

--- a/packages/py/python-clikit/package.yml
+++ b/packages/py/python-clikit/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - python-pastel
     - python-pylev
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-cloudpickle/package.yml
+++ b/packages/py/python-cloudpickle/package.yml
@@ -19,8 +19,8 @@ checkdeps  :
     - python-pytest
     - python-tornado
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     PYTHONPATH=$PWD/tests/cloudpickle_testpkg py.test -v --deselect tests/cloudpickle_test.py::CloudPickleTest::test_importing_multiprocessing_does_not_impact_whichmodule --deselect tests/cloudpickle_test.py::Protocol2CloudPickleTest::test_importing_multiprocessing_does_not_impact_whichmodule

--- a/packages/py/python-coherent-licensed/package.yml
+++ b/packages/py/python-coherent-licensed/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-flit
     - python-installer
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-colorama/package.yml
+++ b/packages/py/python-colorama/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 replaces   :
     - python3-colorama
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/python-colour/package.yml
+++ b/packages/py/python-colour/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 setup      : |
     %patch -p1 -i $pkgfiles/drop-d2to1-requirement.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-comm/package.yml
+++ b/packages/py/python-comm/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-traitlets
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-configobj/package.yml
+++ b/packages/py/python-configobj/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
 rundeps    :
     - python-six
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-constantly/package.yml
+++ b/packages/py/python-constantly/package.yml
@@ -19,8 +19,8 @@ checkdeps  :
     - python-pytest
     - python-twisted
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-contourpy/package.yml
+++ b/packages/py/python-contourpy/package.yml
@@ -22,6 +22,6 @@ rundeps    :
 setup      : |
     sed -e '/ninja/d' -i pyproject.toml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-cppheaderparser/package.yml
+++ b/packages/py/python-cppheaderparser/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-ply
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-cppy/package.yml
+++ b/packages/py/python-cppy/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-crashtest/package.yml
+++ b/packages/py/python-crashtest/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-poetry-core
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-daemonize/package.yml
+++ b/packages/py/python-daemonize/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-dasbus/package.yml
+++ b/packages/py/python-dasbus/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-dateutil/package.yml
+++ b/packages/py/python-dateutil/package.yml
@@ -26,8 +26,8 @@ rundeps    :
     - python-six
 build      : |
     %patch -p1 -i $pkgfiles/relax-setuptools_scm-requires.patch
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    %python3_test pytest3

--- a/packages/py/python-dbus-fast/package.yml
+++ b/packages/py/python-dbus-fast/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-dbusmock/package.yml
+++ b/packages/py/python-dbusmock/package.yml
@@ -21,6 +21,6 @@ rundeps    :
     - python-gobject
     - python3-dbus
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-debian/package.yml
+++ b/packages/py/python-debian/package.yml
@@ -27,9 +27,9 @@ checkdeps  :
     - python-pytest
 build      : |
     export SETUPTOOLS_SCM_PRETEND_VERSION=${version}
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license debian/copyright
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-debugpy/package.yml
+++ b/packages/py/python-debugpy/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-defusedxml/package.yml
+++ b/packages/py/python-defusedxml/package.yml
@@ -17,9 +17,9 @@ builddeps  :
 checkdeps  :
     - python-lxml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     sed -i 's/unittest\.makeSuite(/unittest.defaultTestLoader.loadTestsFromTestCase(/g' tests.py
     %python3_test tests.py

--- a/packages/py/python-deprecation/package.yml
+++ b/packages/py/python-deprecation/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-packaging
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-diff-match-patch/package.yml
+++ b/packages/py/python-diff-match-patch/package.yml
@@ -16,8 +16,8 @@ builddeps  :
     - python-installer
     - python-pytest    # check
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-diskcache/package.yml
+++ b/packages/py/python-diskcache/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-distro/package.yml
+++ b/packages/py/python-distro/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-distutils-extra/package.yml
+++ b/packages/py/python-distutils-extra/package.yml
@@ -19,6 +19,6 @@ rundeps    :
     - intltool
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-docopt/package.yml
+++ b/packages/py/python-docopt/package.yml
@@ -19,8 +19,8 @@ checkdeps  :
 setup      : |
     %patch -p1 -i $pkgfiles/Use-Node.from_parent.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/python-dunamai/package.yml
+++ b/packages/py/python-dunamai/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-packaging
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-easygui/package.yml
+++ b/packages/py/python-easygui/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python3-tkinter
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-engineio/package.yml
+++ b/packages/py/python-engineio/package.yml
@@ -28,8 +28,8 @@ rundeps    :
     - python-requests
     - python-simple-websocket
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest

--- a/packages/py/python-entrypoints/package.yml
+++ b/packages/py/python-entrypoints/package.yml
@@ -16,8 +16,8 @@ builddeps  :
     - python-installer
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-enzyme/package.yml
+++ b/packages/py/python-enzyme/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-evdev/package.yml
+++ b/packages/py/python-evdev/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test py.test3 -v -k "not test_uinput"

--- a/packages/py/python-eventlet/package.yml
+++ b/packages/py/python-eventlet/package.yml
@@ -23,9 +23,9 @@ rundeps    :
     - dnspython
     - python-greenlet
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # Python 3.14: isolated subprocess tests fail due to greenlet shutdown stderr noise.
     %python3_test pytest -v --ignore=tests/patcher_test.py \

--- a/packages/py/python-executing/package.yml
+++ b/packages/py/python-executing/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools-scm
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-exif/package.yml
+++ b/packages/py/python-exif/package.yml
@@ -18,6 +18,6 @@ builddeps  :
 rundeps    :
     - python-plum
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-expandvars/package.yml
+++ b/packages/py/python-expandvars/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-packaging
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-fabulous/package.yml
+++ b/packages/py/python-fabulous/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-faust-cchardet/package.yml
+++ b/packages/py/python-faust-cchardet/package.yml
@@ -23,6 +23,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-feedparser/package.yml
+++ b/packages/py/python-feedparser/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 rundeps    :
     - python-sgmllib3k
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-filetype/package.yml
+++ b/packages/py/python-filetype/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-flaky/package.yml
+++ b/packages/py/python-flaky/package.yml
@@ -17,9 +17,9 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v -k 'example and not options' --doctest-modules test/test_pytest/
     %python3_test pytest -v -k 'example and not options' test/test_pytest/

--- a/packages/py/python-flask-compress/package.yml
+++ b/packages/py/python-flask-compress/package.yml
@@ -20,6 +20,6 @@ rundeps    :
     - python-brotli
     - python-zstandard
 build      : |
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-flask-socketio/package.yml
+++ b/packages/py/python-flask-socketio/package.yml
@@ -23,9 +23,9 @@ rundeps    :
     - flask
     - python-socketio
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # flask_socketio.test_client is not a test module; ignore it to avoid import clashes.
     # Skip Redis queue tests and test_background_task (eventlet timing on Python 3.14).

--- a/packages/py/python-flit-core/package.yml
+++ b/packages/py/python-flit-core/package.yml
@@ -23,11 +23,11 @@ build      : |
     if [[ ${BOOTSTRAP} == "1" ]]; then
         python3 -m pip wheel --no-deps .
     else
-        %python3_setup
+        %pyproject_build
     fi
 install    : |
     if [[ ${BOOTSTRAP} == "1" ]]; then
         python3 -m pip install --root=%installroot% --no-deps --ignore-installed .
     else
-        %python3_install
+        %pyproject_install
     fi

--- a/packages/py/python-flit-scm/package.yml
+++ b/packages/py/python-flit-scm/package.yml
@@ -19,6 +19,6 @@ rundeps    :
     - python-flit-core
     - python-setuptools-scm
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-flit/package.yml
+++ b/packages/py/python-flit/package.yml
@@ -22,6 +22,6 @@ rundeps    :
     - python-requests
     - python-tomli-w
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-freezegun/package.yml
+++ b/packages/py/python-freezegun/package.yml
@@ -21,8 +21,8 @@ checkdeps  :
 rundeps    :
     - python-dateutil
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-frozenlist/package.yml
+++ b/packages/py/python-frozenlist/package.yml
@@ -22,9 +22,9 @@ checkdeps  :
     - python-pytest
     - python-pytest-cov
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v --no-cov \
         --deselect tests/test_frozenlist.py::TestFrozenList::test_iface

--- a/packages/py/python-future/package.yml
+++ b/packages/py/python-future/package.yml
@@ -23,9 +23,9 @@ setup      : |
     %patch -p1 -i ${pkgfiles}/remove-uu.patch
     %patch -p1 -i ${pkgfiles}/test_ftp.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # https://github.com/PythonCharmers/python-future/issues/647
     # Python 3.14: skip lib2to3 tests, unittest.makeSuite, and FancyURLopener tests.

--- a/packages/py/python-genty/package.yml
+++ b/packages/py/python-genty/package.yml
@@ -19,8 +19,8 @@ checkdeps  :
 rundeps    :
     - python-six
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test

--- a/packages/py/python-gevent-websocket/package.yml
+++ b/packages/py/python-gevent-websocket/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-gevent
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-ghp-import/package.yml
+++ b/packages/py/python-ghp-import/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-dateutil
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-gpg/package.yml
+++ b/packages/py/python-gpg/package.yml
@@ -25,6 +25,6 @@ setup      : |
     %reconfigure
     mv src gpg
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-gphoto2/package.yml
+++ b/packages/py/python-gphoto2/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-setuptools
     - python-toml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-gql/package.yml
+++ b/packages/py/python-gql/package.yml
@@ -20,6 +20,6 @@ rundeps    :
     - python-backoff
     - python-graphql-core
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-graphql-core/package.yml
+++ b/packages/py/python-graphql-core/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-poetry-core
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-h11/package.yml
+++ b/packages/py/python-h11/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-h5py/package.yml
+++ b/packages/py/python-h5py/package.yml
@@ -23,6 +23,6 @@ rundeps    :
     - numpy
     - python-six
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-hatch-jupyter-builder/package.yml
+++ b/packages/py/python-hatch-jupyter-builder/package.yml
@@ -19,9 +19,9 @@ checkdeps  :
 rundeps    :
     - python-hatchling
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # Disabled test that require networking
     %python3_test pytest -v -k 'not test_hatch_build'

--- a/packages/py/python-hatch-vcs/package.yml
+++ b/packages/py/python-hatch-vcs/package.yml
@@ -22,8 +22,8 @@ rundeps    :
     - python-hatchling
     - python-setuptools-scm
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-hkdf/package.yml
+++ b/packages/py/python-hkdf/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-hpack/package.yml
+++ b/packages/py/python-hpack/package.yml
@@ -16,7 +16,7 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE

--- a/packages/py/python-html5-parser/package.yml
+++ b/packages/py/python-html5-parser/package.yml
@@ -23,6 +23,6 @@ rundeps    :
 environment: |
     export CFLAGS="${CFLAGS} -Wno-implicit-function-declaration"
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-html5lib/package.yml
+++ b/packages/py/python-html5lib/package.yml
@@ -21,6 +21,6 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/python-3.14-compatibility.patch
     %patch -p1 -i $pkgfiles/pkg_resources.patch
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-httpcore/package.yml
+++ b/packages/py/python-httpcore/package.yml
@@ -30,9 +30,9 @@ rundeps    :
     - python-certifi
     - python-h11
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     export PYTEST_ADDOPTS="-o asyncio_default_fixture_loop_scope=function -W ignore::pytest.PytestDeprecationWarning"
     %python3_test pytest -v \

--- a/packages/py/python-httplib2/package.yml
+++ b/packages/py/python-httplib2/package.yml
@@ -22,9 +22,9 @@ setup      : |
     # Don't hardcode support for one old version please...
     sed -i 's/==/>=/' requirements-test.txt
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    # Requires python-pytest-xdist, use wheel and networking for local check.
 #    %python3_test

--- a/packages/py/python-httpretty/package.yml
+++ b/packages/py/python-httpretty/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-httpx/package.yml
+++ b/packages/py/python-httpx/package.yml
@@ -36,9 +36,9 @@ rundeps    :
     - python-httpcore
     - python-idna
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     export PYTEST_ADDOPTS="-o asyncio_default_fixture_loop_scope=function -W ignore::pytest.PytestDeprecationWarning -W ignore::pytest.PytestUnraisableExceptionWarning"
     %python3_test pytest -v -m "not network" \

--- a/packages/py/python-humanize/package.yml
+++ b/packages/py/python-humanize/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
     - python-pytest-benchmark
     - python-pytest-cov
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-hyperframe/package.yml
+++ b/packages/py/python-hyperframe/package.yml
@@ -15,7 +15,7 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE

--- a/packages/py/python-hyperlink/package.yml
+++ b/packages/py/python-hyperlink/package.yml
@@ -21,8 +21,8 @@ checkdeps  :
 rundeps    :
     - python-idna
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/python-ifaddr/package.yml
+++ b/packages/py/python-ifaddr/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest-cov
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/python-imageio/package.yml
+++ b/packages/py/python-imageio/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - numpy
     - python-pillow
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-incremental/package.yml
+++ b/packages/py/python-incremental/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-twisted # circular
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test trial incremental

--- a/packages/py/python-inflect/package.yml
+++ b/packages/py/python-inflect/package.yml
@@ -24,8 +24,8 @@ rundeps    :
     - python-typeguard
     - python-typing-extensions
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-inflection/package.yml
+++ b/packages/py/python-inflection/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-iniconfig/package.yml
+++ b/packages/py/python-iniconfig/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-iniparse/package.yml
+++ b/packages/py/python-iniparse/package.yml
@@ -19,7 +19,7 @@ builddeps  :
 rundeps    :
     - python-six
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     rm -rf $installdir/usr/share

--- a/packages/py/python-ipdb/package.yml
+++ b/packages/py/python-ipdb/package.yml
@@ -20,9 +20,9 @@ builddeps  :
 rundeps    :
     - python-ipython
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
   #    rm manual_test.py
   #    %python3_test pytest

--- a/packages/py/python-ipykernel/package.yml
+++ b/packages/py/python-ipykernel/package.yml
@@ -35,9 +35,9 @@ rundeps    :
     - python-nest-asyncio
     - python-psutil
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # Headless build root has no display; upstream skips GUI tests when CI is set.
     # test_run_concurrently_sequence probes --cov, which requires pytest-cov.

--- a/packages/py/python-ipython-pygments-lexers/package.yml
+++ b/packages/py/python-ipython-pygments-lexers/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
 rundeps    :
     - pygments
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-ipython_genutils/package.yml
+++ b/packages/py/python-ipython_genutils/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-iso8601/package.yml
+++ b/packages/py/python-iso8601/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-poetry
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-iterable-io/package.yml
+++ b/packages/py/python-iterable-io/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-itsdangerous/package.yml
+++ b/packages/py/python-itsdangerous/package.yml
@@ -20,8 +20,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3

--- a/packages/py/python-jaraco.classes/package.yml
+++ b/packages/py/python-jaraco.classes/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 rundeps    :
     - python-more-itertools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-jaraco.collections/package.yml
+++ b/packages/py/python-jaraco.collections/package.yml
@@ -22,8 +22,8 @@ rundeps    :
 setup      : |
 
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-jaraco.context/package.yml
+++ b/packages/py/python-jaraco.context/package.yml
@@ -17,9 +17,9 @@ builddeps  :
 rundeps    :
     - python-backports.tarfile
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    # Requires `python-portend`
 #    %python3_test pytest -v

--- a/packages/py/python-jaraco.envs/package.yml
+++ b/packages/py/python-jaraco.envs/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
     - virtualenv
 networking : yes # check
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-jaraco.functools/package.yml
+++ b/packages/py/python-jaraco.functools/package.yml
@@ -21,8 +21,8 @@ checkdeps  :
 rundeps    :
     - python-more-itertools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-jaraco.path/package.yml
+++ b/packages/py/python-jaraco.path/package.yml
@@ -21,8 +21,8 @@ checkdeps  :
 setup      : |
 
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-jaraco.test/package.yml
+++ b/packages/py/python-jaraco.test/package.yml
@@ -25,9 +25,9 @@ rundeps    :
     - python-jaraco.functools
 networking : yes # check
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     pytest_options=(
         # ignore doctests to not pull in more dependencies

--- a/packages/py/python-jaraco.text/package.yml
+++ b/packages/py/python-jaraco.text/package.yml
@@ -30,8 +30,8 @@ checkdeps  :
 setup      : |
     %patch -p1 -i ${pkgfiles}/0001-typer-only.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-jedi/package.yml
+++ b/packages/py/python-jedi/package.yml
@@ -22,9 +22,9 @@ rundeps    :
 replaces   :
     - python3-jedi
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # Python 3.14: stdlib os additions, deferred annotations, PEP 695 type params.
     %python3_test pytest -v -k "not test_find_system_environments and not test_string_annotation and not test_compiled_signature_annotation_string and not TestSetupReadline and not pep0695_type_parameter_syntax"

--- a/packages/py/python-jeepney/package.yml
+++ b/packages/py/python-jeepney/package.yml
@@ -23,8 +23,8 @@ checkdeps  :
     - python-testpath
     - python-trio
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-jellyfish/package.yml
+++ b/packages/py/python-jellyfish/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-installer
     - python-maturin
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-jinja/package.yml
+++ b/packages/py/python-jinja/package.yml
@@ -24,8 +24,8 @@ rundeps    :
     - python-babel
     - python-markupsafe
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3

--- a/packages/py/python-jmespath/package.yml
+++ b/packages/py/python-jmespath/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-joblib/package.yml
+++ b/packages/py/python-joblib/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-josepy/package.yml
+++ b/packages/py/python-josepy/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
 rundeps    :
     - python-cryptography
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-json5/package.yml
+++ b/packages/py/python-json5/package.yml
@@ -19,6 +19,6 @@ checkdeps  :
 build      : |
     %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %pytest

--- a/packages/py/python-jsonschema-specifications/package.yml
+++ b/packages/py/python-jsonschema-specifications/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
 rundeps    :
     - python-referencing
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-jsonschema/package.yml
+++ b/packages/py/python-jsonschema/package.yml
@@ -26,9 +26,9 @@ rundeps    :
 environment: |
     export SETUPTOOLS_SCM_PRETEND_VERSION=$version
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # test_exceptions.py requires jsonpath-ng, which is not packaged.
     %python3_test pytest -v --ignore=jsonschema/tests/test_exceptions.py

--- a/packages/py/python-jupyter-events/package.yml
+++ b/packages/py/python-jupyter-events/package.yml
@@ -22,6 +22,6 @@ rundeps    :
     - python-traitlets
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-jupyter-lsp/package.yml
+++ b/packages/py/python-jupyter-lsp/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-jupyter-server
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-jupyter-packaging/package.yml
+++ b/packages/py/python-jupyter-packaging/package.yml
@@ -27,8 +27,8 @@ rundeps    :
     - python-tomlkit
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    %python3_test pytest3 -v

--- a/packages/py/python-jupyter-server-terminals/package.yml
+++ b/packages/py/python-jupyter-server-terminals/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-terminado
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-jupyter-server/package.yml
+++ b/packages/py/python-jupyter-server/package.yml
@@ -26,6 +26,6 @@ rundeps    :
     - python-send2trash
     - python-websocket-client
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-jupyter_client/package.yml
+++ b/packages/py/python-jupyter_client/package.yml
@@ -39,9 +39,9 @@ rundeps    :
     - python-traitlets
     - python-typing-extensions
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # Python 3.14: ipykernel jsonutil triggers DeprecationWarning from _strptime at import.
     # Upstream filter targets ipykernel.jsonutil but the warning originates in _strptime.

--- a/packages/py/python-jupyter_core/package.yml
+++ b/packages/py/python-jupyter_core/package.yml
@@ -22,9 +22,9 @@ checkdeps  :
     - python-pytest
     - python-traitlets
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     install -Dm00644 examples/jupyter-completion.bash ${installdir}/usr/share/bash-completion/completions/jupyter
     install -Dm00644 examples/completions-zsh ${installdir}/usr/share/zsh/site-functions/_jupyter
 check      : |

--- a/packages/py/python-jupyterlab-pygments/package.yml
+++ b/packages/py/python-jupyterlab-pygments/package.yml
@@ -18,9 +18,7 @@ builddeps  :
     - python-jupyterlab
 rundeps    :
     - pygments
-setup      : |
-    rm setup.py
 build      : |
-    python3 -m build --wheel --no-isolation --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-jupyterlab-server/package.yml
+++ b/packages/py/python-jupyterlab-server/package.yml
@@ -21,6 +21,6 @@ rundeps    :
     - python-jupyter-server
     - python-requests
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-kaptan/package.yml
+++ b/packages/py/python-kaptan/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3

--- a/packages/py/python-keyring/package.yml
+++ b/packages/py/python-keyring/package.yml
@@ -29,9 +29,9 @@ rundeps    :
     - python-jaraco.functools
     - python-secretstorage
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # Need python-keyrings-alt
 #check      : |
 #    rm tests/backends/test_{Windows,macOS}.py

--- a/packages/py/python-lap/package.yml
+++ b/packages/py/python-lap/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 rundeps    :
     - numpy
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-lazy-loader/package.yml
+++ b/packages/py/python-lazy-loader/package.yml
@@ -21,6 +21,6 @@ checkdeps  :
 build      : |
     %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %pytest

--- a/packages/py/python-levenshtein/package.yml
+++ b/packages/py/python-levenshtein/package.yml
@@ -26,6 +26,6 @@ rundeps    :
 build      : |
     %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %pytest

--- a/packages/py/python-libarchive-c/package.yml
+++ b/packages/py/python-libarchive-c/package.yml
@@ -18,6 +18,6 @@ builddeps  :
 rundeps    :
     - libarchive
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-libevdev/package.yml
+++ b/packages/py/python-libevdev/package.yml
@@ -23,6 +23,6 @@ rundeps    :
 build      : |
     %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check       : |
     %pytest -v -k 'not test_has_property and not test_enable_event_code and not test_mt_value and not test_slot_value'

--- a/packages/py/python-libtmux/package.yml
+++ b/packages/py/python-libtmux/package.yml
@@ -26,9 +26,9 @@ checkdeps  :
     - python-pytest-rerunfailures
     - tmux
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     pytest_args=(
         --deselect tests/test_pane.py::test_capture_pane_start

--- a/packages/py/python-license-expression/package.yml
+++ b/packages/py/python-license-expression/package.yml
@@ -19,8 +19,8 @@ checkdeps  :
     - python-boolean.py
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-linkify-it-py/package.yml
+++ b/packages/py/python-linkify-it-py/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
     - python-pytest
     - python-uc-micro-py
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-llfuse/package.yml
+++ b/packages/py/python-llfuse/package.yml
@@ -22,6 +22,6 @@ checkdeps  :
 build      : |
     %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %pytest

--- a/packages/py/python-lockfile/package.yml
+++ b/packages/py/python-lockfile/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-lsp-black/package.yml
+++ b/packages/py/python-lsp-black/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - python-black
     - python-lsp-server
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-lsp-jsonrpc/package.yml
+++ b/packages/py/python-lsp-jsonrpc/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
 rundeps    :
     - python-ujson
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-lsp-server/package.yml
+++ b/packages/py/python-lsp-server/package.yml
@@ -50,7 +50,7 @@ rundeps    :
 build      : |
     %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # Ignore websockets test file, pylint integration tests, and specific flaky hover/teardown tests
     %pytest --ignore=test/test_python_lsp.py \

--- a/packages/py/python-lxml-html-clean/package.yml
+++ b/packages/py/python-lxml-html-clean/package.yml
@@ -20,9 +20,9 @@ checkdeps  :
 rundeps    :
     - python-lxml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # Doctest .txt tests fail on Python 3.14 due to lxml.doctestcompare incompatibility
     %python3_test pytest -v tests/test_clean.py

--- a/packages/py/python-lxml/package.yml
+++ b/packages/py/python-lxml/package.yml
@@ -29,7 +29,7 @@ builddeps  :
 build      : |
     %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    pushd $PKG_BUILD_DIR/py3build
 #        python3 test.py -vuf

--- a/packages/py/python-magic/package.yml
+++ b/packages/py/python-magic/package.yml
@@ -16,6 +16,6 @@ builddeps  :
 description: |
     This module uses ctypes to access the libmagic file type identification library. It makes use of the local magic database and supports both textual and MIME-type output.
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-markdown-it-py/package.yml
+++ b/packages/py/python-markdown-it-py/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-mdurl
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-matplotlib-inline/package.yml
+++ b/packages/py/python-matplotlib-inline/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-traitlets
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-mdit-py-plugins/package.yml
+++ b/packages/py/python-mdit-py-plugins/package.yml
@@ -22,8 +22,8 @@ checkdeps  :
     - python-pytest
     - python-pytest-regressions
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-mdurl/package.yml
+++ b/packages/py/python-mdurl/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-flit-core
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-mechanize/package.yml
+++ b/packages/py/python-mechanize/package.yml
@@ -21,9 +21,9 @@ checkdeps  :
 rundeps    :
     - python-html5lib
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # TODO 3.14
 #check      : |
 #    %python3_test run_tests.py

--- a/packages/py/python-mediafile/package.yml
+++ b/packages/py/python-mediafile/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - mutagen
     - python-filetype
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-mergedeep/package.yml
+++ b/packages/py/python-mergedeep/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-minimock/package.yml
+++ b/packages/py/python-minimock/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 setup      : |
     sed -i -e "s|1.2.10.dev0|1.3.0|g" minimock.py conda/meta.yaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     python3 minimock.py -v

--- a/packages/py/python-mock/package.yml
+++ b/packages/py/python-mock/package.yml
@@ -20,6 +20,6 @@ rundeps    :
     - pbr
     - python-six
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-moddb/package.yml
+++ b/packages/py/python-moddb/package.yml
@@ -19,6 +19,6 @@ rundeps    :
     - python-pyrate-limiter
     - python-requests
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-mpmath/package.yml
+++ b/packages/py/python-mpmath/package.yml
@@ -24,9 +24,9 @@ rundeps    :
     - matplotlib
     - python-gmpy2
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v
 replaces   :

--- a/packages/py/python-multidict/package.yml
+++ b/packages/py/python-multidict/package.yml
@@ -19,9 +19,9 @@ checkdeps  :
     - python-pytest
     - python-pytest-cov
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v -m "not leaks" --no-cov \
         --ignore=tests/isolated \

--- a/packages/py/python-munkres/package.yml
+++ b/packages/py/python-munkres/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3

--- a/packages/py/python-mypy_extensions/package.yml
+++ b/packages/py/python-mypy_extensions/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-myst-parser/package.yml
+++ b/packages/py/python-myst-parser/package.yml
@@ -33,8 +33,8 @@ rundeps    :
     - python-sphinx
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v -k "not (test_references_singlehtml or test_fieldlist_extension or test_extended_syntaxes or 320-math)"

--- a/packages/py/python-natsort/package.yml
+++ b/packages/py/python-natsort/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - pyicu
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-nbclassic/package.yml
+++ b/packages/py/python-nbclassic/package.yml
@@ -25,9 +25,9 @@ rundeps    :
     - python-jupyter-server
     - python-notebook-shim
 build      : |
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install
 
     rm -r ${installdir}/usr/lib/python%python3_version%/site-packages/nbclassic/static/components/MathJax
     ln -sv /usr/share/fonts/mathjax2 ${installdir}/usr/lib/python%python3_version%/site-packages/nbclassic/static/components/MathJax

--- a/packages/py/python-nbclient/package.yml
+++ b/packages/py/python-nbclient/package.yml
@@ -19,6 +19,6 @@ rundeps    :
     - python-nbformat
     - python-nest-asyncio
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-nbconvert/package.yml
+++ b/packages/py/python-nbconvert/package.yml
@@ -27,6 +27,6 @@ rundeps    :
     - python-packaging
     - python-pandocfilters
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-nbxmpp/package.yml
+++ b/packages/py/python-nbxmpp/package.yml
@@ -23,6 +23,6 @@ rundeps    :
     - python-packaging
     - python-precis_i18n
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-neovim/package.yml
+++ b/packages/py/python-neovim/package.yml
@@ -20,6 +20,6 @@ rundeps    :
     - python-msgpack
     - python-typing-extensions
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-nest-asyncio/package.yml
+++ b/packages/py/python-nest-asyncio/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-setuptools-scm
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-netaddr/package.yml
+++ b/packages/py/python-netaddr/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-netifaces/package.yml
+++ b/packages/py/python-netifaces/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-notebook-shim/package.yml
+++ b/packages/py/python-notebook-shim/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-jupyter-server
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-notify2/package.yml
+++ b/packages/py/python-notify2/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-setuptools
     - python3-dbus
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-opengl/package.yml
+++ b/packages/py/python-opengl/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-openpyxl/package.yml
+++ b/packages/py/python-openpyxl/package.yml
@@ -22,8 +22,8 @@ checkdeps  :
 rundeps    :
     - python-et_xmlfile
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v -k "not test_iterparse"

--- a/packages/py/python-ordered-set/package.yml
+++ b/packages/py/python-ordered-set/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest

--- a/packages/py/python-outcome/package.yml
+++ b/packages/py/python-outcome/package.yml
@@ -19,8 +19,8 @@ checkdeps  :
 rundeps    :
     - python-attrs
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-overrides/package.yml
+++ b/packages/py/python-overrides/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-packaging/package.yml
+++ b/packages/py/python-packaging/package.yml
@@ -27,13 +27,13 @@ build      : |
     if [[ ${BOOTSTRAP} == "1" ]]; then
         python3 -m pip wheel --no-deps .
     else
-        %python3_setup
+        %pyproject_build
     fi
 install    : |
     if [[ ${BOOTSTRAP} == "1" ]]; then
         python3 -m pip install --root=%installroot% --no-deps --ignore-installed .
     else
-        %python3_install
+        %pyproject_install
     fi
 check      : |
     if [[ ${BOOTSTRAP} != "1" ]]; then

--- a/packages/py/python-pandas/package.yml
+++ b/packages/py/python-pandas/package.yml
@@ -33,10 +33,9 @@ rundeps    :
     - python-pytz
     - python-tzdata
 build      : |
-    # no macros as we need skip-dependency-check here
-    python3 -m build --wheel --no-isolation --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    python3 -m installer --destdir=%installroot% dist/*.whl
+    %pyproject_install
 
 #check      : |
     #mkdir -p .pytest_sandbox

--- a/packages/py/python-pandocfilters/package.yml
+++ b/packages/py/python-pandocfilters/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-parameterized/package.yml
+++ b/packages/py/python-parameterized/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-parsedatetime/package.yml
+++ b/packages/py/python-parsedatetime/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-parso/package.yml
+++ b/packages/py/python-parso/package.yml
@@ -20,9 +20,9 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # Python 3.12 made changes to f-string formatting. See:
     # https://github.com/davidhalter/parso/issues/222

--- a/packages/py/python-pastel/package.yml
+++ b/packages/py/python-pastel/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-poetry-core
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-path/package.yml
+++ b/packages/py/python-path/package.yml
@@ -21,8 +21,8 @@ checkdeps  :
     - python-more-itertools
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-pdm-backend/package.yml
+++ b/packages/py/python-pdm-backend/package.yml
@@ -14,8 +14,8 @@ builddeps  :
     - python-build
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 replaces   :
     - python-pdm-pep517

--- a/packages/py/python-pexpect/package.yml
+++ b/packages/py/python-pexpect/package.yml
@@ -22,9 +22,9 @@ checkdeps  :
 rundeps    :
     - ptyprocess
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # Workaround to fix failing tests: https://github.com/pexpect/pexpect/issues/669#issuecomment-758109973
     echo "set enable-bracketed-paste off" > .inputrc

--- a/packages/py/python-pickleshare/package.yml
+++ b/packages/py/python-pickleshare/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pillow/package.yml
+++ b/packages/py/python-pillow/package.yml
@@ -28,9 +28,9 @@ checkdeps  :
 rundeps    :
     - libjpeg-turbo
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     install -dm00755 $installdir/usr/include/python%python3_version%/
     install -m00644 src/libImaging/*.h $installdir/usr/include/python%python3_version%/
 check      : |

--- a/packages/py/python-pkginfo/package.yml
+++ b/packages/py/python-pkginfo/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pluggy/package.yml
+++ b/packages/py/python-pluggy/package.yml
@@ -19,8 +19,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-plum/package.yml
+++ b/packages/py/python-plum/package.yml
@@ -15,9 +15,9 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    # Need to package python-baseline
 #    %python3_test pytest3 -v

--- a/packages/py/python-ply/package.yml
+++ b/packages/py/python-ply/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-podcastparser/package.yml
+++ b/packages/py/python-podcastparser/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest-cov
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    %python3_test pytest3 -v

--- a/packages/py/python-poetry-core/package.yml
+++ b/packages/py/python-poetry-core/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - python-packaging
     - python-typing-extensions
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-polib/package.yml
+++ b/packages/py/python-polib/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pretend/package.yml
+++ b/packages/py/python-pretend/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-propcache/package.yml
+++ b/packages/py/python-propcache/package.yml
@@ -20,9 +20,9 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v \
         --ignore=tests/test_benchmarks.py \

--- a/packages/py/python-proton-core/package.yml
+++ b/packages/py/python-proton-core/package.yml
@@ -16,8 +16,8 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 replaces   :
     - proton-python-client

--- a/packages/py/python-proton-keyring-linux/package.yml
+++ b/packages/py/python-proton-keyring-linux/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 rundeps    :
     - python-keyring
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 replaces   :
     - python-proton-keyring-linux-secretservice

--- a/packages/py/python-proton-vpn-core-api/package.yml
+++ b/packages/py/python-proton-vpn-core-api/package.yml
@@ -16,9 +16,9 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 replaces   :
     - python-proton-vpn-logger
     - python-proton-vpn-network-manager

--- a/packages/py/python-psutil/package.yml
+++ b/packages/py/python-psutil/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-setuptools
 build      : |
     sed -e '/typing_extensions/d;/mypy_extensions/d;/typed_ast/d;/tomli/d;/types-psutil/d;/types-setuptools/d;/types-typed-ast/d' -i pyproject.toml
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pure-eval/package.yml
+++ b/packages/py/python-pure-eval/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-py-cpuinfo/package.yml
+++ b/packages/py/python-py-cpuinfo/package.yml
@@ -16,8 +16,8 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test

--- a/packages/py/python-pyclip/package.yml
+++ b/packages/py/python-pyclip/package.yml
@@ -23,6 +23,6 @@ rundeps    :
 build      : |
     install -Dm00644 $sources/README.md docs/README.md
 
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pyclipper/package.yml
+++ b/packages/py/python-pyclipper/package.yml
@@ -26,6 +26,6 @@ setup      : |
     sed -i "s/'unittest2', //" setup.py
     sed -i s/unittest2/unittest/ tests/test_pyclipper.py
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pydbus/package.yml
+++ b/packages/py/python-pydbus/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pygdbmi/package.yml
+++ b/packages/py/python-pygdbmi/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 rundeps    :
     - gdb
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pyglet/package.yml
+++ b/packages/py/python-pyglet/package.yml
@@ -18,6 +18,6 @@ builddeps  :
 rundeps    :
     - python-future
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pyhamcrest/package.yml
+++ b/packages/py/python-pyhamcrest/package.yml
@@ -21,9 +21,9 @@ setup      : |
     # Remove obsolete numpy shorthand types which were removed in numpy 2.0
     %patch -p1 -i ${pkgfiles}/248.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # FutureExceptionTest uses asyncio.get_event_loop(), which fails on Python 3.14.
     %python3_test pytest -v -k "not FutureExceptionTest"

--- a/packages/py/python-pyheif/package.yml
+++ b/packages/py/python-pyheif/package.yml
@@ -20,6 +20,6 @@ builddeps  :
 rundeps    :
     - python-cffi
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pylast/package.yml
+++ b/packages/py/python-pylast/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 rundeps    :
     - python-httpx
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 replaces   :
     - python3-pylast

--- a/packages/py/python-pylev/package.yml
+++ b/packages/py/python-pylev/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pylibacl/package.yml
+++ b/packages/py/python-pylibacl/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pyliblo3/package.yml
+++ b/packages/py/python-pyliblo3/package.yml
@@ -20,8 +20,8 @@ builddeps  :
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Fix-compiltation-with-Cython-3.1.2.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 replaces   :
     - python-pyliblo

--- a/packages/py/python-pylint-venv/package.yml
+++ b/packages/py/python-pylint-venv/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-poetry
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pyls-spyder/package.yml
+++ b/packages/py/python-pyls-spyder/package.yml
@@ -21,8 +21,8 @@ checkdeps  :
 rundeps    :
     - python-lsp-server
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/python-pyocr/package.yml
+++ b/packages/py/python-pyocr/package.yml
@@ -20,6 +20,6 @@ rundeps    :
     - python-pillow
     - tesseract
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pypandoc/package.yml
+++ b/packages/py/python-pypandoc/package.yml
@@ -27,8 +27,8 @@ rundeps    :
     - python-pandocfilters
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     python3 tests.py

--- a/packages/py/python-pypdf2/package.yml
+++ b/packages/py/python-pypdf2/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-flit-core
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pypng/package.yml
+++ b/packages/py/python-pypng/package.yml
@@ -18,9 +18,9 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     cd code
     %python3_test pytest -v

--- a/packages/py/python-pyproj/package.yml
+++ b/packages/py/python-pyproj/package.yml
@@ -25,6 +25,6 @@ setup      : |
     # Remove RPATH
     sed -i "s/runtime_library_dirs=libdirs,//" setup.py
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pyproject-hooks/package.yml
+++ b/packages/py/python-pyproject-hooks/package.yml
@@ -22,11 +22,11 @@ build      : |
     if [[ ${BOOTSTRAP} == "1" ]]; then
         python3 -m pip wheel --no-deps .
     else
-        %python3_setup
+        %pyproject_build
     fi
 install    : |
     if [[ ${BOOTSTRAP} == "1" ]]; then
         python3 -m pip install --root=%installroot% --no-deps --ignore-installed .
     else
-        %python3_install
+        %pyproject_install
     fi

--- a/packages/py/python-pyproject-metadata/package.yml
+++ b/packages/py/python-pyproject-metadata/package.yml
@@ -20,8 +20,8 @@ rundeps    :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    %python3_test pytest -v

--- a/packages/py/python-pyrsistent/package.yml
+++ b/packages/py/python-pyrsistent/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
     - python-hypothesis
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-pysequoia/package.yml
+++ b/packages/py/python-pysequoia/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-maturin
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pyserial/package.yml
+++ b/packages/py/python-pyserial/package.yml
@@ -15,9 +15,9 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     pushd test
         %python3_test python3 -m unittest discover -v

--- a/packages/py/python-pysmbc/package.yml
+++ b/packages/py/python-pysmbc/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pysocks/package.yml
+++ b/packages/py/python-pysocks/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pysol-cards/package.yml
+++ b/packages/py/python-pysol-cards/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pystache/package.yml
+++ b/packages/py/python-pystache/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-pytest-asyncio/package.yml
+++ b/packages/py/python-pytest-asyncio/package.yml
@@ -23,8 +23,8 @@ checkdeps  :
 rundeps    :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-pytest-benchmark/package.yml
+++ b/packages/py/python-pytest-benchmark/package.yml
@@ -23,9 +23,9 @@ rundeps    :
     - python-py-cpuinfo
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    needs python-elasticsearch packaged
 #    %python3_test pytest3

--- a/packages/py/python-pytest-cov/package.yml
+++ b/packages/py/python-pytest-cov/package.yml
@@ -22,9 +22,9 @@ rundeps    :
     - python-coverage
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    Upstream tests require process-tests and pytest-xdist (not packaged).
 #    %python3_test pytest -v

--- a/packages/py/python-pytest-datadir/package.yml
+++ b/packages/py/python-pytest-datadir/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
 rundeps    :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-pytest-httpserver/package.yml
+++ b/packages/py/python-pytest-httpserver/package.yml
@@ -20,8 +20,8 @@ builddeps  :
 rundeps    :
     - python-werkzeug
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-pytest-isort/package.yml
+++ b/packages/py/python-pytest-isort/package.yml
@@ -21,8 +21,8 @@ rundeps    :
     - python-isort
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-pytest-jupyter/package.yml
+++ b/packages/py/python-pytest-jupyter/package.yml
@@ -25,9 +25,9 @@ rundeps    :
     - python-jupyter_core
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # TODO 3.14
 #check      : |
 #    %python3_test pytest3 -v

--- a/packages/py/python-pytest-mock/package.yml
+++ b/packages/py/python-pytest-mock/package.yml
@@ -23,8 +23,8 @@ rundeps    :
 environment: |
     export SETUPTOOLS_SCM_PRETEND_VERSION=${version}
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v -k 'not test_standalone_mock'  --assert=plain

--- a/packages/py/python-pytest-param-files/package.yml
+++ b/packages/py/python-pytest-param-files/package.yml
@@ -20,8 +20,8 @@ rundeps    :
     - python-pytest
     - ruamel_yaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-pytest-regressions/package.yml
+++ b/packages/py/python-pytest-regressions/package.yml
@@ -26,8 +26,8 @@ rundeps    :
     - python-pytest-datadir
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-pytest-trio/package.yml
+++ b/packages/py/python-pytest-trio/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - python-pytest
     - python-trio
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pytest/package.yml
+++ b/packages/py/python-pytest/package.yml
@@ -37,9 +37,9 @@ rundeps    :
     - python-packaging
     - python-pluggy
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     # Symlinking pytest3 and py.test3 to prevent check failures
     pushd ${installdir}/usr/bin

--- a/packages/py/python-pythondialog/package.yml
+++ b/packages/py/python-pythondialog/package.yml
@@ -19,6 +19,6 @@ rundeps    :
     - dialog
     - python3
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pytoolconfig/package.yml
+++ b/packages/py/python-pytoolconfig/package.yml
@@ -23,8 +23,8 @@ checkdeps  :
 rundeps    :
     - python-packaging
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest

--- a/packages/py/python-pyuca/package.yml
+++ b/packages/py/python-pyuca/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pyudev/package.yml
+++ b/packages/py/python-pyudev/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 rundeps    :
     - python-six
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 replaces   :
     - python3-pyudev

--- a/packages/py/python-pyusb/package.yml
+++ b/packages/py/python-pyusb/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-setuptools-scm
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-pywavelets/package.yml
+++ b/packages/py/python-pywavelets/package.yml
@@ -25,8 +25,8 @@ checkdeps  :
 rundeps    :
     - numpy
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
   #    %python3_test pytest3 -v

--- a/packages/py/python-pyxattr/package.yml
+++ b/packages/py/python-pyxattr/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-qdarkstyle/package.yml
+++ b/packages/py/python-qdarkstyle/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-qtpy
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-qrcode/package.yml
+++ b/packages/py/python-qrcode/package.yml
@@ -24,8 +24,8 @@ checkdeps  :
 rundeps    :
     - python-pypng
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-qstylizer/package.yml
+++ b/packages/py/python-qstylizer/package.yml
@@ -23,8 +23,8 @@ rundeps    :
     - python-inflection
     - python-tinycss2
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-qt-material/package.yml
+++ b/packages/py/python-qt-material/package.yml
@@ -18,6 +18,6 @@ builddeps  :
 rundeps    :
     - python-jinja
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-qtawesome/package.yml
+++ b/packages/py/python-qtawesome/package.yml
@@ -19,6 +19,6 @@ rundeps    :
     - python-qtpy
     - python-six
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-qtpy/package.yml
+++ b/packages/py/python-qtpy/package.yml
@@ -18,6 +18,6 @@ builddeps  :
 rundeps    :
     - python-packaging
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-rapidfuzz/package.yml
+++ b/packages/py/python-rapidfuzz/package.yml
@@ -19,6 +19,6 @@ builddeps  :
     - python-wheel
     - rapidfuzz-cpp
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-referencing/package.yml
+++ b/packages/py/python-referencing/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - python-attrs
     - python-rpds-py
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-rencode/package.yml
+++ b/packages/py/python-rencode/package.yml
@@ -22,6 +22,6 @@ setup      : |
     %patch -p1 -i ${pkgfiles}/0001-Remove-extra-compile-args.patch
 build      : |
     export PYTHONSAFEPATH=1
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-requests-mock/package.yml
+++ b/packages/py/python-requests-mock/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 rundeps    :
     - python-requests
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-requests-ratelimiter/package.yml
+++ b/packages/py/python-requests-ratelimiter/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - python-pyrate-limiter
     - python-requests
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-requests-toolbelt/package.yml
+++ b/packages/py/python-requests-toolbelt/package.yml
@@ -21,9 +21,9 @@ checkdeps  :
 rundeps    :
     - python-requests
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # Betamax cassettes fail playback with current urllib3 (Content-Length mismatch)
     %python3_test pytest -v -k 'not TestDumpRealResponses and not TestBasedSession'

--- a/packages/py/python-requests/package.yml
+++ b/packages/py/python-requests/package.yml
@@ -27,9 +27,9 @@ rundeps    :
     - python-idna
     - python-urllib3
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
     # requires httpbin,mocker
     #python3_test pytest3

--- a/packages/py/python-resolvelib/package.yml
+++ b/packages/py/python-resolvelib/package.yml
@@ -18,7 +18,7 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 

--- a/packages/py/python-rfc3339-validator/package.yml
+++ b/packages/py/python-rfc3339-validator/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-six
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-rich/package.yml
+++ b/packages/py/python-rich/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - pygments
     - python-markdown-it-py
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-rope/package.yml
+++ b/packages/py/python-rope/package.yml
@@ -21,9 +21,9 @@ checkdeps  :
 rundeps    :
     - python-pytoolconfig
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     # https://github.com/python-rope/rope/commit/702ff3bbb9636ba91f1187d5a0d32b1a8ea76609
     sed -i 's/check_call(\[sys\.executable, "-m", "pip", "uninstall"/check_call([session_venv_python_executable, "-m", "pip", "uninstall"/' ropetest/conftest.py

--- a/packages/py/python-rpds-py/package.yml
+++ b/packages/py/python-rpds-py/package.yml
@@ -20,6 +20,6 @@ checkdeps  :
 build      : |
     %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %pytest -v

--- a/packages/py/python-rsa/package.yml
+++ b/packages/py/python-rsa/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-asn1
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-rtree/package.yml
+++ b/packages/py/python-rtree/package.yml
@@ -22,8 +22,8 @@ checkdeps  :
 rundeps    :
     - libspatialindex
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-rxpy/package.yml
+++ b/packages/py/python-rxpy/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sane/package.yml
+++ b/packages/py/python-sane/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-seaborn/package.yml
+++ b/packages/py/python-seaborn/package.yml
@@ -26,9 +26,9 @@ rundeps    :
     - python-statsmodels
     - scipy
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     pytest_args=(
         --deselect "tests/_core/test_plot.py::TestLabelVisibility::test_1d_column_wrapped"

--- a/packages/py/python-semanticversion/package.yml
+++ b/packages/py/python-semanticversion/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/python-service-identity/package.yml
+++ b/packages/py/python-service-identity/package.yml
@@ -24,8 +24,8 @@ rundeps    :
     - python-attrs
     - python-cryptography
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-setproctitle/package.yml
+++ b/packages/py/python-setproctitle/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-setuptools-gettext/package.yml
+++ b/packages/py/python-setuptools-gettext/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 rundeps    :
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-setuptools-git-versioning/package.yml
+++ b/packages/py/python-setuptools-git-versioning/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-setuptools-git/package.yml
+++ b/packages/py/python-setuptools-git/package.yml
@@ -18,9 +18,9 @@ checkdeps  :
     - git # check
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     git config --global user.email "nobody@nowhere.com"
     %python3_test pytest3 -v setuptools_git/tests.py

--- a/packages/py/python-setuptools/package.yml
+++ b/packages/py/python-setuptools/package.yml
@@ -55,9 +55,9 @@ setup      : |
         s/^core =/dependencies =/
         }' pyproject.toml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     # Delete vendored packages
     # TODO replace with python sitepackage macro

--- a/packages/py/python-sgmllib3k/package.yml
+++ b/packages/py/python-sgmllib3k/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-shellingham/package.yml
+++ b/packages/py/python-shellingham/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-simple-websocket/package.yml
+++ b/packages/py/python-simple-websocket/package.yml
@@ -22,9 +22,9 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/remove-net-access-requirement-in-tests.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # TODO 3.14
 #check      : |
 #    %python3_test pytest -v

--- a/packages/py/python-simplegeneric/package.yml
+++ b/packages/py/python-simplegeneric/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-six/package.yml
+++ b/packages/py/python-six/package.yml
@@ -19,8 +19,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test py.test3

--- a/packages/py/python-smartypants/package.yml
+++ b/packages/py/python-smartypants/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sniffio/package.yml
+++ b/packages/py/python-sniffio/package.yml
@@ -17,9 +17,9 @@ builddeps  :
     - python-setuptools-scm
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # Requires curio
 #check      : |
 #    %python3_test pytest3

--- a/packages/py/python-socketio/package.yml
+++ b/packages/py/python-socketio/package.yml
@@ -28,9 +28,9 @@ rundeps    :
     - python-bidict
     - python-engineio
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v \
         --ignore=tests/async/test_redis_manager.py \

--- a/packages/py/python-spake2/package.yml
+++ b/packages/py/python-spake2/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 rundeps    :
     - python-hkdf
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sparqlwrapper/package.yml
+++ b/packages/py/python-sparqlwrapper/package.yml
@@ -18,6 +18,6 @@ builddeps  :
 rundeps    :
     - rdflib
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sphinx-lv2-theme/package.yml
+++ b/packages/py/python-sphinx-lv2-theme/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools
     - python-sphinx
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sphinx-pytest/package.yml
+++ b/packages/py/python-sphinx-pytest/package.yml
@@ -23,8 +23,8 @@ rundeps    :
     - python-pytest
     - python-sphinx
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-sphinx-rtd-theme/package.yml
+++ b/packages/py/python-sphinx-rtd-theme/package.yml
@@ -19,6 +19,6 @@ rundeps    :
     - python-docutils
     - python-sphinxcontrib-jquery
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sphinxcontrib-apidoc/package.yml
+++ b/packages/py/python-sphinxcontrib-apidoc/package.yml
@@ -19,6 +19,6 @@ rundeps    :
     - pbr
     - python-sphinx
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sphinxcontrib-applehelp/package.yml
+++ b/packages/py/python-sphinxcontrib-applehelp/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-flit-core
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sphinxcontrib-devhelp/package.yml
+++ b/packages/py/python-sphinxcontrib-devhelp/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-flit-core
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sphinxcontrib-htmlhelp/package.yml
+++ b/packages/py/python-sphinxcontrib-htmlhelp/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-flit-core
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sphinxcontrib-jquery/package.yml
+++ b/packages/py/python-sphinxcontrib-jquery/package.yml
@@ -21,9 +21,9 @@ checkdeps  :
 rundeps    :
     - python-sphinx
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v \
         --deselect tests/test_jquery_installed.py::test_jquery_installed_sphinx_ge_60_use_sri \

--- a/packages/py/python-sphinxcontrib-jsmath/package.yml
+++ b/packages/py/python-sphinxcontrib-jsmath/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sphinxcontrib-qthelp/package.yml
+++ b/packages/py/python-sphinxcontrib-qthelp/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-flit-core
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-sphinxcontrib-serializinghtml/package.yml
+++ b/packages/py/python-sphinxcontrib-serializinghtml/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-flit-core
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-spyder-kernels/package.yml
+++ b/packages/py/python-spyder-kernels/package.yml
@@ -25,6 +25,6 @@ rundeps    :
     - python-wurlitzer
     - pyxdg
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-srt/package.yml
+++ b/packages/py/python-srt/package.yml
@@ -21,8 +21,8 @@ checkdeps  :
     - python-hypothesis
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-stack-data/package.yml
+++ b/packages/py/python-stack-data/package.yml
@@ -20,6 +20,6 @@ rundeps    :
     - python-executing
     - python-pure-eval
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-statsmodels/package.yml
+++ b/packages/py/python-statsmodels/package.yml
@@ -24,6 +24,6 @@ rundeps    :
     - python-patsy
     - scipy
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-stopit/package.yml
+++ b/packages/py/python-stopit/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-stringcase/package.yml
+++ b/packages/py/python-stringcase/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-systemd/package.yml
+++ b/packages/py/python-systemd/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-build
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-tabulate/package.yml
+++ b/packages/py/python-tabulate/package.yml
@@ -17,8 +17,8 @@ builddeps  :
     - python-setuptools-scm
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/python-terminado/package.yml
+++ b/packages/py/python-terminado/package.yml
@@ -22,6 +22,6 @@ rundeps    :
     - ptyprocess
     - python-tornado
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-testpath/package.yml
+++ b/packages/py/python-testpath/package.yml
@@ -18,9 +18,9 @@ builddeps  :
     - python-pytest # check
     - python-wheel
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     # Remove windows stuff
     rm -f $installdir/usr/lib/python%python3_version%/site-packages/testpath/{cli-32.exe,cli-64.exe}

--- a/packages/py/python-text-unidecode/package.yml
+++ b/packages/py/python-text-unidecode/package.yml
@@ -19,8 +19,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/python-textdistance/package.yml
+++ b/packages/py/python-textdistance/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-three-merge/package.yml
+++ b/packages/py/python-three-merge/package.yml
@@ -20,9 +20,9 @@ checkdeps  :
 rundeps    :
     - python-diff-match-patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v
 

--- a/packages/py/python-toml/package.yml
+++ b/packages/py/python-toml/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-tomli-w/package.yml
+++ b/packages/py/python-tomli-w/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-packaging
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-toolz/package.yml
+++ b/packages/py/python-toolz/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest

--- a/packages/py/python-torchaudio/package.yml
+++ b/packages/py/python-torchaudio/package.yml
@@ -46,6 +46,6 @@ environment: |
 setup      : |
     echo "%version%" > version.txt
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-torchdata/package.yml
+++ b/packages/py/python-torchdata/package.yml
@@ -20,6 +20,6 @@ builddeps  :
 setup      : |
     echo "%version%" > version.txt
 build      : |
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-torchtext/package.yml
+++ b/packages/py/python-torchtext/package.yml
@@ -38,6 +38,6 @@ environment: |
 setup      : |
     echo "%version%" > version.txt
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-torchvision/package.yml
+++ b/packages/py/python-torchvision/package.yml
@@ -57,6 +57,6 @@ setup      : |
     %patch -p1 -i $pkgfiles/fix-build.patch
     echo "%version%" > version.txt
 build      : |
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-tornado/package.yml
+++ b/packages/py/python-tornado/package.yml
@@ -18,9 +18,9 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE
 #check      : |
 #    # https://github.com/tornadoweb/tornado/issues/2947

--- a/packages/py/python-tqdm/package.yml
+++ b/packages/py/python-tqdm/package.yml
@@ -23,9 +23,9 @@ checkdeps  :
     - python-rich
     - python3-tkinter
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # todo 3.12
 #check      : |
 #    %python3_test pytest -v

--- a/packages/py/python-trio-websocket/package.yml
+++ b/packages/py/python-trio-websocket/package.yml
@@ -18,6 +18,6 @@ rundeps    :
     - python-trio
     - python-wsproto
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-trove-classifiers/package.yml
+++ b/packages/py/python-trove-classifiers/package.yml
@@ -18,9 +18,9 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # todo 3.12
 #check      : |
 #    %python3_test pytest3 -v

--- a/packages/py/python-trustme/package.yml
+++ b/packages/py/python-trustme/package.yml
@@ -26,9 +26,9 @@ rundeps    :
     - python-cryptography
     - python-idna
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # needs networking
 #check      : |
   #    %python3_test pytest3

--- a/packages/py/python-truststore/package.yml
+++ b/packages/py/python-truststore/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-twisted/package.yml
+++ b/packages/py/python-twisted/package.yml
@@ -30,6 +30,6 @@ rundeps    :
     - python-typing-extensions
     - python-zope.interface
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-typer/package.yml
+++ b/packages/py/python-typer/package.yml
@@ -26,9 +26,9 @@ rundeps    :
     - python-rich
     - python-shellingham
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     # /usr/bin/typer conflicts with the erlang
     # package, so rename the binary here.

--- a/packages/py/python-types-markdown/package.yml
+++ b/packages/py/python-types-markdown/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-types-psutil/package.yml
+++ b/packages/py/python-types-psutil/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-types-pyyaml/package.yml
+++ b/packages/py/python-types-pyyaml/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-types-setuptools/package.yml
+++ b/packages/py/python-types-setuptools/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-typogrify/package.yml
+++ b/packages/py/python-typogrify/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 rundeps    :
     - python-smartypants
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-tzlocal/package.yml
+++ b/packages/py/python-tzlocal/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
 rundeps    :
     - python-pytz
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3

--- a/packages/py/python-uc-micro-py/package.yml
+++ b/packages/py/python-uc-micro-py/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-ujson/package.yml
+++ b/packages/py/python-ujson/package.yml
@@ -23,8 +23,8 @@ environment: |
     export UJSON_BUILD_DC_INCLUDES="/usr/include/double-conversion"
     export UJSON_BUILD_DC_LIBS="-ldouble-conversion"
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-unidecode/package.yml
+++ b/packages/py/python-unidecode/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-uritemplate/package.yml
+++ b/packages/py/python-uritemplate/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-urllib3/package.yml
+++ b/packages/py/python-urllib3/package.yml
@@ -32,9 +32,9 @@ setup      : |
     rm -rf test/contrib/
     rm -rf test/test_retry*
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE.txt
 # todo 3.12, shite takes forever or hangs idk
 #check      : |

--- a/packages/py/python-userpath/package.yml
+++ b/packages/py/python-userpath/package.yml
@@ -21,9 +21,9 @@ checkdeps  :
 rundeps    :
     - python-click
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # todo 3.12
 #check      : |
 #    %python3_test pytest -v

--- a/packages/py/python-vcversioner/package.yml
+++ b/packages/py/python-vcversioner/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-versioneer/package.yml
+++ b/packages/py/python-versioneer/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-waitress/package.yml
+++ b/packages/py/python-waitress/package.yml
@@ -17,8 +17,8 @@ builddeps  :
 checkdeps  :
     - python-pytest-cov
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest

--- a/packages/py/python-watchdog/package.yml
+++ b/packages/py/python-watchdog/package.yml
@@ -18,9 +18,9 @@ builddeps  :
   #    - python-pytest-cov
   #    - python-pytest-timeout
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
   #    %python3_test pytest3 \
   #        --deselect tests/test_inotify_buffer.py::test_unmount_watched_directory_filesystem

--- a/packages/py/python-wcwidth/package.yml
+++ b/packages/py/python-wcwidth/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest-cov
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-webencodings/package.yml
+++ b/packages/py/python-webencodings/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-websocket-client/package.yml
+++ b/packages/py/python-websocket-client/package.yml
@@ -18,9 +18,9 @@ builddeps  :
 rundeps    :
     - python-six
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     # remove tests that got installed into the buildroot
     rm -r $installdir/usr/lib/python%python3_version%/site-packages/websocket/tests/
 #check      : |

--- a/packages/py/python-werkzeug/package.yml
+++ b/packages/py/python-werkzeug/package.yml
@@ -24,9 +24,9 @@ rundeps    :
     - python-termcolor
     - python-watchdog
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #   # needs python-ephemeral-port-reserve and python-pytest-xprocess
 #   %python3_test pytest3 -k "not test_monkeypached_sleep"

--- a/packages/py/python-whatthepatch/package.yml
+++ b/packages/py/python-whatthepatch/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 checkdeps  :
     - python-pytest
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/python-whoosh/package.yml
+++ b/packages/py/python-whoosh/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-wsproto/package.yml
+++ b/packages/py/python-wsproto/package.yml
@@ -20,8 +20,8 @@ checkdeps  :
 rundeps    :
     - python-h11
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v

--- a/packages/py/python-wurlitzer/package.yml
+++ b/packages/py/python-wurlitzer/package.yml
@@ -18,9 +18,9 @@ checkdeps  :
     - python-mock
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test py.test3 test.py
 

--- a/packages/py/python-xattr/package.yml
+++ b/packages/py/python-xattr/package.yml
@@ -22,6 +22,6 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Fix-use-with-nuitka.patch
 build      : |
-    python3 -m build --wheel --no-isolation
+    %pyproject_build
 install    : |
-    python3 -m installer --destdir="$installdir" dist/*.whl
+    %pyproject_install

--- a/packages/py/python-xlib/package.yml
+++ b/packages/py/python-xlib/package.yml
@@ -21,6 +21,6 @@ rundeps    :
 setup      : |
     %patch -p1 -i ${pkgfiles}/0001-build-Migrate-from-pkg_resources-to-importlib.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-xmltodict/package.yml
+++ b/packages/py/python-xmltodict/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-yapsy/package.yml
+++ b/packages/py/python-yapsy/package.yml
@@ -18,8 +18,8 @@ builddeps  :
 setup      : |
     %patch -p2 -i $pkgfiles/remove-deprecated-apis.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test

--- a/packages/py/python-yarl/package.yml
+++ b/packages/py/python-yarl/package.yml
@@ -27,9 +27,9 @@ rundeps    :
     - python-multidict
     - python-propcache
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest -v -m "not hypothesis" \
         --ignore=tests/test_pydantic.py \

--- a/packages/py/python-zipp/package.yml
+++ b/packages/py/python-zipp/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 rundeps    :
     - python-more-itertools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-zope.component/package.yml
+++ b/packages/py/python-zope.component/package.yml
@@ -22,6 +22,6 @@ rundeps    :
     - python-zope.event
     - python-zope.hookable
 build      : |
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-zope.deferredimport/package.yml
+++ b/packages/py/python-zope.deferredimport/package.yml
@@ -19,6 +19,6 @@ rundeps    :
     - python-zope.proxy
 build      : |
     # skip dep check for setuptools 82.0, remove on update
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-zope.deprecation/package.yml
+++ b/packages/py/python-zope.deprecation/package.yml
@@ -17,8 +17,8 @@ builddeps  :
     - python-wheel
 build      : |
     # skip dep check for setuptools 82.0, remove on update
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install
 
     rm -f $installdir/usr/lib/python*/site-packages/zope/deprecation/tests.py*

--- a/packages/py/python-zope.event/package.yml
+++ b/packages/py/python-zope.event/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-wheel
 build      : |
     # skip dep check for setuptools 82.0, remove on update
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-zope.exceptions/package.yml
+++ b/packages/py/python-zope.exceptions/package.yml
@@ -18,6 +18,6 @@ builddeps  :
     - python-wheel
 build      : |
     # skip dep check for setuptools 82.0, remove on update
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-zope.hookable/package.yml
+++ b/packages/py/python-zope.hookable/package.yml
@@ -22,8 +22,8 @@ checkdeps  :
     - python-zope.testing
     - python-zope.testrunner
 build      : |
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest --pyargs zope.hookable -v

--- a/packages/py/python-zope.interface/package.yml
+++ b/packages/py/python-zope.interface/package.yml
@@ -21,8 +21,8 @@ builddeps  :
   #    - python-pytest
   #    - python-zope.testing
 build      : |
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
   #    %python3_test pytest

--- a/packages/py/python-zope.proxy/package.yml
+++ b/packages/py/python-zope.proxy/package.yml
@@ -19,6 +19,6 @@ rundeps    :
     - python-zope.interface
 build      : |
     # harsh setuptools limiter
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-zope.testing/package.yml
+++ b/packages/py/python-zope.testing/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-zope.testrunner/package.yml
+++ b/packages/py/python-zope.testrunner/package.yml
@@ -20,8 +20,8 @@ rundeps    :
     - python-zope.exceptions
     - python-zope.interface
 build      : |
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install
 
     rm -frv $installdir/usr/lib/python%python3_version%/site-packages/zope/testrunner/tests

--- a/packages/py/python-zstandard/package.yml
+++ b/packages/py/python-zstandard/package.yml
@@ -17,6 +17,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 setup      : |
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-zstd/package.yml
+++ b/packages/py/python-zstd/package.yml
@@ -21,8 +21,8 @@ checkdeps  :
 environment: |
     export ZSTD_EXTERNAL=1
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest3 -v

--- a/packages/py/pytorch/package.yml
+++ b/packages/py/pytorch/package.yml
@@ -226,9 +226,9 @@ setup      : |
 
     python3 ./tools/amd_build/build_amd.py
 build      : |
-    %python3_setup --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    %python3_install
+    %pyproject_install
 
     # Configure libtorch
     install -dm00755 $installdir/%libdir%

--- a/packages/py/pyxdg/package.yml
+++ b/packages/py/pyxdg/package.yml
@@ -16,6 +16,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/pyyaml/package.yml
+++ b/packages/py/pyyaml/package.yml
@@ -20,8 +20,8 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # check      : |
 #     %python3_test

--- a/packages/q/quodlibet/package.yml
+++ b/packages/q/quodlibet/package.yml
@@ -27,7 +27,7 @@ rundeps    :
     - python3-dbus
     - rygel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license COPYING

--- a/packages/r/rdflib/package.yml
+++ b/packages/r/rdflib/package.yml
@@ -23,9 +23,9 @@ rundeps    :
     - python-html5lib # optional
     - python-isodate
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 networking : true # check
 check      : |
     %python3_test pytest -v --deselect test/test_misc/test_plugins.py

--- a/packages/r/rednotebook/package.yml
+++ b/packages/r/rednotebook/package.yml
@@ -20,6 +20,6 @@ rundeps    :
     - pyenchant
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/r/retext/package.yml
+++ b/packages/r/retext/package.yml
@@ -30,9 +30,9 @@ rundeps    :
     - python-docutils
     - python-pyqt6-webengine
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     install -Dm00644 data/me.mitya57.ReText.desktop $installdir/usr/share/applications/data/me.mitya57.ReText.desktop
 check      : |

--- a/packages/r/reuse/package.yml
+++ b/packages/r/reuse/package.yml
@@ -50,14 +50,14 @@ checkdeps  :
     - python-pytest
     - python-tomlkit
 build      : |
-    %python3_setup
+    %pyproject_build
 
     pushd docs
     PBR_VERSION=${version} sphinx-build -b man . manpages
     rm -rf man/.{doctrees,buildinfo}
     popd
 install    : |
-    %python3_install
+    %pyproject_install
 
     install -Dm00644 -t ${installdir}/usr/share/man/man1/ docs/manpages/*.1
 

--- a/packages/r/ruamel-yaml-clib/package.yml
+++ b/packages/r/ruamel-yaml-clib/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 environment: |
     export CFLAGS="${CFLAGS} -Wno-incompatible-pointer-types"
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/s/s-tui/package.yml
+++ b/packages/s/s-tui/package.yml
@@ -22,7 +22,7 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/use-zenergy.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE

--- a/packages/s/safeeyes/package.yml
+++ b/packages/s/safeeyes/package.yml
@@ -26,9 +26,9 @@ rundeps    :
     - python-xlib
     - xprintidle
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE
 
     install -Dm00644 safeeyes/platform/io.github.slgobinath.SafeEyes.desktop -t ${installdir}/usr/share/applications

--- a/packages/s/scikit-image/package.yml
+++ b/packages/s/scikit-image/package.yml
@@ -32,6 +32,6 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/0001-use-python3-in-env.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/s/scikit-learn/package.yml
+++ b/packages/s/scikit-learn/package.yml
@@ -27,6 +27,6 @@ rundeps    :
     - python-threadpoolctl
     - scipy
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/s/scipy/package.yml
+++ b/packages/s/scipy/package.yml
@@ -39,7 +39,6 @@ setup      : |
     sed -e 's|lapack=openblas|lapack=lapack|' -i meson.build
     sed -e 's|==|>=|g' -e 's|\,<[0-9]*\(.[0-9]\)*||g' -i pyproject.toml
 build      : |
-    # we can't append --skip-dependency-check to our macros
-    python3 -m build --wheel --no-isolation --skip-dependency-check
+    %pyproject_build --skip-dependency-check
 install    : |
-    python3 -m installer --destdir="$installdir" dist/*.whl
+    %pyproject_install

--- a/packages/s/scons/package.yml
+++ b/packages/s/scons/package.yml
@@ -16,9 +16,9 @@ builddeps  :
     - python-setuptools
     - python-wheel
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     install -Dm00644 *.1 -t $installdir/usr/share/man/man1
 #check      : |

--- a/packages/s/screenkey/package.yml
+++ b/packages/s/screenkey/package.yml
@@ -22,7 +22,7 @@ rundeps    :
     - python3-dbus
     - slop
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     rm -rf $installdir/usr/share/doc

--- a/packages/s/solaar/package.yml
+++ b/packages/s/solaar/package.yml
@@ -25,8 +25,8 @@ rundeps    :
     - python-xlib
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     install -D -m 00644 rules.d/42-logitech-unify-permissions.rules $installdir/usr/lib64/udev/rules.d/42-logitech-unify-permissions.rules
     %install_license LICENSE.txt

--- a/packages/s/speedtest-cli/package.yml
+++ b/packages/s/speedtest-cli/package.yml
@@ -17,6 +17,6 @@ builddeps  :
 setup      : |
     %patch -p1 -i $pkgfiles/default-to-https.patch
     %patch -p1 -i $pkgfiles/reorder-servers.patch
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/s/spyder3/package.yml
+++ b/packages/s/spyder3/package.yml
@@ -71,9 +71,9 @@ setup      : |
 build      : |
     export SPYDER_QT_BINDING=pyqt6
     export QT_API=pyqt6
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     # Upstream installs spyder.png to /usr/share/icons (not a theme path)
     rm -rf ${installdir}/usr/share/icons

--- a/packages/s/streamlink/package.yml
+++ b/packages/s/streamlink/package.yml
@@ -47,9 +47,9 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/remove-pytest-minversion.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 # TODO 3.14
 #check      : |
 #    %python3_test pytest3

--- a/packages/s/subliminal/package.yml
+++ b/packages/s/subliminal/package.yml
@@ -29,6 +29,6 @@ rundeps    :
     - python-stevedore
 build      : |
     %patch -p1 -i $pkgfiles/0001-Change-from-pysrt-to-srt.patch
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -21,6 +21,6 @@ rundeps    :
     - python-requests
     - pyyaml
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/s/sympy/package.yml
+++ b/packages/s/sympy/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 rundeps    :
     - python-mpmath
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/t/thefuck/package.yml
+++ b/packages/t/thefuck/package.yml
@@ -37,9 +37,9 @@ setup      : |
     %patch -p1 -i ${pkgfiles}/thefuck-3.32-pytest-9.patch
     %patch -p1 -i ${pkgfiles}/thefuck-3.32-replace-pkg_resources.patch
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     install -Dm00755 $pkgfiles/thefuck.sh $installdir/usr/share/defaults/etc/profile.d/thefuck.sh
 check      : |
     # Don't fail due to permission errors trying to test config in /root.

--- a/packages/t/tmuxp/package.yml
+++ b/packages/t/tmuxp/package.yml
@@ -29,13 +29,13 @@ checkdeps  :
     - python-pytest-mock
     - python-pytest-rerunfailures
 build      : |
-    %python3_setup
+    %pyproject_build
 
     mkdir completions
     shtab --shell=bash tmuxp.cli.create_parser > completions/tmuxp
     shtab --shell=zsh tmuxp.cli.create_parser > completions/_tmuxp
 install    : |
-    %python3_install
+    %pyproject_install
 
     install -Dm00644 -t ${installdir}/usr/share/bash-completion/completions/ completions/tmuxp
     install -Dm00644 -t ${installdir}/usr/share/zsh/site-functions/ completions/_tmuxp

--- a/packages/t/tortoisehg/package.yml
+++ b/packages/t/tortoisehg/package.yml
@@ -23,9 +23,9 @@ rundeps    :
 setup      : |
     sed -i "s|#!/usr/bin/env python|&3|" thg
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     install -Dm00644 icons/scalable/apps/thg.svg $installdir/usr/share/icons/hicolor/scalable/apps/thg.svg
 

--- a/packages/t/trackma/package.yml
+++ b/packages/t/trackma/package.yml
@@ -27,8 +27,8 @@ rundeps    :
     - python3-qt5 # for Qt5 interface
     - python3-urwid # for Curses interface
 setup      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     install -Dm00644 $pkgfiles/trackma-gtk.desktop $installdir/usr/share/applications/trackma-gtk.desktop
     install -Dm00644 $pkgfiles/trackma-qt.desktop $installdir/usr/share/applications/trackma-qt.desktop

--- a/packages/t/trelby/package.yml
+++ b/packages/t/trelby/package.yml
@@ -20,9 +20,9 @@ rundeps    :
     - python-reportlab
     - wxPython
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     install -Dm00644 trelby/resources/trelby.desktop $installdir/usr/share/applications/trelby.desktop
     install -Dm00644 trelby/resources/icon256.png $installdir/usr/share/icons/hicolor/256x256/apps/trelby.png
     install -Dm00644 $pkgfiles/org.trelby.Trelby.metainfo.xml -t $installdir/usr/share/metainfo

--- a/packages/t/types-python-dateutil/package.yml
+++ b/packages/t/types-python-dateutil/package.yml
@@ -15,6 +15,6 @@ builddeps  :
     - python-installer
     - python-setuptools
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/u/ulauncher/package.yml
+++ b/packages/u/ulauncher/package.yml
@@ -26,9 +26,9 @@ rundeps    :
     - python3-dbus
     - pyxdg
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     # We don't have wmctrl because it is DOA
     rm -f $installdir/usr/bin/ulauncher-toggle

--- a/packages/u/urlscan/package.yml
+++ b/packages/u/urlscan/package.yml
@@ -19,6 +19,6 @@ builddeps  :
 rundeps    :
     - python3-urwid
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/v/variety/package.yml
+++ b/packages/v/variety/package.yml
@@ -33,9 +33,9 @@ rundeps    :
     - python3-dbus
     - xdg-user-dirs
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     # setuptools no longer installs the desktop entry or theme icons
     install -Dm00644 variety.desktop -t ${installdir}/usr/share/applications/
     install -Dm00644 variety/data/icons/scalable/apps/variety.svg -t ${installdir}/usr/share/icons/hicolor/scalable/apps/

--- a/packages/v/veusz/package.yml
+++ b/packages/v/veusz/package.yml
@@ -24,9 +24,9 @@ rundeps    :
     - numpy
     - python-qt6
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license COPYING
 
     install -Dm00644 support/veusz.desktop $installdir/usr/share/applications/veusz.desktop

--- a/packages/v/virtualenv-clone/package.yml
+++ b/packages/v/virtualenv-clone/package.yml
@@ -20,9 +20,9 @@ checkdeps  :
 rundeps    :
     - python3
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 #check      : |
 #    sed -i -e '$a[tox:tox]' setup.cfg
 #    %python3_test

--- a/packages/v/virtualenvwrapper/package.yml
+++ b/packages/v/virtualenvwrapper/package.yml
@@ -21,6 +21,6 @@ rundeps    :
     - virtualenv
     - virtualenv-clone
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/v/vorta/package.yml
+++ b/packages/v/vorta/package.yml
@@ -27,9 +27,9 @@ rundeps    :
     - python-qt6
     - python-secretstorage
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     %install_license LICENSE.txt
 
     # Install desktop file, appstream metainfo and app icons

--- a/packages/w/woeusb/package.yml
+++ b/packages/w/woeusb/package.yml
@@ -27,9 +27,9 @@ setup      : |
     %patch -p1 -i $pkgfiles/pep517.patch
     rm setup.py
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     install -Dm00644 src/WoeUSB/data/woeusb-logo.png $installdir/usr/share/icons/hicolor/256x256/apps/woeusb-logo.png
     install -Dm00644 miscellaneous/WoeUSB-ng.desktop $installdir/usr/share/applications/WoeUSB-ng.desktop

--- a/packages/x/xkcdpass/package.yml
+++ b/packages/x/xkcdpass/package.yml
@@ -16,9 +16,9 @@ builddeps  :
 checkdeps  :
     - python-pytest
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
     install -Dm00644 xkcdpass.1  $installdir/usr/share/man/man1/xkcdpass.1
 check      : |
     # Wordlist test is currently broken

--- a/packages/y/yapf/package.yml
+++ b/packages/y/yapf/package.yml
@@ -21,8 +21,8 @@ checkdeps  :
 rundeps    :
     - python-platformdirs
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 check      : |
     %python3_test pytest

--- a/packages/y/yewtube/package.yml
+++ b/packages/y/yewtube/package.yml
@@ -25,9 +25,9 @@ rundeps    :
     - youtube-search-python
     - yt-dlp
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install
 
     # Replace auto-installed yt script witht the one that actually works
     install -m 0755 yt $installdir/usr/bin/yt

--- a/packages/y/yt-dlp-ejs/package.yml
+++ b/packages/y/yt-dlp-ejs/package.yml
@@ -19,6 +19,6 @@ builddeps  :
     - python-hatchling
     - python-installer
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/y/yt-dlp/package.yml
+++ b/packages/y/yt-dlp/package.yml
@@ -29,9 +29,9 @@ rundeps    :
     - yt-dlp-ejs
 build      : |
     %make PREFIX=$installdir/usr yt-dlp.1 completion-bash completion-fish completion-zsh
-    python3 -m build --wheel --no-isolation
+    %pyproject_build
 install    : |
-    python3 -m installer --destdir="$installdir" dist/*.whl
+    %pyproject_install
     rm -rf $installdir/usr/share/doc
     ln -s /usr/bin/yt-dlp $installdir/usr/bin/youtube-dl
     ln -s /usr/bin/yt-dlp $installdir/usr/bin/yt-dlc

--- a/packages/y/yubikey-manager/package.yml
+++ b/packages/y/yubikey-manager/package.yml
@@ -28,7 +28,7 @@ rundeps    :
     - python-openssl
     - python-pyscard
 build      : |
-    %python3_setup
+    %pyproject_build
 
     # Create shell completions
     python -m venv --system-site-packages completion-env
@@ -36,7 +36,7 @@ build      : |
     _YKMAN_COMPLETE=bash_source completion-env/bin/ykman > ykman.bash
     _YKMAN_COMPLETE=zsh_source completion-env/bin/ykman > _ykman
 install    : |
-    %python3_install
+    %pyproject_install
 
     install -Dm00644 -t ${installdir}/%libdir%/systemd/service-preset/ ${pkgfiles}/20-yubikey-manager.preset
 

--- a/packages/z/zxing-cpp/package.yml
+++ b/packages/z/zxing-cpp/package.yml
@@ -43,13 +43,13 @@ build      : |
 
     pushd wrappers/python
     export VERBOSE=1
-    %python3_setup
+    %pyproject_build
     popd
 install    : |
     %ninja_install
 
     pushd wrappers/python
-    %python3_install
+    %pyproject_install
     popd
 
     # Substitute the python shared library built by pyproject which is statically linked with the shared one built by cmake


### PR DESCRIPTION
**Summary**
Instead of using dual-case python3_{setup,install} macros for both legacy style .egg-info setuptools installation and modern .dist-info wheel installation. Use pyproject_{build,install} macros when .dist-info is present in the pspec.

The only mixed case package found was nemo-extensions which was manually handled.

This will allow us to update the macros in ypkg to avoid having python3_{setup,install} dual casing the macros which causes various headaches over the years.

**Test Plan**

Build a mixture of .egg-info and .dist-info packages manually, build nemo-extensions to ensure the manifests didn't change.

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [ ] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
