### PR TITLE
keychain: Update to 3.0.4

### DIFF
--- a/packages/k/keychain/package.yml
+++ b/packages/k/keychain/package.yml
@@ -1,15 +1,29 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : keychain
-version    : 2.8.5
-release    : 3
+version    : 3.0.4
+release    : 4
 source     :
-    - https://github.com/funtoo/keychain/archive/2.8.5.tar.gz : dcce703e5001211c8ebc0528f45b523f84d2bceeb240600795b4d80cb8475a0b
-homepage   : https://www.funtoo.org/Keychain
-license    : GPL-2.0-or-later
+    - https://github.com/danielrobbins/keychain/archive/refs/tags/3.0.4.tar.gz : e38da6a078d187de13615fafb878167fd1fa1c4c9c466e100ead1981be5f12b7
+homepage   : https://kernel-seeds.org/projects/keychain/
+license    : GPL-3.0-or-later
 component  : network.util
 summary    : agent manager for ssh and gnupg
 description: |
     Helps you to manage ssh and GPG keys in a convenient and secure manner. It acts as a frontend to ssh-agent and ssh-add, but allows you to easily have one long running ssh-agent process per system, rather than the norm of one ssh-agent per login session.
+builddeps  :
+    - python-build
+    - python-installer
+    - python-packaging
+    - python-setuptools
+    - python-wheel
+rundeps    :
+    - python3
+checkdeps  :
+    - openssh
+    - python-pytest
+build      : |
+    %pyproject_build
 install    : |
-    install -Dm00775 keychain -t $installdir/usr/bin
-    install -Dm00664 keychain.1 -t $installdir/usr/share/man/man1
+    %pyproject_install
+check      : |
+    %pytest

--- a/packages/k/keychain/pspec_x86_64.xml
+++ b/packages/k/keychain/pspec_x86_64.xml
@@ -1,12 +1,12 @@
 <PISI>
     <Source>
         <Name>keychain</Name>
-        <Homepage>https://www.funtoo.org/Keychain</Homepage>
+        <Homepage>https://kernel-seeds.org/projects/keychain/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
-        <License>GPL-2.0-or-later</License>
+        <License>GPL-3.0-or-later</License>
         <PartOf>network.util</PartOf>
         <Summary xml:lang="en">agent manager for ssh and gnupg</Summary>
         <Description xml:lang="en">Helps you to manage ssh and GPG keys in a convenient and secure manner. It acts as a frontend to ssh-agent and ssh-add, but allows you to easily have one long running ssh-agent process per system, rather than the norm of one ssh-agent per login session.
@@ -21,16 +21,82 @@
         <PartOf>network.util</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/keychain</Path>
-            <Path fileType="man">/usr/share/man/man1/keychain.1.zst</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain-3.0.4.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain-3.0.4.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain-3.0.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain-3.0.4.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain-3.0.4.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain-3.0.4.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__main__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/__main__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/__main__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/agents.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/agents.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/coordination.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/coordination.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/env.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/env.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/keys.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/keys.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/main.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/main.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/paths.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/paths.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/state.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/state.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/util.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/__pycache__/util.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/agents.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/coordination.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/docs/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/docs/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/docs/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/docs/_doc_texts.json</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/env.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/keys.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/main.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/__pycache__/core.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/__pycache__/core.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/__pycache__/inspect.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/__pycache__/inspect.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/__pycache__/tables.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/__pycache__/tables.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/core.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/inspect.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/output/tables.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/paths.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/__pycache__/actions.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/__pycache__/actions.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/__pycache__/compat.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/__pycache__/compat.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/__pycache__/config.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/__pycache__/config.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/__pycache__/platform.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/__pycache__/platform.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/actions.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/compat.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/config.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/runtime/platform.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/state.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/keychain/util.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2025-09-10</Date>
-            <Version>2.8.5</Version>
+        <Update release="4">
+            <Date>2026-09-02</Date>
+            <Version>3.0.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Catch up to current
- New homepage and repo
- Add License
- Updated package for new python base
- Added pytest
- [Change Log](https://github.com/danielrobbins/keychain/releases?page=1#release-3.0.4)

This is a major change from the previous version, but as stated on the [read me](https://github.com/danielrobbins/keychain#upgrading-from-keychain-2x)
it is backwards compatible from the 2.x version.

**Test Plan**
- Pass test suite
- Check version
- Verify environment
- Generate test tempporary key `ssh-keygen -t ed25519 -f ~/.ssh/test_key -N ""`
- Add it using keychain `keychain ~/.ssh/test_key`
- Verify it added

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
