### PR TITLE
apache-ant: Update to v1.10.18

### DIFF
--- a/packages/a/apache-ant/package.yml
+++ b/packages/a/apache-ant/package.yml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : apache-ant
-version    : 1.10.15
-release    : 14
+version    : 1.10.18
+release    : 15
 source     :
-    - https://github.com/apache/ant/archive/refs/tags/rel/1.10.15.tar.gz : ec9db6ab5d812b803ec82421f7e95527657def3bbc52f9f2da6e0cf22345db85
+    - https://github.com/apache/ant/archive/refs/tags/rel/1.10.18.tar.gz : d77ba49adf36f0f5de22f791b7a677cabd72bdd9cc226ee10e35fd9bf230a061
+homepage   : https://ant.apache.org/
 license    : Apache-2.0
 component  : programming.java
-homepage   : https://ant.apache.org/
 summary    : A software tool for automating software build processes
 description: |
     Apache Ant is a Java library and command-line tool whose mission is to drive processes described in build files as targets and extension points dependent upon each other.
@@ -16,12 +16,12 @@ rundeps    :
     - openjdk-25
 build      : |
     export JAVA_HOME=/usr/lib64/openjdk-25
-    ./build.sh -Dant.install=$installdir/usr install-lite
+    ./build.sh -Dant.install=${installdir}/usr install-lite
 install    : |
-    find $installdir/usr/bin \( -name '*.cmd' -o -name '*.bat' \) -delete
-    mv $installdir/usr/lib $installdir/usr/lib64
+    find ${installdir}/usr/bin \( -name '*.cmd' -o -name '*.bat' \) -delete
+    mv ${installdir}/usr/lib ${installdir}/usr/lib64
 
-    pushd $installdir/usr/bin
+    pushd ${installdir}/usr/bin
     find . -type f \! -name "*.*" -exec sed --debug -i "2r $pkgfiles/java-shim.txt" {} \;
     popd 
 

--- a/packages/a/apache-ant/pspec_x86_64.xml
+++ b/packages/a/apache-ant/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>apache-ant</Name>
         <Homepage>https://ant.apache.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.java</PartOf>
@@ -56,12 +56,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2026-06-12</Date>
-            <Version>1.10.15</Version>
+        <Update release="15">
+            <Date>2026-09-10</Date>
+            <Version>1.10.18</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://ant.apache.org/).

**Security**
Includes fixes for:
- CVE-2026-78254

**Test Plan**

Smoke test

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
