### PR TITLE
libplatform: Update to v2.2.0

### DIFF
--- a/packages/l/libplatform/abi_used_symbols
+++ b/packages/l/libplatform/abi_used_symbols
@@ -41,6 +41,6 @@ libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
-libstdc++.so.6:_ZdlPvm
+libstdc++.so.6:_ZdlPv
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__gxx_personality_v0

--- a/packages/l/libplatform/package.yml
+++ b/packages/l/libplatform/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libplatform
-version    : 2.1.0.1
-release    : 5
+version    : 2.2.0
+release    : 6
 source     :
-    - https://github.com/Pulse-Eight/platform/archive/p8-platform-2.1.0.1.tar.gz : 064f8d2c358895c7e0bea9ae956f8d46f3f057772cb97f2743a11d478a0f68a0
+    - https://github.com/Pulse-Eight/platform/archive/p8-platform-2.2.0.tar.gz : e1a0669e54793794afb5965d7d35a5456d8dbbda772fe505824c481279887ba0
 homepage   : https://github.com/Pulse-Eight/platform/
 license    : GPL-2.0-or-later
 component  : desktop.multimedia
@@ -11,8 +11,10 @@ summary    : Platform support library used by libCEC and binary add-ons for Kodi
 description: |
     Platform support library used by libCEC and binary add-ons for Kodi.
 setup      : |
-    %cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
+    %cmake_ninja \
+        -DBUILD_SHARED_LIBS=ON
 build      : |
-    %make
+    %cmake_build
 install    : |
-    %make_install
+    %cmake_install
+    %install_license LICENSE.md

--- a/packages/l/libplatform/pspec_x86_64.xml
+++ b/packages/l/libplatform/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libplatform</Name>
         <Homepage>https://github.com/Pulse-Eight/platform/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.multimedia</PartOf>
@@ -20,9 +20,10 @@
 </Description>
         <PartOf>desktop.multimedia</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/libp8-platform.so.2</Path>
-            <Path fileType="library">/usr/lib/libp8-platform.so.2.1.0</Path>
-            <Path fileType="library">/usr/lib/p8-platform/p8-platform-config.cmake</Path>
+            <Path fileType="library">/usr/lib64/libp8-platform.so.2</Path>
+            <Path fileType="library">/usr/lib64/libp8-platform.so.2.2.0</Path>
+            <Path fileType="library">/usr/lib64/p8-platform/p8-platform-config.cmake</Path>
+            <Path fileType="data">/usr/share/licenses/libplatform/LICENSE.md</Path>
         </Files>
     </Package>
     <Package>
@@ -32,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">libplatform</Dependency>
+            <Dependency release="6">libplatform</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/p8-platform/os.h</Path>
@@ -51,17 +52,17 @@
             <Path fileType="header">/usr/include/p8-platform/util/buffer.h</Path>
             <Path fileType="header">/usr/include/p8-platform/util/timeutils.h</Path>
             <Path fileType="header">/usr/include/p8-platform/util/util.h</Path>
-            <Path fileType="library">/usr/lib/libp8-platform.so</Path>
-            <Path fileType="data">/usr/lib/pkgconfig/p8-platform.pc</Path>
+            <Path fileType="library">/usr/lib64/libp8-platform.so</Path>
+            <Path fileType="data">/usr/lib64/pkgconfig/p8-platform.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-03-21</Date>
-            <Version>2.1.0.1</Version>
+        <Update release="6">
+            <Date>2026-09-07</Date>
+            <Version>2.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/Pulse-Eight/platform/releases/tag/p8-platform-2.2.0).

Part of https://github.com/getsolus/packages/issues/10518

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild `libcec` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
