### PR TITLE
rio: Update to v0.5.27

### DIFF
--- a/packages/r/rio/abi_used_symbols
+++ b/packages/r/rio/abi_used_symbols
@@ -66,6 +66,7 @@ libc.so.6:_exit
 libc.so.6:abort
 libc.so.6:bcmp
 libc.so.6:calloc
+libc.so.6:cfsetspeed
 libc.so.6:chdir
 libc.so.6:chroot
 libc.so.6:clock_gettime
@@ -318,6 +319,7 @@ libonig.so.5:onig_new_match_param
 libonig.so.5:onig_region_clear
 libonig.so.5:onig_region_free
 libonig.so.5:onig_search_with_param
+libonig.so.5:onig_set_retry_limit_in_search_of_match_param
 libstdc++.so.6:_ZNKSt10filesystem7__cxx114path5_List13_Impl_deleterclEPNS2_5_ImplE
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12find_last_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm

--- a/packages/r/rio/package.yml
+++ b/packages/r/rio/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : rio
-version    : 0.5.25
-release    : 13
+version    : 0.5.27
+release    : 14
 source     :
-    - https://github.com/raphamorim/rio/archive/refs/tags/v0.5.25.tar.gz : 4e6c3c412e8db1e8d7db3bb043a39afc2fd78091ab30ce4c6d264f96c25a5d60
+    - https://github.com/raphamorim/rio/archive/refs/tags/v0.5.27.tar.gz : 860cb019a4f6a87bffb786ac2408f51f7c7f09551be234355fb3fd4feeac5331
 homepage   : https://rioterm.com
 license    : MIT
 component  : system.utils

--- a/packages/r/rio/pspec_x86_64.xml
+++ b/packages/r/rio/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-08-21</Date>
-            <Version>0.5.25</Version>
+        <Update release="14">
+            <Date>2026-09-04</Date>
+            <Version>0.5.27</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/raphamorim/rio/releases/tag/v0.5.27).

**Test Plan**

Open rio

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
