### PR TITLE
pam-wrapper: Update to v1.1.8

### DIFF
--- a/packages/p/pam-wrapper/abi_used_symbols
+++ b/packages/p/pam-wrapper/abi_used_symbols
@@ -1,3 +1,4 @@
+libc.so.6:__asprintf_chk
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
@@ -24,11 +25,9 @@ libc.so.6:fstat
 libc.so.6:fstatat
 libc.so.6:getenv
 libc.so.6:getpid
-libc.so.6:kill
-libc.so.6:lstat
 libc.so.6:malloc
 libc.so.6:memcpy
-libc.so.6:mkdir
+libc.so.6:mkdtemp
 libc.so.6:mkstemp
 libc.so.6:nftw
 libc.so.6:open
@@ -42,7 +41,6 @@ libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strdup
-libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strndup

--- a/packages/p/pam-wrapper/package.yml
+++ b/packages/p/pam-wrapper/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : pam-wrapper
-version    : 1.1.5
-release    : 11
+version    : 1.1.8
+release    : 12
 source     :
-    - https://gitlab.com/cwrap/pam_wrapper/-/archive/pam_wrapper-1.1.5/pam_wrapper-pam_wrapper-1.1.5.tar.gz : 2003608f0489b03e17bb11ff3b4857909b850a53f559a20aef5cead694b09fa2
+    - https://gitlab.com/cwrap/pam_wrapper/-/archive/pam_wrapper-1.1.8/pam_wrapper-pam_wrapper-1.1.8.tar.gz : fed0b8ea9d440fe7f0a5333c6fa0284ac24ac4b3bab1af6e31d6f632c83edeec
 license    : GPL-3.0-or-later
 component  : security
 homepage   : https://cwrap.org/pam_wrapper.html

--- a/packages/p/pam-wrapper/pspec_x86_64.xml
+++ b/packages/p/pam-wrapper/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pam-wrapper</Name>
         <Homepage>https://cwrap.org/pam_wrapper.html</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>security</PartOf>
@@ -22,9 +22,9 @@
         <Files>
             <Path fileType="library">/usr/lib/python3.14/site-packages/pypamtest.so</Path>
             <Path fileType="library">/usr/lib64/libpam_wrapper.so.0</Path>
-            <Path fileType="library">/usr/lib64/libpam_wrapper.so.0.0.8</Path>
+            <Path fileType="library">/usr/lib64/libpam_wrapper.so.0.0.11</Path>
             <Path fileType="library">/usr/lib64/libpamtest.so.0</Path>
-            <Path fileType="library">/usr/lib64/libpamtest.so.0.0.8</Path>
+            <Path fileType="library">/usr/lib64/libpamtest.so.0.0.11</Path>
             <Path fileType="library">/usr/lib64/pam_wrapper/pam_chatty.so</Path>
             <Path fileType="library">/usr/lib64/pam_wrapper/pam_get_items.so</Path>
             <Path fileType="library">/usr/lib64/pam_wrapper/pam_matrix.so</Path>
@@ -43,7 +43,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="11">pam-wrapper</Dependency>
+            <Dependency release="12">pam-wrapper</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libpamtest.h</Path>
@@ -59,12 +59,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2026-06-07</Date>
-            <Version>1.1.5</Version>
+        <Update release="12">
+            <Date>2026-09-09</Date>
+            <Version>1.1.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Update pam-wrapper

**Changelog:**
1.1.8

* Fixed compilation warnings for clang 20
* Fixed some cmake issues

1.1.7

* Fix installation of python module

1.1.6

* Improve config dir creation if we have pam_start_confdir()
* Fixed PAM_WRAPPER_DISABLE_DEEPBIND
* Directly fail if we can't create the config dir

Full release notes available [here](https://gitlab.com/cwrap/pam_wrapper/-/tags)

**Test Plan**

- Built kscreenlocker from KDE sources which requires this package

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
