### PR TITLE
libwebkit-gtk: Fix libexecdir

### DIFF
--- a/packages/l/libwebkit-gtk/package.yml
+++ b/packages/l/libwebkit-gtk/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libwebkit-gtk
 version    : 2.52.6
-release    : 149
+release    : 150
 source     :
     - https://webkitgtk.org/releases/webkitgtk-2.52.6.tar.xz : 179a2ea3f8f6edd4be7f31fdc55afc57bd0729f1fba648c61d4181539ac116fc
 homepage   : https://webkitgtk.org
@@ -111,6 +111,7 @@ setup      : |
             -DPORT=GTK \
             -DUSE_FLITE=OFF \
             -DUSE_LIBBACKTRACE=OFF \
+            -DCMAKE_INSTALL_LIBEXECDIR=libexec \
             "$@"
     }
 

--- a/packages/l/libwebkit-gtk/pspec_x86_64.xml
+++ b/packages/l/libwebkit-gtk/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libwebkit-gtk</Name>
         <Homepage>https://webkitgtk.org</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-only</License>
         <PartOf>desktop.gtk</PartOf>
@@ -30,7 +30,7 @@
         <Description xml:lang="en">The javascriptcore-gtk41-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from libwebkit-gtk41.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="149">javascriptcore-gtk41</Dependency>
+            <Dependency releaseFrom="150">javascriptcore-gtk41</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/webkitgtk-4.1/JavaScriptCore/JSBase.h</Path>
@@ -75,7 +75,7 @@
         <Description xml:lang="en">The javascriptcore-gtk6-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from libwebkit-gtk6.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="149">javascriptcore-gtk6</Dependency>
+            <Dependency releaseFrom="150">javascriptcore-gtk6</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/webkitgtk-6.0/jsc/JSCClass.h</Path>
@@ -99,7 +99,7 @@
         <Description xml:lang="en">WebKitGTK is the port of the WebKit web rendering engine to the GTK platform. This package contains WebKitGTK for GTK 3 and libsoup 3.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency release="149">javascriptcore-gtk41</Dependency>
+            <Dependency release="150">javascriptcore-gtk41</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/girepository-1.0/WebKit2-4.1.typelib</Path>
@@ -183,8 +183,8 @@
         <Description xml:lang="en">The libwebkit-gtk41-devel package contains libraries, build data, and header files for developing applications that use libwebkit-gtk41.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="149">javascriptcore-gtk41-devel</Dependency>
-            <Dependency releaseFrom="149">libwebkit-gtk41</Dependency>
+            <Dependency release="150">javascriptcore-gtk41-devel</Dependency>
+            <Dependency releaseFrom="150">libwebkit-gtk41</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/webkitgtk-4.1/webkit/WebKitApplicationInfo.h</Path>
@@ -401,7 +401,7 @@
         <Description xml:lang="en">This package contains developer documentation for libwebkit-gtk41.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="149">libwebkit-gtk41</Dependency>
+            <Dependency releaseFrom="150">libwebkit-gtk41</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="doc">/usr/share/doc/javascriptcoregtk-4.1/RedHatDisplay-Black.woff</Path>
@@ -4299,7 +4299,7 @@
         <Description xml:lang="en">WebKitGTK is the port of the WebKit web rendering engine to the GTK platform. This package contains WebKitGTK for GTK 4.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency release="149">javascriptcore-gtk6</Dependency>
+            <Dependency release="150">javascriptcore-gtk6</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/WebKitWebDriver</Path>
@@ -4384,8 +4384,8 @@
         <Description xml:lang="en">The libwebkit-gtk6-devel package contains libraries, build data, and header files for developing applications that use libwebkit-gtk6.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="149">javascriptcore-gtk6-devel</Dependency>
-            <Dependency releaseFrom="149">libwebkit-gtk6</Dependency>
+            <Dependency release="150">javascriptcore-gtk6-devel</Dependency>
+            <Dependency releaseFrom="150">libwebkit-gtk6</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/webkitgtk-6.0/webkit/WebKitApplicationInfo.h</Path>
@@ -4487,7 +4487,7 @@
         <Description xml:lang="en">This package contains developer documentation for libwebkit-gtk6.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="149">libwebkit-gtk6</Dependency>
+            <Dependency releaseFrom="150">libwebkit-gtk6</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="doc">/usr/share/doc/javascriptcoregtk-6.0/RedHatDisplay-Black.woff</Path>
@@ -6106,12 +6106,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="149">
-            <Date>2026-08-26</Date>
+        <Update release="150">
+            <Date>2026-09-06</Date>
             <Version>2.52.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Fix libexecdir

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Do all the updates, install all these, reboot, and successfully launch GNOME Web.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
