### PR TITLE
vcmi: Update to v1.7.5

### DIFF
--- a/packages/v/vcmi/abi_symbols
+++ b/packages/v/vcmi/abi_symbols
@@ -1011,7 +1011,6 @@ libvcmi.so:_ZN11CLogManager9addLoggerEP7CLogger
 libvcmi.so:_ZN11CLogManager9getLoggerERK13CLoggerDomain
 libvcmi.so:_ZN11CLogManagerC1Ev
 libvcmi.so:_ZN11CLogManagerC2Ev
-libvcmi.so:_ZN11CLogManagerD0Ev
 libvcmi.so:_ZN11CLogManagerD1Ev
 libvcmi.so:_ZN11CLogManagerD2Ev
 libvcmi.so:_ZN11CMapPatcher13readPatchDataEv
@@ -5258,6 +5257,7 @@ libvcmi.so:_ZNK5CHero11getModScopeB5cxx11Ev
 libvcmi.so:_ZNK5CHero12getIconIndexEv
 libvcmi.so:_ZNK5CHero13getNameTextIDB5cxx11Ev
 libvcmi.so:_ZNK5CHero13registerIconsERKSt8functionIFviiRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES8_EE
+libvcmi.so:_ZNK5CHero15defaultCreatureEv
 libvcmi.so:_ZNK5CHero17getNameTranslatedB5cxx11Ev
 libvcmi.so:_ZNK5CHero18getBiographyTextIDB5cxx11Ev
 libvcmi.so:_ZNK5CHero22getBiographyTranslatedB5cxx11Ev

--- a/packages/v/vcmi/abi_used_symbols
+++ b/packages/v/vcmi/abi_used_symbols
@@ -2035,13 +2035,19 @@ libc.so.6:epoll_wait
 libc.so.6:eventfd
 libc.so.6:execve
 libc.so.6:exit
+libc.so.6:fclose
 libc.so.6:fcntl
+libc.so.6:ferror
 libc.so.6:flockfile
 libc.so.6:fopen
 libc.so.6:fork
+libc.so.6:fread
 libc.so.6:free
 libc.so.6:freeaddrinfo
+libc.so.6:fseeko
+libc.so.6:ftello
 libc.so.6:funlockfile
+libc.so.6:fwrite
 libc.so.6:getaddrinfo
 libc.so.6:getenv
 libc.so.6:getsockname
@@ -2175,7 +2181,6 @@ libm.so.6:sqrt
 libm.so.6:sqrtf
 libm.so.6:tan
 libm.so.6:tanh
-libminizip.so.1:fill_fopen64_filefunc
 libminizip.so.1:unzClose
 libminizip.so.1:unzCloseCurrentFile
 libminizip.so.1:unzGetCurrentFileInfo64
@@ -2240,6 +2245,7 @@ libstdc++.so.6:_ZNSo9_M_insertIdEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertIlEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertImEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertIyEERSoT_
+libstdc++.so.6:_ZNSoC2Ev
 libstdc++.so.6:_ZNSolsEi
 libstdc++.so.6:_ZNSolsEs
 libstdc++.so.6:_ZNSt11logic_errorC1EPKc
@@ -2282,6 +2288,7 @@ libstdc++.so.6:_ZNSt13runtime_errorD1Ev
 libstdc++.so.6:_ZNSt13runtime_errorD2Ev
 libstdc++.so.6:_ZNSt14basic_ifstreamIcSt11char_traitsIcEE5closeEv
 libstdc++.so.6:_ZNSt14basic_ifstreamIcSt11char_traitsIcEED1Ev
+libstdc++.so.6:_ZNSt14basic_ofstreamIcSt11char_traitsIcEE4openEPKcSt13_Ios_Openmode
 libstdc++.so.6:_ZNSt14basic_ofstreamIcSt11char_traitsIcEEC1EPKcSt13_Ios_Openmode
 libstdc++.so.6:_ZNSt14basic_ofstreamIcSt11char_traitsIcEED1Ev
 libstdc++.so.6:_ZNSt15__exception_ptr13exception_ptr10_M_releaseEv

--- a/packages/v/vcmi/package.yml
+++ b/packages/v/vcmi/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : vcmi
-version    : 1.7.4
-release    : 37
+version    : 1.7.5
+release    : 38
 source     :
-    - git|https://github.com/vcmi/vcmi.git : 1.7.4
+    - https://github.com/vcmi/vcmi/releases/download/1.7.5/VCMI-Sources.tar.gz : e5822c193348534bb25d14e04ebec2d241058d12fa84beaa8234ee016710eb7a
 homepage   : https://vcmi.eu/
 license    :
     - CC-BY-SA-4.0
@@ -40,7 +40,7 @@ rundeps    :
     - innoextract
 setup      : |
     %patch -p1 -i ${pkgfiles}/fix-translated-metadata-output.patch
-    %cmake \
+    %cmake_ninja \
         -DBUILD_SHARED_LIBS=ON \
         -DCMAKE_SKIP_RPATH=FALSE \
         -DENABLE_DISCORD=OFF \
@@ -48,7 +48,7 @@ setup      : |
         -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE \
         -DCMAKE_INSTALL_RPATH=%libdir%/vcmi
 build      : |
-    %make
+    %cmake_build
 install    : |
-    %make_install
+    %cmake_install
     %install_license license*

--- a/packages/v/vcmi/pspec_x86_64.xml
+++ b/packages/v/vcmi/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>vcmi</Name>
         <Homepage>https://vcmi.eu/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>CC-BY-SA-4.0</License>
         <License>GPL-2.0-or-later</License>
@@ -649,12 +649,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2026-08-17</Date>
-            <Version>1.7.4</Version>
+        <Update release="38">
+            <Date>2026-09-07</Date>
+            <Version>1.7.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/vcmi/vcmi/releases/tag/1.7.5)
- Part of https://github.com/getsolus/packages/pull/10518

**Test Plan**

- Start vcmi, get through launcher

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
