### PR TITLE
stripe-cli: update to v1.50.11

### DIFF
--- a/packages/s/stripe-cli/files/0001-version.patch
+++ b/packages/s/stripe-cli/files/0001-version.patch
@@ -11,7 +11,7 @@ diff --git a/pkg/version/version.go b/pkg/version/version.go
  // git tag assigned to the release. Versions built from source will
  // always show master.
 -var Version = "master"
-+var Version = "1.43.8"
++var Version = "1.50.11"
 
  // Template for the version string.
  var Template = fmt.Sprintf("stripe version %s\n", Version)

--- a/packages/s/stripe-cli/package.yml
+++ b/packages/s/stripe-cli/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : stripe-cli
-version    : 1.43.8
-release    : 3
+version    : 1.50.11
+release    : 4
 source     :
-    - https://github.com/stripe/stripe-cli/archive/refs/tags/v1.43.8.tar.gz : 0be76f37ee06bac6ad5e56ec542be71e828356e37f36f721a3b8b7afedefe78d
+    - https://github.com/stripe/stripe-cli/archive/refs/tags/v1.50.11.tar.gz : 60571665ca0b7021a33a90a0b99adf7d13cbb6f9d28a398a9ac80d646a303f11
 homepage   : https://stripe.com
 license    : Apache-2.0
 component  : programming.tools
@@ -18,5 +18,5 @@ setup      : |
 build      : |
     %make
 install    : |
-    install -Dm00755 ./stripe $installdir/usr/bin/stripe
+    %install_bin ./stripe
     %install_license LICENSE

--- a/packages/s/stripe-cli/pspec_x86_64.xml
+++ b/packages/s/stripe-cli/pspec_x86_64.xml
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-07-20</Date>
-            <Version>1.43.8</Version>
+        <Update release="4">
+            <Date>2026-09-11</Date>
+            <Version>1.50.11</Version>
             <Comment>Packaging update</Comment>
             <Name>Trevor Busk</Name>
             <Email>trevor@tbusk.com</Email>


### PR DESCRIPTION
**Summary**

- See changes since last update [here](https://github.com/stripe/stripe-cli/compare/v1.43.8...v1.50.11).

**Test Plan**

<!-- Short description of how the package was tested -->

- Ran a few commands like version, whoami, and some get commands like charges, customers, and balance

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
