### PR TITLE
xiphos: Fix build

### DIFF
--- a/packages/x/xiphos/package.yml
+++ b/packages/x/xiphos/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xiphos
 version    : 4.4.0
-release    : 38
+release    : 39
 source     :
     - https://github.com/crosswire/xiphos/releases/download/4.4.0/xiphos-4.4.0.tar.xz : 64787e97906e5c2f58b59bfc9122d7d2e89565f05329a84d8567834995d5a5db
 homepage   : https://xiphos.org/
@@ -31,13 +31,9 @@ builddeps  :
     - rarian
     - yelp-tools
 setup      : |
-    mkdir build && cd build
-    %cmake ..
+    %cmake_ninja
 build      : |
-    pushd build
-    %make
+    %cmake_build
 install    : |
-    pushd build
-    %make_install
-    popd
+    %cmake_install
     %install_license COPYING

--- a/packages/x/xiphos/pspec_x86_64.xml
+++ b/packages/x/xiphos/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xiphos</Name>
         <Homepage>https://xiphos.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>office</PartOf>
@@ -367,12 +367,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2026-08-31</Date>
+        <Update release="39">
+            <Date>2026-09-05</Date>
             <Version>4.4.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Fix build with newer CMake macros.

Merge once `xiphos` fails on the build server.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the package built successfully.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
