### PR TITLE
libpcap: Update to 1.10.7

### DIFF
--- a/packages/l/libpcap/package.yml
+++ b/packages/l/libpcap/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libpcap
-version    : 1.10.6
-release    : 14
+version    : 1.10.7
+release    : 15
 source     :
-    - https://github.com/the-tcpdump-group/libpcap/archive/refs/tags/libpcap-1.10.6.tar.gz : fcaeefbbca8d99249c8f271f3218f77cdbfd7718cc141f5edd16e90575e6bbed
+    - https://github.com/the-tcpdump-group/libpcap/archive/refs/tags/libpcap-1.10.7.tar.gz : 4ad339e52286366ab614290202117aab5c42aca9a35ffa0d74edff3c37058f52
 homepage   : https://www.tcpdump.org
 license    : BSD-3-Clause
 component  : system.utils
@@ -40,3 +40,5 @@ build      : |
 install    : |
     %ninja_install
     rm -v $installdir/%libdir%/*.a
+    
+    %install_license LICENSE

--- a/packages/l/libpcap/pspec_x86_64.xml
+++ b/packages/l/libpcap/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libpcap</Name>
         <Homepage>https://www.tcpdump.org</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>system.utils</PartOf>
@@ -26,7 +26,8 @@ the network, including those destined for other hosts.
         <Files>
             <Path fileType="executable">/usr/bin/pcap-config</Path>
             <Path fileType="library">/usr/lib64/libpcap.so.1</Path>
-            <Path fileType="library">/usr/lib64/libpcap.so.1.10.6</Path>
+            <Path fileType="library">/usr/lib64/libpcap.so.1.10.7</Path>
+            <Path fileType="data">/usr/share/licenses/libpcap/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/pcap-config.1.zst</Path>
             <Path fileType="man">/usr/share/man/man7/pcap-filter.7.zst</Path>
             <Path fileType="man">/usr/share/man/man7/pcap-linktype.7.zst</Path>
@@ -42,11 +43,11 @@ the network, including those destined for other hosts.
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="14">libpcap</Dependency>
+            <Dependency release="15">libpcap</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpcap.so.1</Path>
-            <Path fileType="library">/usr/lib32/libpcap.so.1.10.6</Path>
+            <Path fileType="library">/usr/lib32/libpcap.so.1.10.7</Path>
         </Files>
     </Package>
     <Package>
@@ -58,8 +59,8 @@ the network, including those destined for other hosts.
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="14">libpcap-32bit</Dependency>
-            <Dependency release="14">libpcap-devel</Dependency>
+            <Dependency release="15">libpcap-32bit</Dependency>
+            <Dependency release="15">libpcap-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpcap.so</Path>
@@ -75,7 +76,7 @@ the network, including those destined for other hosts.
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="14">libpcap</Dependency>
+            <Dependency release="15">libpcap</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/pcap-bpf.h</Path>
@@ -177,12 +178,12 @@ the network, including those destined for other hosts.
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2026-03-03</Date>
-            <Version>1.10.6</Version>
+        <Update release="15">
+            <Date>2026-09-09</Date>
+            <Version>1.10.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security release
- [Change Log](https://github.com/the-tcpdump-group/libpcap/blob/master/CHANGES)

**Security**
- CVE-2026-0799
- CVE-2026-31912
- CVE-2026-31911
- CVE-2026-6244
- CVE-2026-6554
- CVE-2026-18313
- CVE-2026-18238

**Test Plan**
- Test with tcpdump

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
