### PR TITLE
common/Scripts/yauto.py: Suggest newer macros for new packages

### DIFF
--- a/common/Scripts/yauto.py
+++ b/common/Scripts/yauto.py
@@ -360,12 +360,12 @@ description: |
                 setup = "%configure --disable-static"
             elif self.compile_type == CMAKE:
                 setup = "%cmake_ninja"
-                build = "%ninja_build"
-                install = "%ninja_install"
+                build = "%cmake_build"
+                install = "%cmake_install"
             elif self.compile_type == MESON:
                 setup = "%meson_configure"
-                build = "%ninja_build"
-                install = "%ninja_install"
+                build = "%meson_build"
+                install = "%meson_install"
             elif self.compile_type == PYTHON_MODULES:
                 setup = ""
                 build = "%python3_setup"


### PR DESCRIPTION
**Summary**

`go-task new` uses yauto to guess the build system of a new package and template in some macros. Suggest new macros for cmake and meson.

**Test Plan**

- Start a new meson package, get meson macros

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
