### PR TITLE
wireshark: Update to 4.6.8

### DIFF
--- a/packages/w/wireshark/abi_symbols
+++ b/packages/w/wireshark/abi_symbols
@@ -1282,6 +1282,7 @@ libwireshark.so.19:port_with_resolution_to_str_buf
 libwireshark.so.19:postdissectors_want_hfids
 libwireshark.so.19:postseq_cleanup_all_protocols
 libwireshark.so.19:pref_clean_stash
+libwireshark.so.19:pref_get_changed_flags
 libwireshark.so.19:pref_stash
 libwireshark.so.19:pref_unstash
 libwireshark.so.19:prefs

--- a/packages/w/wireshark/abi_used_symbols
+++ b/packages/w/wireshark/abi_used_symbols
@@ -108,7 +108,7 @@ libQt6Core.so.6:_ZN11QTranslatorC1EP7QObject
 libQt6Core.so.6:_ZN11QTranslatorD1Ev
 libQt6Core.so.6:_ZN12QEasingCurveC1ENS_4TypeE
 libQt6Core.so.6:_ZN12QEasingCurveD1Ev
-libQt6Core.so.6:_ZN12QLibraryInfo4pathENS_11LibraryPathE
+libQt6Core.so.6:_ZN12QLibraryInfo5pathsENS_11LibraryPathE
 libQt6Core.so.6:_ZN13QElapsedTimer10invalidateEv
 libQt6Core.so.6:_ZN13QElapsedTimer5startEv
 libQt6Core.so.6:_ZN13QElapsedTimer7restartEv

--- a/packages/w/wireshark/package.yml
+++ b/packages/w/wireshark/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : wireshark
-version    : 4.6.7
-release    : 106
+version    : 4.6.8
+release    : 107
 source     :
-    - https://gitlab.com/wireshark/wireshark/-/archive/v4.6.7/wireshark-v4.6.7.tar.gz : fcd09518b4b5a1fb799c084e8cede9d4ed85b78eccee879e463da15072508914
+    - https://gitlab.com/wireshark/wireshark/-/archive/v4.6.8/wireshark-v4.6.8.tar.gz : d6789c907f9d9650728c90e15631ed2b35c6bd5101e39c37b619427dc471fefd
 homepage   : https://www.wireshark.org/
 license    :
     - GPL-2.0-or-later
@@ -50,7 +50,7 @@ install    : |
     %ninja_install
     %install_license COPYING
 
-    install -Dm00644 $pkgfiles/wireshark.sysusers $installdir/%libdir%/sysusers.d/wireshark.conf
+    %install_file $pkgfiles/wireshark.sysusers $installdir/%libdir%/sysusers.d/wireshark.conf
     chmod 750  $installdir/usr/bin/dumpcap
     chown :150 $installdir/usr/bin/dumpcap
 

--- a/packages/w/wireshark/pspec_x86_64.xml
+++ b/packages/w/wireshark/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wireshark</Name>
         <Homepage>https://www.wireshark.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>BSD-2-Clause</License>
@@ -38,10 +38,10 @@
             <Path fileType="executable">/usr/bin/wireshark</Path>
             <Path fileType="library">/usr/lib64/libwireshark.so</Path>
             <Path fileType="library">/usr/lib64/libwireshark.so.19</Path>
-            <Path fileType="library">/usr/lib64/libwireshark.so.19.0.7</Path>
+            <Path fileType="library">/usr/lib64/libwireshark.so.19.1.8</Path>
             <Path fileType="library">/usr/lib64/libwiretap.so</Path>
             <Path fileType="library">/usr/lib64/libwiretap.so.16</Path>
-            <Path fileType="library">/usr/lib64/libwiretap.so.16.0.7</Path>
+            <Path fileType="library">/usr/lib64/libwiretap.so.16.0.8</Path>
             <Path fileType="library">/usr/lib64/libwsutil.so</Path>
             <Path fileType="library">/usr/lib64/libwsutil.so.17</Path>
             <Path fileType="library">/usr/lib64/libwsutil.so.17.0.0</Path>
@@ -64,14 +64,14 @@
             <Path fileType="library">/usr/lib64/wireshark/plugins/4.6/epan/wimaxasncp.so</Path>
             <Path fileType="library">/usr/lib64/wireshark/plugins/4.6/epan/wimaxmacphy.so</Path>
             <Path fileType="library">/usr/lib64/wireshark/plugins/4.6/wiretap/usbdump.so</Path>
-            <Path fileType="executable">/usr/libexec/wireshark/extcap/androiddump</Path>
-            <Path fileType="executable">/usr/libexec/wireshark/extcap/ciscodump</Path>
-            <Path fileType="executable">/usr/libexec/wireshark/extcap/dpauxmon</Path>
-            <Path fileType="executable">/usr/libexec/wireshark/extcap/randpktdump</Path>
-            <Path fileType="executable">/usr/libexec/wireshark/extcap/sdjournal</Path>
-            <Path fileType="executable">/usr/libexec/wireshark/extcap/sshdump</Path>
-            <Path fileType="executable">/usr/libexec/wireshark/extcap/udpdump</Path>
-            <Path fileType="executable">/usr/libexec/wireshark/extcap/wifidump</Path>
+            <Path fileType="library">/usr/lib64/wireshark/wireshark/extcap/androiddump</Path>
+            <Path fileType="library">/usr/lib64/wireshark/wireshark/extcap/ciscodump</Path>
+            <Path fileType="library">/usr/lib64/wireshark/wireshark/extcap/dpauxmon</Path>
+            <Path fileType="library">/usr/lib64/wireshark/wireshark/extcap/randpktdump</Path>
+            <Path fileType="library">/usr/lib64/wireshark/wireshark/extcap/sdjournal</Path>
+            <Path fileType="library">/usr/lib64/wireshark/wireshark/extcap/sshdump</Path>
+            <Path fileType="library">/usr/lib64/wireshark/wireshark/extcap/udpdump</Path>
+            <Path fileType="library">/usr/lib64/wireshark/wireshark/extcap/wifidump</Path>
             <Path fileType="data">/usr/share/applications/org.wireshark.Wireshark.desktop</Path>
             <Path fileType="doc">/usr/share/doc/wireshark/COPYING</Path>
             <Path fileType="doc">/usr/share/doc/wireshark/README.xml-output</Path>
@@ -465,12 +465,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="106">
-            <Date>2026-08-28</Date>
-            <Version>4.6.7</Version>
+        <Update release="107">
+            <Date>2026-09-09</Date>
+            <Version>4.6.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security
- [Change Log](https://www.wireshark.org/docs/relnotes/wireshark-4.6.8.html)

**Security**
- wnpa-sec-2026-64
- wnpa-sec-2026-65
- wnpa-sec-2026-66
- wnpa-sec-2026-67
- wnpa-sec-2026-68
- wnpa-sec-2026-69
- wnpa-sec-2026-70
- wnpa-sec-2026-71
- wnpa-sec-2026-72
- wnpa-sec-2026-73
- wnpa-sec-2026-74
- wnpa-sec-2026-75
- wnpa-sec-2026-76
- wnpa-sec-2026-77
- wnpa-sec-2026-78
- wnpa-sec-2026-79
- wnpa-sec-2026-80
- wnpa-sec-2026-81
- wnpa-sec-2026-82
- wnpa-sec-2026-83
- wnpa-sec-2026-84
- wnpa-sec-2026-85
- wnpa-sec-2026-86
- wnpa-sec-2026-87
- wnpa-sec-2026-88
- wnpa-sec-2026-89
- wnpa-sec-2026-90
- wnpa-sec-2026-91

**Test Plan**
- Launch and test

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
