### PR TITLE
ypkg: Fix cmake macro using Unix Makefiles

### DIFF
--- a/packages/y/ypkg/files/0001-macros-cmake-Fix-generation-using-Unix-Makefiles.patch
+++ b/packages/y/ypkg/files/0001-macros-cmake-Fix-generation-using-Unix-Makefiles.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Sat, 5 Sep 2026 18:03:39 -0400
+Subject: [PATCH] macros/cmake: Fix generation using Unix Makefiles
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ data/macros/actions/cmake.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/data/macros/actions/cmake.yaml b/data/macros/actions/cmake.yaml
+index fc6eee9..c200ec9 100644
+--- a/data/macros/actions/cmake.yaml
++++ b/data/macros/actions/cmake.yaml
+@@ -29,12 +29,12 @@ defines:
+         -DCMAKE_INSTALL_LIBDIR="lib%LIBSUFFIX%" \
+         -DCMAKE_INSTALL_LIBEXECDIR=lib%LIBSUFFIX%/${package} \
+         -DCMAKE_INSTALL_PREFIX=%PREFIX% \
+-        -DCMAKE_LIB_SUFFIX=%LIBFUFFIX%
++        -DCMAKE_LIB_SUFFIX=%LIBSUFFIX%
+ 
+     - options_cmake_ninja: |
+         -G Ninja \
+         %options_cmake%
+ 
+     - options_cmake_make: |
+-        -G \"Unix Makefiles\" \
++        -G "Unix Makefiles" \
+         %options_cmake%

--- a/packages/y/ypkg/package.yml
+++ b/packages/y/ypkg/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ypkg
 version    : 35.1.3
-release    : 221
+release    : 222
 source     :
     - https://github.com/getsolus/ypkg/archive/refs/tags/v35.1.3.tar.gz : 5b74195180b7042ee52bafeaefb8d773e8b0aeae28c26be353ac9fb643a1ef3d
 homepage   : https://github.com/getsolus/ypkg
@@ -42,6 +42,8 @@ rundeps    :
 environment: |
     # ensure our nuitka build doesn't pull in -v3 hwcaps libs
     export GLIBC_TUNABLES=glibc.cpu.hwcaps=-AVX
+setup      : |
+    %patch -p1 -i ${pkgfiles}/0001-macros-cmake-Fix-generation-using-Unix-Makefiles.patch
 build      : |
     %pyproject_build
 install    : |

--- a/packages/y/ypkg/pspec_x86_64.xml
+++ b/packages/y/ypkg/pspec_x86_64.xml
@@ -114,8 +114,8 @@ Simply put, it is a tool to convert a build process into a packaging operation.
         </Files>
     </Package>
     <History>
-        <Update release="221">
-            <Date>2026-09-02</Date>
+        <Update release="222">
+            <Date>2026-09-05</Date>
             <Version>35.1.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**

Fix CMake macro with Unix Makefiles.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `evolution-ews` using this patch (and switching the recipe to use the new cmake build and install macros).

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
