### PR TITLE
python-poetry: Update to 2.4.2

### DIFF
--- a/packages/py/python-poetry/package.yml
+++ b/packages/py/python-poetry/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-poetry
-version    : 2.4.1
-release    : 21
+version    : 2.4.2
+release    : 22
 source     :
     # The bootstrap source needs to be from pypi as it's the only source with a setup.py
-    - https://files.pythonhosted.org/packages/source/p/poetry/poetry-2.4.1.tar.gz : 189399b80347ecf908244b2564a7b1d92b648fa1fe2a204888f94a472fec0cac
+    - https://files.pythonhosted.org/packages/source/p/poetry/poetry-2.4.2.tar.gz : e547fa69196fc109ee0900e233222732b08b8732c4345252a34d68968c0498f2
 homepage   : https://python-poetry.org/
 license    : MIT
 component  : programming.python
@@ -40,6 +40,6 @@ rundeps    :
     - python-trove-classifiers
     - virtualenv
 build      : |
-    %python3_setup
+    %pyproject_build
 install    : |
-    %python3_install
+    %pyproject_install

--- a/packages/py/python-poetry/pspec_x86_64.xml
+++ b/packages/py/python-poetry/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-poetry</Name>
         <Homepage>https://python-poetry.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -21,11 +21,11 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/poetry</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/poetry-2.4.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/poetry-2.4.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/poetry-2.4.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/poetry-2.4.1.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/poetry-2.4.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/poetry-2.4.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/poetry-2.4.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/poetry-2.4.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/poetry-2.4.2.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/poetry-2.4.2.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/poetry/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/poetry/__pycache__/__main__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/poetry/__pycache__/__main__.cpython-314.pyc</Path>
@@ -604,12 +604,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2026-06-05</Date>
-            <Version>2.4.1</Version>
+        <Update release="22">
+            <Date>2026-09-03</Date>
+            <Version>2.4.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security
- [Change Log](https://github.com/python-poetry/poetry/releases/tag/2.4.2)

**Security**
- No CVE yet. Fixes a vulnerability when downloading files from a compromised URL or package source.

**Test Plan**
- `poetry new poetry-test` verify directory
- Verify successfully generated build artifacts

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
