### PR TITLE
util-linux: Add security patch

### DIFF
--- a/packages/u/util-linux/files/CVE-2026-78408.patch
+++ b/packages/u/util-linux/files/CVE-2026-78408.patch
@@ -1,0 +1,80 @@
+From 286dd3ff41526b582ef48830de239dffbaa61f90 Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Thu, 3 Sep 2026 12:17:14 +0200
+Subject: [PATCH] nsenter: close cgroup.procs fd after join to prevent
+ authority leak [CVE-2026-78408]
+
+The --join-cgroup option opens the target's cgroup.procs while running
+as root and writes nsenter's own PID to migrate itself. The descriptor
+was left open across subsequent namespace transitions, credential drops
+(setgroups/setgid/setuid) and execve().
+
+The kernel performs cgroup migration permission checks using the
+credentials captured at open time (file->f_cred). An open cgroup.procs
+descriptor therefore carries the opener's migration authority regardless
+of later privilege changes. A program executed inside the target
+namespace inherits root's cgroup migration capability even when running
+as an unprivileged user with no capabilities.
+
+Fix this by:
+
+ - closing the temporary /proc/PID/cgroup fd after reading the path
+ - adding O_CLOEXEC to the cgroup.procs open as defense in depth
+ - closing cgroup_procs_fd immediately after the self-migration write
+ - initializing the temporary cgroup fd to -1 instead of 0 to avoid
+   accidentally closing stdin via open_target_fd()
+
+The descriptor has no legitimate use after the single migration write.
+
+Introduced-by: b40650b71a74 ("nsenter: add option -c to join the cgroup of target process")
+References: b0cf1cf0d255 ("nsenter: close cgroup.procs fd after join to prevent authority leak")
+Signed-off-by: Karel Zak <kzak@redhat.com>
+(cherry picked from commit afe067c979b9ba2cbe856f7c6411210120ea62aa)
+---
+ sys-utils/nsenter.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/sys-utils/nsenter.c b/sys-utils/nsenter.c
+index 62ef366d430..f449c65d2b4 100644
+--- a/sys-utils/nsenter.c
++++ b/sys-utils/nsenter.c
+@@ -466,7 +466,7 @@ static int get_ns_ino(const char *path, ino_t *ino)
+ static void open_cgroup_procs(void)
+ {
+ 	char *buf = NULL, *path = NULL, *p;
+-	int cgroup_fd = 0;
++	int cgroup_fd = -1;
+ 	char fdpath[PATH_MAX];
+ 
+ 	open_target_fd(&cgroup_fd, "cgroup", optarg);
+@@ -474,6 +474,8 @@ static void open_cgroup_procs(void)
+ 	if (read_all_alloc(cgroup_fd, &buf) < 1)
+ 		err(EXIT_FAILURE, _("failed to get cgroup path"));
+ 
++	close(cgroup_fd);
++
+ 	p = strtok(buf, "\n");
+ 	if (p)
+ 		path = strrchr(p, ':');
+@@ -483,7 +485,7 @@ static void open_cgroup_procs(void)
+ 
+ 	snprintf(fdpath, sizeof(fdpath), _PATH_SYS_CGROUP "/%s/cgroup.procs", path);
+ 
+-	if ((cgroup_procs_fd = open(fdpath, O_WRONLY | O_APPEND)) < 0)
++	if ((cgroup_procs_fd = open(fdpath, O_WRONLY | O_APPEND | O_CLOEXEC)) < 0)
+ 		err(EXIT_FAILURE, _("failed to open cgroup.procs"));
+ 
+ 	free(buf);
+@@ -923,8 +925,11 @@ int main(int argc, char *argv[])
+ 	}
+ 
+ 	// Join into the target cgroup
+-	if (cgroup_procs_fd >= 0)
++	if (cgroup_procs_fd >= 0) {
+ 		join_into_cgroup();
++		close(cgroup_procs_fd);
++		cgroup_procs_fd = -1;
++	}
+ 
+ 	if (uid_gid_fd >= 0) {
+ 		struct stat st;

--- a/packages/u/util-linux/package.yml
+++ b/packages/u/util-linux/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : util-linux
 version    : 2.42.3
-release    : 61
+release    : 62
 source     :
     - https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.42/util-linux-2.42.3.tar.xz : 66ac7c0e725278eb2b039e3104f2c91119341d941b41bac7a285c695f940bd57
 homepage   : https://github.com/util-linux/util-linux
@@ -46,6 +46,8 @@ rundeps    :
     - devel :
         - libeconf-devel
 setup      : |
+    %patch -p1 -i ${pkgfiles}/CVE-2026-78408.patch # Can be removed for versions after v2.42.3
+
     # Fix usage with musl
     export CFLAGS="${CFLAGS/-D_FORTIFY_SOURCE=2/}"
 

--- a/packages/u/util-linux/pspec_x86_64.xml
+++ b/packages/u/util-linux/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>util-linux</Name>
         <Homepage>https://github.com/util-linux/util-linux</Homepage>
         <Packager>
-            <Name>Clint Eschberger</Name>
-            <Email>clint@eschberger.info</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>BSD-4-Clause-UC</License>
@@ -1567,7 +1567,7 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="61">util-linux</Dependency>
+            <Dependency release="62">util-linux</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libblkid.so.1</Path>
@@ -1588,8 +1588,8 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="61">util-linux-devel</Dependency>
-            <Dependency release="61">util-linux-32bit</Dependency>
+            <Dependency release="62">util-linux-32bit</Dependency>
+            <Dependency release="62">util-linux-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/lib_fdisk.a</Path>
@@ -1627,7 +1627,7 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="61">util-linux</Dependency>
+            <Dependency release="62">util-linux</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/blkid/blkid.h</Path>
@@ -1677,12 +1677,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="61">
-            <Date>2026-09-02</Date>
+        <Update release="62">
+            <Date>2026-09-05</Date>
             <Version>2.42.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Clint Eschberger</Name>
-            <Email>clint@eschberger.info</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Follow-up patch after v2.42.3 tag

**Security**

- CVE-2026-78408

**Test Plan**

- Reboot, happy system

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
