### PR TITLE
libarchive: Update to 3.8.9

### DIFF
--- a/packages/l/libarchive/abi_used_symbols
+++ b/packages/l/libarchive/abi_used_symbols
@@ -47,7 +47,6 @@ libc.so.6:__strcpy_chk
 libc.so.6:__vfprintf_chk
 libc.so.6:__vprintf_chk
 libc.so.6:__vsnprintf_chk
-libc.so.6:__vsprintf_chk
 libc.so.6:_exit
 libc.so.6:abort
 libc.so.6:access
@@ -201,7 +200,6 @@ libc.so.6:vfork
 libc.so.6:waitpid
 libc.so.6:wcrtomb
 libc.so.6:wcschr
-libc.so.6:wcscpy
 libc.so.6:wcslen
 libc.so.6:wmemcmp
 libc.so.6:wmemmove

--- a/packages/l/libarchive/abi_used_symbols32
+++ b/packages/l/libarchive/abi_used_symbols32
@@ -154,7 +154,6 @@ libc.so.6:vfork
 libc.so.6:waitpid
 libc.so.6:wcrtomb
 libc.so.6:wcschr
-libc.so.6:wcscpy
 libc.so.6:wcslen
 libc.so.6:wmemcmp
 libc.so.6:wmemmove

--- a/packages/l/libarchive/package.yml
+++ b/packages/l/libarchive/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libarchive
-version    : 3.8.7
-release    : 63
+version    : 3.8.9
+release    : 64
 source     :
-    - https://github.com/libarchive/libarchive/releases/download/v3.8.7/libarchive-3.8.7.tar.xz : d3a8ba457ae25c27c84fd2830a2efdcc5b1d40bf585d4eb0d35f47e99e5d4774
+    - https://github.com/libarchive/libarchive/releases/download/v3.8.9/libarchive-3.8.9.tar.xz : 888c934f9d95648ecb9163dc8e23ab80a476ecb81a8f1154704a227b5b676dde
 homepage   : https://www.libarchive.org/
 license    : BSD-2-Clause
 component  :
@@ -39,6 +39,7 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
 
     # remove iconv from libarchive.pc requirements.
     # Upstream issue: https://github.com/libarchive/libarchive/issues/1766

--- a/packages/l/libarchive/pspec_x86_64.xml
+++ b/packages/l/libarchive/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libarchive</Name>
         <Homepage>https://www.libarchive.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>programming.library</PartOf>
@@ -21,7 +21,8 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libarchive.so.13</Path>
-            <Path fileType="library">/usr/lib64/libarchive.so.13.8.7</Path>
+            <Path fileType="library">/usr/lib64/libarchive.so.13.8.9</Path>
+            <Path fileType="data">/usr/share/licenses/libarchive/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -31,11 +32,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="63">libarchive</Dependency>
+            <Dependency release="64">libarchive</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libarchive.so.13</Path>
-            <Path fileType="library">/usr/lib32/libarchive.so.13.8.7</Path>
+            <Path fileType="library">/usr/lib32/libarchive.so.13.8.9</Path>
         </Files>
     </Package>
     <Package>
@@ -45,8 +46,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="63">libarchive-32bit</Dependency>
-            <Dependency release="63">libarchive-devel</Dependency>
+            <Dependency release="64">libarchive-devel</Dependency>
+            <Dependency release="64">libarchive-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libarchive.so</Path>
@@ -60,7 +61,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="63">libarchive</Dependency>
+            <Dependency release="64">libarchive</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/bsdcat</Path>
@@ -84,7 +85,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="63">libarchive</Dependency>
+            <Dependency release="64">libarchive</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/archive.h</Path>
@@ -131,12 +132,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="63">
-            <Date>2026-08-16</Date>
-            <Version>3.8.7</Version>
+        <Update release="64">
+            <Date>2026-09-10</Date>
+            <Version>3.8.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security release (low)
- [Change Log](https://github.com/libarchive/libarchive/releases#release-v3.8.9)

**Security**
- CVE-2026-15028
- CVE-2026-16517

**Test Plan**
- Pass check
- Open zip and compressed tar files with ark

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
