### PR TITLE
systemd: Update to v261.3

### DIFF
--- a/packages/s/systemd/abi_symbols
+++ b/packages/s/systemd/abi_symbols
@@ -1304,6 +1304,7 @@ libsystemd-shared-261.so:ask_password_agent
 libsystemd-shared-261.so:ask_password_agent_close
 libsystemd-shared-261.so:ask_password_agent_open
 libsystemd-shared-261.so:ask_password_agent_open_if_enabled
+libsystemd-shared-261.so:ask_password_agent_prompt_fields_are_safe
 libsystemd-shared-261.so:ask_password_auto
 libsystemd-shared-261.so:ask_password_plymouth
 libsystemd-shared-261.so:ask_password_tty
@@ -2644,7 +2645,6 @@ libsystemd-shared-261.so:env_file_fputs_assignment
 libsystemd-shared-261.so:env_name_is_valid
 libsystemd-shared-261.so:env_value_is_valid
 libsystemd-shared-261.so:epoll_events_to_poll
-libsystemd-shared-261.so:epoll_pwait2_shim
 libsystemd-shared-261.so:erase_and_free
 libsystemd-shared-261.so:errno_from_name
 libsystemd-shared-261.so:errno_name
@@ -3883,6 +3883,7 @@ libsystemd-shared-261.so:mhd_respondf_internal
 libsystemd-shared-261.so:microhttpd_logger
 libsystemd-shared-261.so:minimal_size_by_fs_magic
 libsystemd-shared-261.so:minimal_size_by_fs_name
+libsystemd-shared-261.so:missing_epoll_pwait2
 libsystemd-shared-261.so:mkdir_p
 libsystemd-shared-261.so:mkdir_p_internal
 libsystemd-shared-261.so:mkdir_p_label
@@ -4310,6 +4311,7 @@ libsystemd-shared-261.so:path_is_temporary_fs
 libsystemd-shared-261.so:path_is_user_config_dir
 libsystemd-shared-261.so:path_is_user_data_dir
 libsystemd-shared-261.so:path_is_valid_full
+libsystemd-shared-261.so:path_is_valid_search_path
 libsystemd-shared-261.so:path_make_absolute
 libsystemd-shared-261.so:path_make_absolute_cwd
 libsystemd-shared-261.so:path_make_relative
@@ -4431,12 +4433,12 @@ libsystemd-shared-261.so:pidref_namespace_open_by_type
 libsystemd-shared-261.so:pidref_new_from_pid
 libsystemd-shared-261.so:pidref_safe_fork_full
 libsystemd-shared-261.so:pidref_set_parent
-libsystemd-shared-261.so:pidref_set_pid
 libsystemd-shared-261.so:pidref_set_pid_and_pidfd_id
+libsystemd-shared-261.so:pidref_set_pid_full
 libsystemd-shared-261.so:pidref_set_pidfd
 libsystemd-shared-261.so:pidref_set_pidfd_consume
 libsystemd-shared-261.so:pidref_set_pidfd_take
-libsystemd-shared-261.so:pidref_set_pidstr
+libsystemd-shared-261.so:pidref_set_pidstr_full
 libsystemd-shared-261.so:pidref_sigqueue
 libsystemd-shared-261.so:pidref_verify
 libsystemd-shared-261.so:pidref_wait_for_terminate_and_check
@@ -4468,6 +4470,7 @@ libsystemd-shared-261.so:pkcs11_uri_valid
 libsystemd-shared-261.so:pkcs7_extract_signers
 libsystemd-shared-261.so:pkcs7_new
 libsystemd-shared-261.so:pkey_generate_volume_keys
+libsystemd-shared-261.so:plymouth_build_password_packet
 libsystemd-shared-261.so:plymouth_connect
 libsystemd-shared-261.so:plymouth_hide_splash
 libsystemd-shared-261.so:plymouth_send_msg
@@ -7161,6 +7164,7 @@ libsystemd-shared-261.so:take_fdopen
 libsystemd-shared-261.so:take_fdopen_unlocked
 libsystemd-shared-261.so:take_fdopendir
 libsystemd-shared-261.so:tar_c
+libsystemd-shared-261.so:tar_hardlink_db_new
 libsystemd-shared-261.so:tar_strip_suffixes
 libsystemd-shared-261.so:tar_x
 libsystemd-shared-261.so:target_state_from_string

--- a/packages/s/systemd/abi_symbols32
+++ b/packages/s/systemd/abi_symbols32
@@ -1243,6 +1243,7 @@ libsystemd-shared-261.so:ask_password_agent
 libsystemd-shared-261.so:ask_password_agent_close
 libsystemd-shared-261.so:ask_password_agent_open
 libsystemd-shared-261.so:ask_password_agent_open_if_enabled
+libsystemd-shared-261.so:ask_password_agent_prompt_fields_are_safe
 libsystemd-shared-261.so:ask_password_auto
 libsystemd-shared-261.so:ask_password_plymouth
 libsystemd-shared-261.so:ask_password_tty
@@ -2542,7 +2543,6 @@ libsystemd-shared-261.so:env_file_fputs_assignment
 libsystemd-shared-261.so:env_name_is_valid
 libsystemd-shared-261.so:env_value_is_valid
 libsystemd-shared-261.so:epoll_events_to_poll
-libsystemd-shared-261.so:epoll_pwait2_shim
 libsystemd-shared-261.so:erase_and_free
 libsystemd-shared-261.so:errno_from_name
 libsystemd-shared-261.so:errno_name
@@ -3760,6 +3760,7 @@ libsystemd-shared-261.so:metrics_method_list
 libsystemd-shared-261.so:metrics_setup_varlink_server
 libsystemd-shared-261.so:minimal_size_by_fs_magic
 libsystemd-shared-261.so:minimal_size_by_fs_name
+libsystemd-shared-261.so:missing_epoll_pwait2
 libsystemd-shared-261.so:mkdir_p
 libsystemd-shared-261.so:mkdir_p_internal
 libsystemd-shared-261.so:mkdir_p_label
@@ -4159,6 +4160,7 @@ libsystemd-shared-261.so:path_is_temporary_fs
 libsystemd-shared-261.so:path_is_user_config_dir
 libsystemd-shared-261.so:path_is_user_data_dir
 libsystemd-shared-261.so:path_is_valid_full
+libsystemd-shared-261.so:path_is_valid_search_path
 libsystemd-shared-261.so:path_make_absolute
 libsystemd-shared-261.so:path_make_absolute_cwd
 libsystemd-shared-261.so:path_make_relative
@@ -4278,12 +4280,12 @@ libsystemd-shared-261.so:pidref_namespace_open_by_type
 libsystemd-shared-261.so:pidref_new_from_pid
 libsystemd-shared-261.so:pidref_safe_fork_full
 libsystemd-shared-261.so:pidref_set_parent
-libsystemd-shared-261.so:pidref_set_pid
 libsystemd-shared-261.so:pidref_set_pid_and_pidfd_id
+libsystemd-shared-261.so:pidref_set_pid_full
 libsystemd-shared-261.so:pidref_set_pidfd
 libsystemd-shared-261.so:pidref_set_pidfd_consume
 libsystemd-shared-261.so:pidref_set_pidfd_take
-libsystemd-shared-261.so:pidref_set_pidstr
+libsystemd-shared-261.so:pidref_set_pidstr_full
 libsystemd-shared-261.so:pidref_sigqueue
 libsystemd-shared-261.so:pidref_verify
 libsystemd-shared-261.so:pidref_wait_for_terminate_and_check
@@ -4297,6 +4299,7 @@ libsystemd-shared-261.so:pkcs11_rsa_padding_from_string
 libsystemd-shared-261.so:pkcs11_rsa_padding_to_string
 libsystemd-shared-261.so:pkcs11_uri_valid
 libsystemd-shared-261.so:pkcs7_extract_signers
+libsystemd-shared-261.so:plymouth_build_password_packet
 libsystemd-shared-261.so:plymouth_connect
 libsystemd-shared-261.so:plymouth_hide_splash
 libsystemd-shared-261.so:plymouth_send_msg
@@ -6289,6 +6292,7 @@ libsystemd-shared-261.so:take_fdopen
 libsystemd-shared-261.so:take_fdopen_unlocked
 libsystemd-shared-261.so:take_fdopendir
 libsystemd-shared-261.so:tar_c
+libsystemd-shared-261.so:tar_hardlink_db_new
 libsystemd-shared-261.so:tar_strip_suffixes
 libsystemd-shared-261.so:tar_x
 libsystemd-shared-261.so:target_state_from_string

--- a/packages/s/systemd/package.yml
+++ b/packages/s/systemd/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : systemd
-version    : '261.2'
-release    : 192
+version    : '261.3'
+release    : 193
 source     :
-    - https://github.com/systemd/systemd/archive/refs/tags/v261.2.tar.gz : ed1059ff964f5df35b6056434cc17cc83f86dc913f10489948a0b19b6081c5ec
+    - https://github.com/systemd/systemd/archive/refs/tags/v261.3.tar.gz : 3f8d3d3969af7214bda600930e14c6a24135eb3dce1ba7f1b980b74e6dc15b72
 license    :
     - LGPL-2.1-or-later
     - GPL-2.0-or-later
@@ -99,7 +99,6 @@ setup      : |
     %patch -p1 -i ${pkgfiles}/patches/downstream/0001-Remove-etc-os-release-from-tmpfiles.patch
 
     # Upstream patches
-    %patch -p1 -i ${pkgfiles}/patches/upstream/systemd-261-dont-discard-x11-context.patch
 
     # ERROR: File fuzz-unit-file/dm-back-slash.swap does not exist.
     # mv "test/fuzz/fuzz-unit-file/dm-back\x2dslash.swap" "test/fuzz/fuzz-unit-file/dm-back-slash.swap"
@@ -230,9 +229,9 @@ setup      : |
         -Dxkbcommon=${_IS_64BIT_FEAT} \
         -Dzlib=${_IS_64BIT_FEAT}
 build      : |
-    %ninja_build
+    %meson_build
 install    : |
-    %ninja_install
+    %meson_install
 
     # Solus is responsible for its own glibc + PAM configuration, *not* systemd..
     rm -rfv ${installdir}/usr/share/factory/*

--- a/packages/s/systemd/pspec_x86_64.xml
+++ b/packages/s/systemd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>systemd</Name>
         <Homepage>https://www.github.com/systemd/systemd</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <License>GPL-2.0-or-later</License>
@@ -115,8 +115,15 @@
             <Path fileType="library">/usr/lib/systemd/boot/efi/addonx64.efi.stub</Path>
             <Path fileType="library">/usr/lib/systemd/boot/efi/linuxx64.efi.stub</Path>
             <Path fileType="library">/usr/lib/systemd/boot/efi/systemd-bootx64.efi</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/glymur-asus-zenbook-a14-ux3407na.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/glymur-asus-zenbook-a16-ux3607oa.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/glymur-crd.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/glymur-hp-elitebook-x-g2q.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/glymur-lenovo-yoga-slim7x.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/msm8998-lenovo-miix-630-81f1.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/purwa-lenovo-ideacentre-mini-01q8x10.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/sc7180-acer-aspire1.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/sc7180-ecs-liva-qc710.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/sc8180x-lenovo-flex-5g-81xe.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/sc8180x-lenovo-flex-5g-82ak.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/sc8280xp-huawei-gaokun3.json</Path>
@@ -125,7 +132,9 @@
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/sc8280xp-lenovo-thinkpad-x13s-4810.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/sc8280xp-microsoft-blackrock.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/sc8280xp-microsoft-surface-pro-9-5G.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/sc8280xp-radxa-dragon-q8b.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/sdm850-lenovo-yoga-c630.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x126100-lenovo-ideapad-slim3.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1e001de-devkit.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1e78100-acer-sfa14-11.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1e78100-lenovo-thinkpad-t14s-lcd.json</Path>
@@ -139,6 +148,7 @@
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1e80100-dell-inspiron-14-plus-7441.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1e80100-dell-latitude-7455.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1e80100-dell-xps13-9345.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1e80100-honor-magicbook-art-14.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1e80100-hp-elitebook-ultra-g1q.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1e80100-hp-omnibook-x14.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1e80100-lenovo-yoga-slim7x.json</Path>
@@ -148,12 +158,14 @@
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p42100-acer-swift-go14-01.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p42100-asus-vivobook-s15.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p42100-asus-zenbook-a14.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p42100-hp-elitebook-6-g1q.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p42100-hp-omnibook-x14.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p42100-lenovo-ideapad-5-2in1.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p42100-lenovo-ideapad-slim-5-oled.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p42100-lenovo-thinkbook-16.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p42100-microsoft-surface-pro-12in.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p64100-acer-swift-sf14-11.json</Path>
+            <Path fileType="library">/usr/lib/systemd/boot/hwids/aa64/x1p64100-dell-latitude-5455.json</Path>
             <Path fileType="library">/usr/lib/systemd/boot/solus-mok.cer</Path>
             <Path fileType="library">/usr/lib/systemd/catalog/systemd.be.catalog</Path>
             <Path fileType="library">/usr/lib/systemd/catalog/systemd.be@latin.catalog</Path>
@@ -1657,7 +1669,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="192">systemd</Dependency>
+            <Dependency release="193">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnss_myhostname.so.2</Path>
@@ -1680,8 +1692,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="192">systemd-32bit</Dependency>
-            <Dependency release="192">systemd-devel</Dependency>
+            <Dependency release="193">systemd-devel</Dependency>
+            <Dependency release="193">systemd-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib32/pkgconfig/libsystemd.pc</Path>
@@ -1695,7 +1707,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="192">systemd</Dependency>
+            <Dependency release="193">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libudev.h</Path>
@@ -2598,12 +2610,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="192">
+        <Update release="193">
             <Date>2026-09-11</Date>
-            <Version>261.2</Version>
+            <Version>261.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/systemd/systemd/compare/v261.2...v261.3).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install packages, reboot, login, watch as my system did not explode.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
