### PR TITLE
fuse: Update to 3.18.3

### DIFF
--- a/packages/f/fuse/abi_used_symbols
+++ b/packages/f/fuse/abi_used_symbols
@@ -9,6 +9,7 @@ libc.so.6:__isoc23_strtoul
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__memmove_chk
+libc.so.6:__open64_2
 libc.so.6:__printf_chk
 libc.so.6:__realpath_chk
 libc.so.6:__snprintf_chk
@@ -39,6 +40,7 @@ libc.so.6:environ
 libc.so.6:execl
 libc.so.6:execle
 libc.so.6:exit
+libc.so.6:fchdir
 libc.so.6:fclose
 libc.so.6:fcntl64
 libc.so.6:ferror

--- a/packages/f/fuse/package.yml
+++ b/packages/f/fuse/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fuse
-version    : 3.18.2
-release    : 19
+version    : 3.18.3
+release    : 20
 source     :
-    - https://github.com/libfuse/libfuse/releases/download/fuse-3.18.2/fuse-3.18.2.tar.gz : f01de85717e20adf5f98aff324acd85dd73d61a5ca3834d573dcf0bd6e54a298
+    - https://github.com/libfuse/libfuse/releases/download/fuse-3.18.3/fuse-3.18.3.tar.gz : bcd19582c5e30f7fe45dd86a5540e998590aa01903afc7ebcbeea6c8ac5421ee
 license    :
     - GPL-2.0-only
     - LGPL-2.1-only
@@ -26,7 +26,7 @@ install    : |
     %ninja_install
     %install_license LICENSE GPL2.txt LGPL2.txt
 
-    install -Dm0644 $pkgfiles/fuse.conf $installdir/usr/share/defaults/fuse/fuse.conf
+    %install_file $pkgfiles/fuse.conf $installdir/usr/share/defaults/fuse/fuse.conf
 
     rm -rfv $installdir/etc
     rm -rfv $installdir/dev

--- a/packages/f/fuse/pspec_x86_64.xml
+++ b/packages/f/fuse/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fuse</Name>
         <Homepage>https://github.com/libfuse/libfuse</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>LGPL-2.1-only</License>
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>system.utils</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="19">fuse-common</Dependency>
+            <Dependency releaseFrom="20">fuse-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/fusermount3</Path>
-            <Path fileType="library">/usr/lib64/libfuse3.so.3.18.2</Path>
+            <Path fileType="library">/usr/lib64/libfuse3.so.3.18.3</Path>
             <Path fileType="library">/usr/lib64/libfuse3.so.4</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/99-fuse3.rules</Path>
             <Path fileType="executable">/usr/sbin/mount.fuse3</Path>
@@ -52,7 +52,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="19">fuse</Dependency>
+            <Dependency release="20">fuse</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/fuse3/cuse_lowlevel.h</Path>
@@ -67,12 +67,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-03-25</Date>
-            <Version>3.18.2</Version>
+        <Update release="20">
+            <Date>2026-09-09</Date>
+            <Version>3.18.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- [Change Log](https://github.com/faust-streaming/cChardet/releases#release-v3.2.0)

**Security**
- fuse_session_custom_io(): Disabled by default to prevent custom IO peers from forging requests without bounds checks, which could crash or corrupt the filesystem.
- fusermount3 Symlink Swap Prevention: Resolves mountpoints a single time using O_PATH|O_NOFOLLOW to prevent attackers from redirecting the mount via symlink swapping.
- fusermount3 Privilege Drop (Auto-Unmount): Runs the auto-unmount probe as the calling user rather than as root, preventing attackers from opening arbitrary paths via symlinks.
- fusermount3 Privilege Drop (Fallback): If passing the device descriptor fails, it safely unmounts by dropping privileges and running standard checks, rather than executing umount2() as root on a caller-supplied path.
- fusermount3 Descriptor Validation: Now checks the return value of fstat() when validating the communication file descriptor.
- fusermount3 Out-of-Bounds Fix: Fixes an out-of-bounds read that triggered when option strings were completely empty (e.g., during read-only mounts).
- fusermount3 Configuration Fix: Rejects invalid negative mount_max values (like -2) which previously broke and blocked all non-root mounts.
- mount_util Argument Injection: Terminates /bin/mount and /bin/umount arguments with so unprivileged users cannot trick mount(8) into executing malicious positional operands.
- mount_util BusyBox Compatibility: Skips the mtab update entirely for option-like arguments, as BusyBox's mount(8) does not honor the terminator.
- Unmount Safety: Passes the UMOUNT_NOFOLLOW flag to both kernel and non-setuid unmount paths in fusermount3 and the core library.
- util Pointer Underflow: Avoids a pointer underflow bug when trimming lines in fuse.conf.
- Privilege Escalation Prevention (lib): Correctly relays KILLPRIV_V2 flags on file truncations and writes, ensuring suid/sgid bits are properly stripped by the filesystem and do not survive malicious modifications.

**Test Plan**
- Test with sshfs
- Build `sshfs-fuse` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
