### PR TITLE
imagemagick: Update to v7.1.2.31

### DIFF
--- a/packages/i/imagemagick/abi_symbols
+++ b/packages/i/imagemagick/abi_symbols
@@ -3357,6 +3357,7 @@ libMagickCore-7.Q16HDRI.so.10:RegisterBAYERImage
 libMagickCore-7.Q16HDRI.so.10:RegisterBGRImage
 libMagickCore-7.Q16HDRI.so.10:RegisterBMPImage
 libMagickCore-7.Q16HDRI.so.10:RegisterBRAILLEImage
+libMagickCore-7.Q16HDRI.so.10:RegisterC2PAImage
 libMagickCore-7.Q16HDRI.so.10:RegisterCALSImage
 libMagickCore-7.Q16HDRI.so.10:RegisterCAPTIONImage
 libMagickCore-7.Q16HDRI.so.10:RegisterCINImage
@@ -3717,6 +3718,7 @@ libMagickCore-7.Q16HDRI.so.10:UnregisterBAYERImage
 libMagickCore-7.Q16HDRI.so.10:UnregisterBGRImage
 libMagickCore-7.Q16HDRI.so.10:UnregisterBMPImage
 libMagickCore-7.Q16HDRI.so.10:UnregisterBRAILLEImage
+libMagickCore-7.Q16HDRI.so.10:UnregisterC2PAImage
 libMagickCore-7.Q16HDRI.so.10:UnregisterCALSImage
 libMagickCore-7.Q16HDRI.so.10:UnregisterCAPTIONImage
 libMagickCore-7.Q16HDRI.so.10:UnregisterCINImage

--- a/packages/i/imagemagick/abi_used_symbols
+++ b/packages/i/imagemagick/abi_used_symbols
@@ -286,7 +286,6 @@ libc.so.6:fread
 libc.so.6:free
 libc.so.6:freeaddrinfo
 libc.so.6:freelocale
-libc.so.6:fseek
 libc.so.6:fseeko
 libc.so.6:fstat
 libc.so.6:fsync

--- a/packages/i/imagemagick/package.yml
+++ b/packages/i/imagemagick/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : imagemagick
-version    : 7.1.2.30
-release    : 225
+version    : 7.1.2.31
+release    : 226
 source     :
-    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-30.tar.gz : 3034a64f22398e15ee3dd1e6b1aa83d838cfc47df1bb246ae0eca9590e6ace72
+    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-31.tar.gz : 34d9cc3acddc3e3c429d23af60eda5ceaac477a8b296ddb9469f773f44a80a5f
 homepage   : https://imagemagick.org/
 license    : Apache-2.0
 component  : multimedia.graphics
@@ -47,10 +47,10 @@ build      : |
 install    : |
     %make_install
     %install_license LICENSE
-    install -dm00755 $installdir/usr/share/defaults
-    mv $installdir/etc/ImageMagick-7 $installdir/usr/share/defaults
-    rm -rvf "$installdir/%perl_privlib%"
-    rmdir $installdir/etc
+    %install_dir ${installdir}/usr/share/defaults
+    mv ${installdir}/etc/ImageMagick-7 ${installdir}/usr/share/defaults
+    rm -rvf "${installdir}/%perl_privlib%"
+    rmdir ${installdir}/etc
 patterns   :
     - docs :
         - /usr/share/doc

--- a/packages/i/imagemagick/pspec_x86_64.xml
+++ b/packages/i/imagemagick/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>imagemagick</Name>
         <Homepage>https://imagemagick.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -94,7 +94,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="225">imagemagick</Dependency>
+            <Dependency release="226">imagemagick</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ImageMagick-7/Magick++.h</Path>
@@ -460,12 +460,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="225">
-            <Date>2026-08-25</Date>
-            <Version>7.1.2.30</Version>
+        <Update release="226">
+            <Date>2026-09-04</Date>
+            <Version>7.1.2.31</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://imagemagick.org/changelog/#gsc.tab=0).

**Security**
Includes fixes for:
- GHSA-4gg2-hfgh-6f5c
- GHSA-7hjx-392p-f8cm
- GHSA-r868-pmwh-fv2c
- GHSA-vcjj-32hg-qpx5
- GHSA-6xf5-c3jx-rp39
- GHSA-5rg6-j44q-q892
- GHSA-4fq9-vrx7-gv92
- GHSA-2w4h-697j-4vrm
- GHSA-qr53-hc3p-fc62
- GHSA-v45j-x8p4-3mh4
- GHSA-89wq-f8f6-2j2v
- GHSA-92rw-c5mw-27v4
- GHSA-3rjr-534c-8v67
- GHSA-jvjm-9f73-fhpq
- GHSA-p6j5-2qwh-6486

**Test Plan**

`magick identify example.png`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
