### PR TITLE
meson: Update to v1.12.0

### DIFF
--- a/packages/m/meson/package.yml
+++ b/packages/m/meson/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : meson
-version    : 1.11.0
-release    : 71
+version    : 1.12.0
+release    : 72
 source     :
-    - https://github.com/mesonbuild/meson/releases/download/1.11.0/meson-1.11.0.tar.gz : dffdd0915ceb028541fe3bed77d63ba35e78514591c043736b450d62634eeb31
+    - https://github.com/mesonbuild/meson/releases/download/1.12.0/meson-1.12.0.tar.gz : 88afe0c20e52030218924ac37d0c81c59b4b5f3ae3752c8c6d7470c7d365886c
 homepage   : https://mesonbuild.com/
 license    : Apache-2.0
 component  : system.devel
@@ -25,5 +25,5 @@ install    : |
     %pyproject_install
 
     # install autocompletions
-    install -Dm 00644 $workdir/data/shell-completions/bash/meson $installdir/usr/share/bash-completion/completions/meson
-    install -Dm 00644 $workdir/data/shell-completions/zsh/_meson $installdir/usr/share/zsh/site-functions/_meson
+    %install_file ${workdir}/data/shell-completions/bash/meson -t ${installdir}/usr/share/bash-completion/completions
+    %install_file ${workdir}/data/shell-completions/zsh/_meson -t ${installdir}/usr/share/zsh/site-functions

--- a/packages/m/meson/pspec_x86_64.xml
+++ b/packages/m/meson/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>meson</Name>
         <Homepage>https://mesonbuild.com/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>system.devel</PartOf>
@@ -21,12 +21,12 @@
         <PartOf>system.devel</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/meson</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.11.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.11.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.11.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.11.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.11.0.dist-info/licenses/COPYING</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.11.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.12.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.12.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.12.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.12.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.12.0.dist-info/licenses/COPYING</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/meson-1.12.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/__pycache__/__init__.cpython-314.pyc</Path>
@@ -397,6 +397,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/__pycache__/__init__.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/__pycache__/compiler.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/__pycache__/compiler.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/__pycache__/decorators.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/__pycache__/decorators.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/__pycache__/dependencyfallbacks.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/__pycache__/dependencyfallbacks.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/__pycache__/interpreter.cpython-314.opt-1.pyc</Path>
@@ -410,6 +412,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/__pycache__/type_checking.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/__pycache__/type_checking.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/compiler.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/decorators.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/dependencyfallbacks.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/interpreter.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mesonbuild/interpreter/interpreterobjects.py</Path>
@@ -765,12 +768,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="71">
-            <Date>2026-06-05</Date>
-            <Version>1.11.0</Version>
+        <Update release="72">
+            <Date>2026-09-10</Date>
+            <Version>1.12.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/mesonbuild/meson/blob/1.12.0/docs/markdown/Release-notes-for-1.12.0.md).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build the `budgie-desktop` package with this version of Meson.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
