### PR TITLE
rtl-sdr: Update to 2.0.3

### DIFF
--- a/packages/r/rtl-sdr/abi_used_symbols
+++ b/packages/r/rtl-sdr/abi_used_symbols
@@ -1,9 +1,11 @@
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
+libc.so.6:__recv_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:accept
 libc.so.6:bind
@@ -30,7 +32,6 @@ libc.so.6:localtime
 libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
-libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:optarg
 libc.so.6:optind
@@ -56,7 +57,6 @@ libc.so.6:pthread_rwlock_rdlock
 libc.so.6:pthread_rwlock_unlock
 libc.so.6:pthread_rwlock_wrlock
 libc.so.6:puts
-libc.so.6:recv
 libc.so.6:select
 libc.so.6:send
 libc.so.6:setsockopt
@@ -77,7 +77,6 @@ libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strtod
-libc.so.6:strtol
 libc.so.6:time
 libc.so.6:usleep
 libm.so.6:atan

--- a/packages/r/rtl-sdr/files/fix-udev-directory.patch
+++ b/packages/r/rtl-sdr/files/fix-udev-directory.patch
@@ -1,0 +1,13 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -110,8 +110,9 @@ option(INSTALL_UDEV_RULES "Install udev rules for RTL-SDR" OFF)
+ if (INSTALL_UDEV_RULES)
+     install (
+         FILES rtl-sdr.rules
+-        DESTINATION "/etc/udev/rules.d"
++        DESTINATION "/usr/lib64/udev/rules.d"
+         COMPONENT "udev"
++        RENAME 10-rtl-sdr.rules
+         )
+ else (INSTALL_UDEV_RULES)
+     message (STATUS "Udev rules not being installed, install them with -DINSTALL_UDEV_RULES=ON")

--- a/packages/r/rtl-sdr/package.yml
+++ b/packages/r/rtl-sdr/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : rtl-sdr
 version    : 2.0.2
-release    : 5
+release    : 6
 source     :
-    - https://gitea.osmocom.org/sdr/rtl-sdr/archive/v2.0.2.tar.gz : f7c770020945c603595502f292f66b4159c86b2de6fdca35eed31f22b188ddf0
+    - git|https://gitea.osmocom.org/sdr/rtl-sdr.git : v2.0.3
 homepage   : https://osmocom.org/projects/rtl-sdr/wiki
 license    : GPL-2.0-or-later
 component  : multimedia.library
@@ -13,11 +13,27 @@ description: |
 builddeps  :
     - pkgconfig(libusb-1.0)
 setup      : |
-    %cmake . -DDETACH_KERNEL_DRIVER=ON
+    %patch -p1 -i ${pkgfiles}/fix-udev-directory.patch
+
+    # fix udev rules and allow access to any user that is locally logged in or in the rtlsdr group
+    # https://bugzilla.redhat.com/show_bug.cgi?id=815093
+    sed -e 's/GROUP="plugdev"/GROUP="rtlsdr", TAG+="uaccess"/' -i rtl-sdr.rules
+
+    %cmake_ninja \
+        -DDETACH_KERNEL_DRIVER=ON \
+        -DINSTALL_UDEV_RULES=ON
 build      : |
-    %make
+    %cmake_build
 install    : |
-    %make_install
-    install -D -m00644 rtl-sdr.rules $installdir/%libdir%/udev/rules.d/10-rtl-sdr.rules
+    %cmake_install
+    %install_license COPYING
+
+    %sysusers 'g rtlsdr -'
+
+    # module blacklisting rules
+    %install_file debian/rtl-sdr-blacklist.conf ${installdir}/%libdir%/modprobe.d/rtlsdr.conf
+
+    # man pages
+    %install_file -t ${installdir}/usr/share/man/man1 debian/*.1
 
     rm  $installdir/%libdir%/*.a

--- a/packages/r/rtl-sdr/pspec_x86_64.xml
+++ b/packages/r/rtl-sdr/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>rtl-sdr</Name>
         <Homepage>https://osmocom.org/projects/rtl-sdr/wiki</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.library</PartOf>
@@ -29,8 +29,19 @@
             <Path fileType="executable">/usr/bin/rtl_tcp</Path>
             <Path fileType="executable">/usr/bin/rtl_test</Path>
             <Path fileType="library">/usr/lib64/librtlsdr.so.0</Path>
-            <Path fileType="library">/usr/lib64/librtlsdr.so.2.0.1</Path>
+            <Path fileType="library">/usr/lib64/librtlsdr.so.2.0.3</Path>
+            <Path fileType="library">/usr/lib64/modprobe.d/rtlsdr.conf</Path>
+            <Path fileType="library">/usr/lib64/sysusers.d/rtl-sdr.conf</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/10-rtl-sdr.rules</Path>
+            <Path fileType="data">/usr/share/licenses/rtl-sdr/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/rtl_adsb.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/rtl_biast.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/rtl_eeprom.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/rtl_fm.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/rtl_power.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/rtl_sdr.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/rtl_tcp.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/rtl_test.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -40,7 +51,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">rtl-sdr</Dependency>
+            <Dependency release="6">rtl-sdr</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/rtl-sdr.h</Path>
@@ -54,12 +65,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-07-15</Date>
+        <Update release="6">
+            <Date>2026-09-10</Date>
             <Version>2.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://gitea.osmocom.org/sdr/rtl-sdr/compare/v2.0.2...v2.0.3).

Part of https://github.com/getsolus/packages/issues/10518

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `soapyrtlsdr` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
