### PR TITLE
podman: Update to v6.1.1

### DIFF
--- a/packages/p/podman/package.yml
+++ b/packages/p/podman/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : podman
-version    : 6.1.0
-release    : 52
+version    : 6.1.1
+release    : 53
 source     :
-    - https://github.com/containers/podman/archive/refs/tags/v6.1.0.tar.gz : e086183db2f852476a7fa2580d0276cef32086b4cf17ae7020948f06eb613e0d
+    - https://github.com/containers/podman/archive/refs/tags/v6.1.1.tar.gz : 3646384ab6eff7b3d4473e1a0c1e34b6a8001e5a89600af44cc12376da77bccc
     - https://github.com/openSUSE/catatonit/releases/download/v0.2.1/catatonit.tar.xz#catatonit.tar.gz : 9950425501af862e12f618bdc930ea755c46db6a16072a1462b4fc93b2bd59bc
 homepage   : https://podman.io/
 license    :

--- a/packages/p/podman/pspec_x86_64.xml
+++ b/packages/p/podman/pspec_x86_64.xml
@@ -305,9 +305,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2026-08-14</Date>
-            <Version>6.1.0</Version>
+        <Update release="53">
+            <Date>2026-09-04</Date>
+            <Version>6.1.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/podman-container-tools/podman/releases).

**Security**
- CVE-2026-17106

**Test Plan**

Run podman

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
