### PR TITLE
containerd: Update to v2.3.5

### DIFF
--- a/packages/c/containerd/package.yml
+++ b/packages/c/containerd/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : containerd
-version    : 2.3.4
-release    : 76
+version    : 2.3.5
+release    : 77
 source     :
-    - https://github.com/containerd/containerd/archive/refs/tags/v2.3.4.tar.gz : 175bbf57d637c987fa742f846b43b1b8ba2c61af6a9eaec619c625e4a8a19b69
+    - https://github.com/containerd/containerd/archive/refs/tags/v2.3.5.tar.gz : a99a4dca98061064ff4cb35d27d1ec2345717e9108c822329fcec91dc72bff96
 homepage   : https://containerd.io/
 license    : Apache-2.0
 component  : virt

--- a/packages/c/containerd/pspec_x86_64.xml
+++ b/packages/c/containerd/pspec_x86_64.xml
@@ -36,9 +36,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="76">
-            <Date>2026-08-14</Date>
-            <Version>2.3.4</Version>
+        <Update release="77">
+            <Date>2026-09-04</Date>
+            <Version>2.3.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/containerd/containerd/releases/tag/v2.3.5).

**Security**
Includes fixes for:
- CVE-2026-53495
- GHSA-rp3h-jf77-q9p4

**Test Plan**

docker works

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
