### PR TITLE
libde265: Update to v1.1.2

### DIFF
--- a/packages/l/libde265/package.yml
+++ b/packages/l/libde265/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libde265
-version    : 1.1.1
-release    : 17
+version    : 1.1.2
+release    : 18
 source     :
-    - https://github.com/strukturag/libde265/releases/download/v1.1.1/libde265-1.1.1.tar.gz : fd48a927e94ed74fc7ce8829d222b9d8599fcbfe8b6448ba66705babc56ab219
+    - https://github.com/strukturag/libde265/releases/download/v1.1.2/libde265-1.1.2.tar.gz : eaacd1943ab0c452c19f6136a36ca227e6b761b39a81eaca8454d48c147e1f67
 homepage   : https://www.libde265.org/
 license    : LGPL-3.0-or-later
 component  : multimedia.codecs

--- a/packages/l/libde265/pspec_x86_64.xml
+++ b/packages/l/libde265/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libde265</Name>
         <Homepage>https://www.libde265.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>multimedia.codecs</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>multimedia.codecs</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libde265.so.0</Path>
-            <Path fileType="library">/usr/lib64/libde265.so.0.2.1</Path>
+            <Path fileType="library">/usr/lib64/libde265.so.0.2.2</Path>
             <Path fileType="data">/usr/share/licenses/libde265/COPYING</Path>
         </Files>
     </Package>
@@ -32,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="17">libde265</Dependency>
+            <Dependency release="18">libde265</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libde265/de265-version.h</Path>
@@ -45,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2026-06-17</Date>
-            <Version>1.1.1</Version>
+        <Update release="18">
+            <Date>2026-09-04</Date>
+            <Version>1.1.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/strukturag/libde265/releases/tag/v1.1.2).

**Security**
- GHSA-xp3h-6f5r-8cxp
- GHSA-mm7m-v26f-wf8x

**Test Plan**

Rebuild libheif against this version, saw no symbol changes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
