### PR TITLE
vim: Update to 9.2.1091

### DIFF
--- a/packages/v/vim/package.yml
+++ b/packages/v/vim/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : vim
-version    : 9.2.1015
-release    : 174
+version    : 9.2.1091
+release    : 175
 source     :
-    - https://github.com/vim/vim/archive/refs/tags/v9.2.1015.tar.gz#vim.tar.gz : fd4f55bac07efe79ca734540116e59bffbf061fbbe849f68c656cc8f6fa5081a
+    - https://github.com/vim/vim/archive/refs/tags/v9.2.1091.tar.gz#vim.tar.gz : 11a6f4200366c4a5dd40a4ef17f515e37b924083832813ac5491f530d2969eeb
 extract    : false
 homepage   : https://www.vim.org
 license    : Vim

--- a/packages/v/vim/pspec_x86_64.xml
+++ b/packages/v/vim/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>vim</Name>
         <Homepage>https://www.vim.org</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>Vim</License>
         <PartOf>editor</PartOf>
@@ -947,6 +947,7 @@
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/r.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/racc.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/racket.vim</Path>
+            <Path fileType="data">/usr/share/vim/vim92/ftplugin/radvd.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/raku.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/rasi.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/readline.vim</Path>
@@ -959,6 +960,7 @@
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/rmd.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/rnc.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/rnoweb.vim</Path>
+            <Path fileType="data">/usr/share/vim/vim92/ftplugin/robot.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/roc.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/routeros.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/ftplugin/rpl.vim</Path>
@@ -2234,6 +2236,7 @@
             <Path fileType="data">/usr/share/vim/vim92/syntax/racc.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/syntax/racket.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/syntax/radiance.vim</Path>
+            <Path fileType="data">/usr/share/vim/vim92/syntax/radvd.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/syntax/raku.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/syntax/raml.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/syntax/rapid.vim</Path>
@@ -2361,6 +2364,7 @@
             <Path fileType="data">/usr/share/vim/vim92/syntax/structurizr.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/syntax/stylus.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/syntax/sudoers.vim</Path>
+            <Path fileType="data">/usr/share/vim/vim92/syntax/svelte.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/syntax/svg.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/syntax/svn.vim</Path>
             <Path fileType="data">/usr/share/vim/vim92/syntax/swayconfig.vim</Path>
@@ -2594,7 +2598,7 @@
         <Description xml:lang="en">Vim, which stands for Vi IMproved, is an open-source, multiplatform text editor extended from vi. It was first released by Bram Moolenaar in 1991. Since then, numerous features have been added to Vim, many of which are helpful in editing program source code.
 </Description>
         <RuntimeDependencies>
-            <Dependency releaseFrom="174">vim</Dependency>
+            <Dependency releaseFrom="175">vim</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/eview</Path>
@@ -2776,12 +2780,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="174">
-            <Date>2026-08-28</Date>
-            <Version>9.2.1015</Version>
+        <Update release="175">
+            <Date>2026-09-12</Date>
+            <Version>9.2.1091</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- No changelog

**Security**
- CWE-88 Ex Command Injection via Unescaped Buffer Name in sign_jump() in Vim < v9.2.1090 - Low

**Test Plan**
- Edit a file

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
