### PR TITLE
uv: update to 0.12.10

### DIFF
--- a/packages/u/uv/abi_used_symbols
+++ b/packages/u/uv/abi_used_symbols
@@ -216,5 +216,4 @@ libgcc_s.so.1:_Unwind_GetTextRelBase
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
-libm.so.6:log2f
 libm.so.6:pow

--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -2,10 +2,10 @@
 #
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : uv
-version    : 0.12.3
-release    : 20
+version    : 0.12.10
+release    : 21
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.12.3.tar.gz : 7d95d35a941135b96cc344c63b8da427d456900f58621481b909eac00904db7f
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.12.10.tar.gz : 92f0f678f111cb34535fcdfffe98ecc75c98f1e34908cc1f80f4c213fbcb537c
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -38,15 +38,15 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="20">uv</Dependency>
+            <Dependency releaseFrom="21">uv</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/licenses/LICENSE-MIT</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.3.dist-info/sboms/uv.cyclonedx.json</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.10.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.10.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.10.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.10.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.10.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.12.10.dist-info/sboms/uv.cyclonedx.json</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -67,12 +67,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/uv-build</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/licenses/LICENSE-MIT</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.3.dist-info/sboms/uv-build.cyclonedx.json</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.10.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.10.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.10.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.10.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.10.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build-0.12.10.dist-info/sboms/uv-build.cyclonedx.json</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv_build/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -83,9 +83,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-08-07</Date>
-            <Version>0.12.3</Version>
+        <Update release="21">
+            <Date>2026-09-05</Date>
+            <Version>0.12.10</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

- Improve compatibility with Python packaging workflows and newer Python releases.
- Enhance package installation and dependency management performance.
- Fix package management edge cases and improve reliability of locking, environments, and diagnostics.

Release notes:
    - [0.12.10](https://github.com/astral-sh/uv/releases)
    - [0.12.9](https://github.com/astral-sh/uv/releases)
    - [0.12.8](https://github.com/astral-sh/uv/releases)
    - [0.12.7](https://github.com/astral-sh/uv/releases)
    - [0.12.6](https://github.com/astral-sh/uv/releases)
    - [0.12.5](https://github.com/astral-sh/uv/releases)
    - [0.12.4](https://github.com/astral-sh/uv/releases)

**Test Plan**

- Run smoke tests defined in source
- Installed locally and run some commands.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
